### PR TITLE
fixes #118 - fix for linux Ctrl+V running on windows 

### DIFF
--- a/frontend/src/features/server-pane/ServerDialog.vue
+++ b/frontend/src/features/server-pane/ServerDialog.vue
@@ -232,6 +232,21 @@ watch(
   },
 )
 
+const onPasteConnectionString = (e: ClipboardEvent) => {
+  const pasted = e.clipboardData?.getData('text/plain') ?? ''
+  if (!pasted) {
+    return
+  }
+  e.preventDefault()
+
+  const input = e.target as HTMLInputElement
+  const start = input.selectionStart ?? 0
+  const end = input.selectionEnd ?? generalForm.value.connectionString.length
+  const current = generalForm.value.connectionString
+
+  generalForm.value.connectionString = current.slice(0, start) + pasted + current.slice(end)
+}
+
 function stripAuthMechanism(uri: string): string {
   return uri
     .replace(/[?&]authMechanism=[^&]*/gi, '')
@@ -335,7 +350,8 @@ const onTestConnection = async () => {
                 required>
                 <n-input
                   v-model:value="generalForm.connectionString"
-                  :placeholder="$t('serverPane.dialogs.server.connectionStringTip')" />
+                  :placeholder="$t('serverPane.dialogs.server.connectionStringTip')"
+                  @paste="onPasteConnectionString" />
               </n-form-item-gi>
               <n-form-item-gi
                 :label="$t('serverPane.dialogs.server.authMethod')"

--- a/frontend/src/features/server-pane/ServerDialog.vue
+++ b/frontend/src/features/server-pane/ServerDialog.vue
@@ -232,21 +232,6 @@ watch(
   },
 )
 
-const onPasteConnectionString = (e: ClipboardEvent) => {
-  const pasted = e.clipboardData?.getData('text/plain') ?? ''
-  if (!pasted) {
-    return
-  }
-  e.preventDefault()
-
-  const input = e.target as HTMLInputElement
-  const start = input.selectionStart ?? 0
-  const end = input.selectionEnd ?? generalForm.value.connectionString.length
-  const current = generalForm.value.connectionString
-
-  generalForm.value.connectionString = current.slice(0, start) + pasted + current.slice(end)
-}
-
 function stripAuthMechanism(uri: string): string {
   return uri
     .replace(/[?&]authMechanism=[^&]*/gi, '')
@@ -350,8 +335,7 @@ const onTestConnection = async () => {
                 required>
                 <n-input
                   v-model:value="generalForm.connectionString"
-                  :placeholder="$t('serverPane.dialogs.server.connectionStringTip')"
-                  @paste="onPasteConnectionString" />
+                  :placeholder="$t('serverPane.dialogs.server.connectionStringTip')" />
               </n-form-item-gi>
               <n-form-item-gi
                 :label="$t('serverPane.dialogs.server.authMethod')"

--- a/frontend/src/init/environment.ts
+++ b/frontend/src/init/environment.ts
@@ -14,3 +14,7 @@ export function isMacOS() {
 export function isWindows() {
   return os === 'windows'
 }
+
+export function isLinux() {
+  return os === 'linux'
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -4,7 +4,7 @@ import relativeTime from 'dayjs/plugin/relativeTime'
 import { createApp, nextTick } from 'vue'
 import App from './app/App.vue'
 import { createPinia } from 'pinia'
-import { loadEnvironment } from './init/environment'
+import { isLinux, loadEnvironment } from './init/environment'
 import { initMonaco } from './init/monaco'
 import { initDiscreteApi } from './init/discrete'
 import { useNotifier } from '@/utils/dialog'
@@ -41,7 +41,9 @@ async function initApp() {
 
   await loadEnvironment()
   initMonaco()
-  initClipboardWorkaround()
+  if (isLinux()) {
+    initClipboardWorkaround()
+  }
 
   await initDiscreteApi()
   app.config.errorHandler = (err) => {


### PR DESCRIPTION

## Summary

A work around for Ctrl-V being intercepted on Linux before getting to Vervet was running on Windows causing a double paste.  

## Changes

- added a OS check before the clipboard work around for linux. 

## Checklist

- [X] `bun run lint` passes (from `frontend/`)
- [X] `go test ./...` passes
- [X] Tested manually in `wails dev`
- [X] Screenshots included (if UI changes)
