### PR TITLE
Add server statistics page

### DIFF
--- a/frontend/src/features/data-browser/DataBrowserTree.vue
+++ b/frontend/src/features/data-browser/DataBrowserTree.vue
@@ -113,6 +113,12 @@ function handleContextMenuSelect(key: string) {
         tabStore.openStatisticsTab(serverId, dbName, '', 'database')
       }
     }
+    if (node.type === DataNodeType.Server) {
+      const serverId = node.key as string
+      if (serverId) {
+        tabStore.openStatisticsTab(serverId, '', '', 'server')
+      }
+    }
   }
 }
 

--- a/frontend/src/features/data-browser/useDataTreeContextMenu.ts
+++ b/frontend/src/features/data-browser/useDataTreeContextMenu.ts
@@ -29,6 +29,11 @@ export function useDataTreeContextMenu() {
       disabled: false,
     },
     {
+      label: 'Statistics',
+      key: 'statistics',
+      disabled: false,
+    },
+    {
       label: 'Disconnect',
       key: 'disconnect',
       disabled: false,

--- a/frontend/src/features/statistics/ServerStatisticsTab.vue
+++ b/frontend/src/features/statistics/ServerStatisticsTab.vue
@@ -1,0 +1,163 @@
+<script lang="ts" setup>
+import { onMounted, ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { formatBytes } from '@/utils/formatBytes.ts'
+import { ArrowPathIcon } from '@heroicons/vue/24/outline'
+import StatisticsTab from './StatisticsTab.vue'
+import type { StatCard } from './StatisticsSummaryCards.vue'
+import * as collectionsProxy from 'wailsjs/go/api/CollectionsProxy'
+
+const props = defineProps<{
+  serverId: string
+}>()
+
+const { t } = useI18n()
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const stats = ref<Record<string, any> | null>(null)
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+function formatUptime(seconds: number): string {
+  const days = Math.floor(seconds / 86400)
+  const hours = Math.floor((seconds % 86400) / 3600)
+  const mins = Math.floor((seconds % 3600) / 60)
+  const parts: string[] = []
+  if (days > 0) {
+    parts.push(`${days}${t('common.unit_day')}`)
+  }
+  if (hours > 0) {
+    parts.push(`${hours}${t('common.unit_hour')}`)
+  }
+  if (mins > 0) {
+    parts.push(`${mins}${t('common.unit_minute')}`)
+  }
+  if (parts.length === 0) {
+    parts.push(`${Math.floor(seconds)}${t('common.unit_second')}`)
+  }
+  return parts.join(' ')
+}
+
+const cards = computed<StatCard[]>(() => {
+  if (!stats.value) {
+    return []
+  }
+  const s = stats.value
+  const result: StatCard[] = []
+
+  if (s.version != null) {
+    result.push({
+      label: t('statistics.serverCards.version'),
+      value: String(s.version),
+    })
+  }
+  if (s.uptime != null) {
+    result.push({
+      label: t('statistics.serverCards.uptime'),
+      value: formatUptime(Number(s.uptime)),
+    })
+  }
+  if (s.connections && s.connections.current != null) {
+    result.push({
+      label: t('statistics.serverCards.connections'),
+      value: Number(s.connections.current).toLocaleString(),
+      subValue: s.connections.available != null
+        ? `${Number(s.connections.available).toLocaleString()} ${t('statistics.serverCards.available')}`
+        : undefined,
+    })
+  }
+  if (s.mem && s.mem.resident != null) {
+    result.push({
+      label: t('statistics.serverCards.memResident'),
+      value: formatBytes(Number(s.mem.resident) * 1024 * 1024),
+    })
+  }
+  if (s.mem && s.mem.virtual != null) {
+    result.push({
+      label: t('statistics.serverCards.memVirtual'),
+      value: formatBytes(Number(s.mem.virtual) * 1024 * 1024),
+    })
+  }
+  if (s.opcounters) {
+    const total = ['insert', 'query', 'update', 'delete', 'command']
+      .reduce((sum, key) => sum + (Number(s.opcounters[key]) || 0), 0)
+    result.push({
+      label: t('statistics.serverCards.totalOperations'),
+      value: total.toLocaleString(),
+    })
+  }
+
+  return result
+})
+
+const documents = computed(() => {
+  if (!stats.value) {
+    return []
+  }
+  return [stats.value]
+})
+
+async function fetchStatistics() {
+  loading.value = true
+  error.value = null
+  try {
+    const result = await collectionsProxy.GetServerStatistics(props.serverId)
+    if (result.isSuccess) {
+      stats.value = result.data
+    } else {
+      error.value = result.error
+    }
+  } catch (e) {
+    error.value = String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  fetchStatistics()
+})
+</script>
+
+<template>
+  <div v-if="error" class="error-container">
+    <div class="error-toolbar">
+      <n-button size="small" @click="fetchStatistics">
+        <template #icon>
+          <n-icon :component="ArrowPathIcon" />
+        </template>
+        {{ t('statistics.toolbar.refresh') }}
+      </n-button>
+    </div>
+    <div class="error-state">
+      <n-result status="error" :title="t('statistics.error')" :description="error" />
+    </div>
+  </div>
+  <statistics-tab
+    v-else
+    :cards="cards"
+    :documents="documents"
+    :loading="loading"
+    @refresh="fetchStatistics" />
+</template>
+
+<style lang="scss" scoped>
+.error-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.error-toolbar {
+  padding: 4px 12px 8px;
+  flex-shrink: 0;
+}
+
+.error-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+}
+</style>

--- a/frontend/src/features/statistics/StatisticsContentPane.vue
+++ b/frontend/src/features/statistics/StatisticsContentPane.vue
@@ -3,6 +3,7 @@ import { useTabStore } from '@/features/tabs/tabs'
 import { useI18n } from 'vue-i18n'
 import CollectionStatisticsTab from './CollectionStatisticsTab.vue'
 import DatabaseStatisticsTab from './DatabaseStatisticsTab.vue'
+import ServerStatisticsTab from './ServerStatisticsTab.vue'
 import { computed } from 'vue'
 
 const tabStore = useTabStore()
@@ -45,6 +46,9 @@ function handleClose(statisticsTabId: string) {
           v-else-if="statsTab.level === 'database'"
           :server-id="statsTab.serverId"
           :db-name="statsTab.dbName" />
+        <ServerStatisticsTab
+          v-else-if="statsTab.level === 'server'"
+          :server-id="statsTab.serverId" />
       </n-tab-pane>
     </n-tabs>
     <div v-else class="empty-state">

--- a/frontend/src/features/tabs/tabs.ts
+++ b/frontend/src/features/tabs/tabs.ts
@@ -394,7 +394,10 @@ export const useTabStore = defineStore('tabs', {
       tab.activeStatisticsTabId = statisticsTabId
     },
 
-    statisticsTabLabel(_tab: ServerTabItem, statsTab: StatisticsTabItem): string {
+    statisticsTabLabel(tab: ServerTabItem, statsTab: StatisticsTabItem): string {
+      if (statsTab.level === 'server') {
+        return i18nGlobal.t('statistics.serverTabLabel', { server: tab.title })
+      }
       if (statsTab.level === 'database') {
         return i18nGlobal.t('statistics.databaseTabLabel', { database: statsTab.dbName })
       }

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -155,7 +155,8 @@ export default {
   statistics: {
     tabLabel: '{collection} statistics',
     databaseTabLabel: '{database} statistics',
-    emptyState: 'Right-click a collection or database to view its statistics',
+    serverTabLabel: '{server} statistics',
+    emptyState: 'Right-click a server, database, or collection to view its statistics',
     toolbar: {
       refresh: 'Refresh',
     },
@@ -174,6 +175,15 @@ export default {
       dataSize: 'Data Size',
       storageSize: 'Storage Size',
       indexSize: 'Index Size',
+    },
+    serverCards: {
+      version: 'Version',
+      uptime: 'Uptime',
+      connections: 'Connections',
+      available: 'available',
+      memResident: 'Resident Memory',
+      memVirtual: 'Virtual Memory',
+      totalOperations: 'Total Operations',
     },
     bytes: '{value} bytes',
     error: 'Failed to load statistics',

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -5,6 +5,7 @@ import "fmt"
 type CollectionsProvider interface {
 	GetStatistics(serverID string, dbName string, collectionName string) (map[string]any, error)
 	GetDatabaseStatistics(serverID string, dbName string) (map[string]any, error)
+	GetServerStatistics(serverID string) (map[string]any, error)
 }
 
 type CollectionsProxy struct {
@@ -13,6 +14,20 @@ type CollectionsProxy struct {
 
 func NewCollectionsProxy(provider CollectionsProvider) *CollectionsProxy {
 	return &CollectionsProxy{provider: provider}
+}
+
+func (cp *CollectionsProxy) GetServerStatistics(serverID string) Result[map[string]any] {
+	result, err := cp.provider.GetServerStatistics(serverID)
+	if err != nil {
+		return Result[map[string]any]{
+			IsSuccess: false,
+			Error:     fmt.Sprintf("Error getting server statistics: %v", err),
+		}
+	}
+	return Result[map[string]any]{
+		IsSuccess: true,
+		Data:      result,
+	}
 }
 
 func (cp *CollectionsProxy) GetDatabaseStatistics(serverID string, dbName string) Result[map[string]any] {

--- a/internal/collections/service.go
+++ b/internal/collections/service.go
@@ -33,6 +33,27 @@ func (s *CollectionsService) Init(ctx context.Context) {
 	s.ctx = ctx
 }
 
+func (s *CollectionsService) GetServerStatistics(serverID string) (map[string]any, error) {
+	s.log.Debug("Getting server statistics",
+		slog.String("serverID", serverID),
+	)
+
+	client, err := s.clients.GetClient(serverID)
+	if err != nil {
+		return nil, err
+	}
+
+	var result bson.M
+	err = client.Database("admin").RunCommand(s.ctx, bson.D{
+		{Key: "serverStatus", Value: 1},
+	}).Decode(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (s *CollectionsService) GetDatabaseStatistics(serverID, dbName string) (map[string]any, error) {
 	s.log.Debug("Getting database statistics",
 		slog.String("serverID", serverID),


### PR DESCRIPTION
Extends statistics feature to support server-level statistics via MongoDB's serverStatus command, accessible from the server context menu. Shows version, uptime, connections, memory usage, and total operations as summary cards.
implements #69 