### PR TITLE
Fix resiliency issues in connection lifecycle, timeouts, and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ go.work.sum
 build/bin
 frontend/dist
 test-results
+.worktrees
+.superpowers

--- a/frontend/src/app/AppContent.vue
+++ b/frontend/src/app/AppContent.vue
@@ -41,6 +41,15 @@ runtime.EventsOn('oidc-reauth-required', (serverID: string) => {
   })
 })
 
+runtime.EventsOn('config-parse-error', (detail: string) => {
+  notification.warning({
+    title: i18n.t('errorTitles.configParseError'),
+    content: i18n.t('errors.configParseError'),
+    meta: detail,
+    duration: 15000,
+  })
+})
+
 const data = reactive({
   navMenuWidth: 50,
   toolbarHeight: 38,

--- a/frontend/src/features/data-browser/browserStore.ts
+++ b/frontend/src/features/data-browser/browserStore.ts
@@ -303,7 +303,12 @@ export const useDataBrowserStore = defineStore('browser', {
     },
 
     async disconnectAll() {
-      await connectionsProxy.DisconnectAll()
+      const result = await connectionsProxy.DisconnectAll()
+      if (!result.isSuccess) {
+        const notifier = useNotifier()
+        notifier.warning(i18nGlobal.t('errorTitles.disconnect'), { detail: result.errorDetail })
+      }
+      // Always clean up frontend state
       this.connections = []
       this.serverTreeStates = {}
       const tabStore = useTabStore()
@@ -312,7 +317,12 @@ export const useDataBrowserStore = defineStore('browser', {
     async disconnect(serverId: string) {
       const server = this.connections.find((x) => x.serverID === serverId)
       if (server != null) {
-        await connectionsProxy.Disconnect(serverId)
+        const result = await connectionsProxy.Disconnect(serverId)
+        if (!result.isSuccess) {
+          const notifier = useNotifier()
+          notifier.warning(i18nGlobal.t('errorTitles.disconnect'), { detail: result.errorDetail })
+        }
+        // Always clean up frontend state — backend registry also always cleans up
         this.connections = this.connections.filter((x) => x.serverID !== serverId)
         delete this.serverTreeStates[serverId]
         const tabStore = useTabStore()
@@ -451,7 +461,12 @@ export const useDataBrowserStore = defineStore('browser', {
     async connect(serverId: string, reload: boolean = false) {
       if (this.isConnected(serverId)) {
         if (!reload) {
-          await connectionsProxy.Disconnect(serverId)
+          await this.disconnect(serverId)
+          return {
+            success: true,
+            serverId: serverId,
+            name: '',
+          }
         }
         return {
           success: true,

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -523,9 +523,11 @@ export default {
     query_cancelled: 'Query cancelled',
     operation_not_supported: 'Operation not supported by the current query engine',
     unknown_error: 'An unexpected error occurred',
+    configParseError: 'Your server configuration file could not be read. Your server list may appear empty until the file is repaired or new servers are added.',
   },
   errorTitles: {
     loadServers: 'Failed to load servers',
+    configParseError: 'Server Configuration Error',
     loadServerDetails: 'Failed to load server details',
     connect: 'Failed to connect to server',
     disconnect: 'Failed to disconnect from server',

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -528,6 +528,7 @@ export default {
     loadServers: 'Failed to load servers',
     loadServerDetails: 'Failed to load server details',
     connect: 'Failed to connect to server',
+    disconnect: 'Failed to disconnect from server',
     listDatabases: 'Failed to load databases',
     listCollections: 'Failed to load collections',
     listViews: 'Failed to load views',

--- a/internal/clientregistry/registry.go
+++ b/internal/clientregistry/registry.go
@@ -211,13 +211,23 @@ func (r *ClientRegistry) Disconnect(serverID string) error {
 		return fmt.Errorf("no active connection for server %s", serverID)
 	}
 
+	// Always remove the client from the map, even if Disconnect() fails.
+	// A broken client reference is worse than a missing one — the user
+	// must be able to reconnect.
+	delete(r.clients, serverID)
+
+	if rc.client == nil {
+		r.log.Warn("Client was nil; removed from registry without disconnecting",
+			slog.String("serverID", serverID))
+		return nil
+	}
+
 	if err := rc.client.Disconnect(r.ctx); err != nil {
-		r.log.Error("Error disconnecting",
+		r.log.Error("Error disconnecting (client removed from registry anyway)",
 			slog.String("serverID", serverID), slog.Any("error", err))
 		return fmt.Errorf("error during disconnect: %w", err)
 	}
 
-	delete(r.clients, serverID)
 	r.log.Info("Disconnected client", slog.String("serverID", serverID))
 	return nil
 }

--- a/internal/clientregistry/registry.go
+++ b/internal/clientregistry/registry.go
@@ -238,6 +238,11 @@ func (r *ClientRegistry) DisconnectAll() error {
 
 	var lastErr error
 	for id, rc := range r.clients {
+		if rc.client == nil {
+			r.log.Warn("Client was nil; removed from registry without disconnecting",
+				slog.String("serverID", id))
+			continue
+		}
 		if err := rc.client.Disconnect(r.ctx); err != nil {
 			r.log.Error("Error disconnecting",
 				slog.String("serverID", id), slog.Any("error", err))

--- a/internal/clientregistry/registry_test.go
+++ b/internal/clientregistry/registry_test.go
@@ -57,7 +57,7 @@ func TestClientRegistry_Disconnect(t *testing.T) {
 
 		assert.True(t, reg.IsConnected("test-server"))
 
-		// Disconnect will error (nil client), but should still clean up
+		// Disconnect handles nil client gracefully and should still clean up
 		_ = reg.Disconnect("test-server")
 
 		assert.False(t, reg.IsConnected("test-server"))

--- a/internal/clientregistry/registry_test.go
+++ b/internal/clientregistry/registry_test.go
@@ -31,3 +31,35 @@ func TestClientRegistry_IsConnected(t *testing.T) {
 		assert.False(t, reg.IsConnected("unknown"))
 	})
 }
+
+func TestClientRegistry_Disconnect(t *testing.T) {
+	t.Run("returns error for unknown serverID", func(t *testing.T) {
+		reg := NewClientRegistry(nil, nil)
+		reg.Init(context.Background())
+
+		err := reg.Disconnect("unknown")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no active connection")
+	})
+
+	t.Run("removes client from map even when client is nil", func(t *testing.T) {
+		reg := NewClientRegistry(nil, nil)
+		reg.Init(context.Background())
+
+		// Manually inject a client to simulate a connected state
+		reg.mu.Lock()
+		reg.clients["test-server"] = registeredClient{
+			client:   nil,
+			serverID: "test-server",
+			name:     "Test",
+		}
+		reg.mu.Unlock()
+
+		assert.True(t, reg.IsConnected("test-server"))
+
+		// Disconnect will error (nil client), but should still clean up
+		_ = reg.Disconnect("test-server")
+
+		assert.False(t, reg.IsConnected("test-server"))
+	})
+}

--- a/internal/collections/service.go
+++ b/internal/collections/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"time"
 	"vervet/internal/logging"
 	"vervet/internal/models"
 	"vervet/internal/queryengine"
@@ -13,6 +14,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
+
+const operationTimeout = 30 * time.Second
 
 // ClientProvider provides access to active MongoDB connections
 type ClientProvider interface {
@@ -47,8 +50,11 @@ func (s *CollectionsService) GetServerStatistics(serverID string) (map[string]an
 		return nil, err
 	}
 
+	ctx, cancel := context.WithTimeout(s.ctx, operationTimeout)
+	defer cancel()
+
 	var result bson.M
-	err = client.Database("admin").RunCommand(s.ctx, bson.D{
+	err = client.Database("admin").RunCommand(ctx, bson.D{
 		{Key: "serverStatus", Value: 1},
 	}).Decode(&result)
 	if err != nil {
@@ -70,8 +76,11 @@ func (s *CollectionsService) GetStatistics(serverID, dbName, collectionName stri
 		return nil, err
 	}
 
+	ctx, cancel := context.WithTimeout(s.ctx, operationTimeout)
+	defer cancel()
+
 	var result bson.M
-	err = client.Database(dbName).RunCommand(s.ctx, bson.D{
+	err = client.Database(dbName).RunCommand(ctx, bson.D{
 		{Key: "collStats", Value: collectionName},
 	}).Decode(&result)
 	if err != nil {
@@ -91,8 +100,11 @@ func (s *CollectionsService) GetCollections(serverID, dbName string) ([]string, 
 		return nil, err
 	}
 
+	ctx, cancel := context.WithTimeout(s.ctx, operationTimeout)
+	defer cancel()
+
 	db := client.Database(dbName)
-	names, err := db.ListCollectionNames(s.ctx, bson.D{})
+	names, err := db.ListCollectionNames(ctx, bson.D{})
 	if err != nil {
 		return nil, err
 	}
@@ -110,9 +122,12 @@ func (s *CollectionsService) GetViews(serverID, dbName string) ([]string, error)
 		return nil, err
 	}
 
+	ctx, cancel := context.WithTimeout(s.ctx, operationTimeout)
+	defer cancel()
+
 	db := client.Database(dbName)
 	filter := bson.D{{Key: "type", Value: "view"}}
-	names, err := db.ListCollectionNames(s.ctx, filter)
+	names, err := db.ListCollectionNames(ctx, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +146,10 @@ func (s *CollectionsService) CreateCollection(serverID, dbName, collectionName s
 		return err
 	}
 
-	err = client.Database(dbName).CreateCollection(s.ctx, collectionName)
+	ctx, cancel := context.WithTimeout(s.ctx, operationTimeout)
+	defer cancel()
+
+	err = client.Database(dbName).CreateCollection(ctx, collectionName)
 	if err != nil {
 		s.log.Error("Failed to create collection",
 			slog.String("serverID", serverID),
@@ -153,7 +171,11 @@ func (s *CollectionsService) GetCollectionSchema(serverID, dbName, collName stri
 	if err != nil {
 		return models.CollectionSchema{}, err
 	}
-	return queryengine.SampleSchema(s.ctx, client, dbName, collName)
+
+	ctx, cancel := context.WithTimeout(s.ctx, operationTimeout)
+	defer cancel()
+
+	return queryengine.SampleSchema(ctx, client, dbName, collName)
 }
 
 func (s *CollectionsService) RenameCollection(serverID, dbName, oldName, newName string) error {
@@ -175,12 +197,15 @@ func (s *CollectionsService) RenameCollection(serverID, dbName, oldName, newName
 		return err
 	}
 
+	ctx, cancel := context.WithTimeout(s.ctx, operationTimeout)
+	defer cancel()
+
 	// MongoDB renames via the admin command: renameCollection
 	cmd := bson.D{
 		{Key: "renameCollection", Value: dbName + "." + oldName},
 		{Key: "to", Value: dbName + "." + newName},
 	}
-	err = client.Database("admin").RunCommand(s.ctx, cmd).Err()
+	err = client.Database("admin").RunCommand(ctx, cmd).Err()
 	if err != nil {
 		s.log.Error("Failed to rename collection",
 			slog.String("serverID", serverID),
@@ -210,7 +235,10 @@ func (s *CollectionsService) DropCollection(serverID, dbName, collectionName str
 		return err
 	}
 
-	err = client.Database(dbName).Collection(collectionName).Drop(s.ctx)
+	ctx, cancel := context.WithTimeout(s.ctx, operationTimeout)
+	defer cancel()
+
+	err = client.Database(dbName).Collection(collectionName).Drop(ctx)
 	if err != nil {
 		s.log.Error("Failed to drop collection",
 			slog.String("serverID", serverID),

--- a/internal/connectionStrings/store.go
+++ b/internal/connectionStrings/store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 	"vervet/internal/logging"
 	"vervet/internal/models"
@@ -13,6 +14,7 @@ import (
 
 const serviceName = "Vervet"
 const keyringTimeout = 5 * time.Second
+const keyringCooldown = 1 * time.Minute
 
 type Store interface {
 	StoreRegisteredServerURI(registeredServerID, uri string) error
@@ -24,19 +26,23 @@ type Store interface {
 }
 
 type store struct {
-	log *slog.Logger
+	log              *slog.Logger
+	mu               sync.Mutex
+	keyringAvailable bool
+	lastCheck        time.Time
 }
 
 func NewStore(log *slog.Logger) *store {
 	return &store{
-		log: log.With(slog.String(logging.SourceKey, "ConnectionStringStore")),
+		log:              log.With(slog.String(logging.SourceKey, "ConnectionStringStore")),
+		keyringAvailable: true,
 	}
 }
 
 // StoreRegisteredServerURI securely saves a connectionURI associated with a user provided name
 func (s *store) StoreRegisteredServerURI(registeredServerID, uri string) error {
 	key := getKey(registeredServerID)
-	err := withTimeout(keyringTimeout, func() error {
+	err := s.withTimeout(keyringTimeout, func() error {
 		return keyring.Set(serviceName, key, uri)
 	})
 	if err != nil {
@@ -49,7 +55,7 @@ func (s *store) StoreRegisteredServerURI(registeredServerID, uri string) error {
 func (s *store) GetRegisteredServerURI(registeredServerID string) (string, error) {
 	key := getKey(registeredServerID)
 	var uri string
-	err := withTimeout(keyringTimeout, func() error {
+	err := s.withTimeout(keyringTimeout, func() error {
 		var getErr error
 		uri, getErr = keyring.Get(serviceName, key)
 		return getErr
@@ -64,7 +70,7 @@ func (s *store) GetRegisteredServerURI(registeredServerID string) (string, error
 
 func (s *store) DeleteRegisteredServerURI(registeredServerID string) error {
 	key := getKey(registeredServerID)
-	err := withTimeout(keyringTimeout, func() error {
+	err := s.withTimeout(keyringTimeout, func() error {
 		return keyring.Delete(serviceName, key)
 	})
 	if err != nil {
@@ -74,11 +80,40 @@ func (s *store) DeleteRegisteredServerURI(registeredServerID string) error {
 	return nil
 }
 
+func (s *store) checkKeyringAvailable() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.keyringAvailable {
+		return nil
+	}
+
+	if time.Since(s.lastCheck) < keyringCooldown {
+		return fmt.Errorf("keyring unavailable (will retry after cooldown) — the OS secret service may not be running")
+	}
+
+	// Cooldown expired, allow retry
+	s.keyringAvailable = true
+	return nil
+}
+
+func (s *store) markKeyringUnavailable() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.keyringAvailable = false
+	s.lastCheck = time.Now()
+}
+
 // withTimeout runs fn in a goroutine and returns its error, or a timeout error
 // if it doesn't complete within the given duration. This prevents keyring operations
 // from hanging indefinitely when the OS secret service (D-Bus) is unavailable,
 // which is common in environments like WSL2 without a running keyring daemon.
-func withTimeout(timeout time.Duration, fn func() error) error {
+// If the keyring has previously timed out, it fails fast during the cooldown period.
+func (s *store) withTimeout(timeout time.Duration, fn func() error) error {
+	if err := s.checkKeyringAvailable(); err != nil {
+		return err
+	}
+
 	done := make(chan error, 1)
 	go func() {
 		done <- fn()
@@ -87,6 +122,9 @@ func withTimeout(timeout time.Duration, fn func() error) error {
 	case err := <-done:
 		return err
 	case <-time.After(timeout):
+		s.markKeyringUnavailable()
+		s.log.Warn("Keyring operation timed out, marking unavailable for cooldown",
+			slog.Duration("cooldown", keyringCooldown))
 		return fmt.Errorf("keyring operation timed out after %v — the OS secret service may be unavailable (check that a keyring daemon is running)", timeout)
 	}
 }

--- a/internal/connections/manager.go
+++ b/internal/connections/manager.go
@@ -175,12 +175,17 @@ func (cm *ConnectionManager) TestConnectionWithConfig(ctx context.Context, cfg m
 
 func (cm *ConnectionManager) Disconnect(serverID string) error {
 	err := cm.registry.Disconnect(serverID)
+
+	// Always emit the event: the registry removes the client from its map
+	// even when the underlying driver disconnect fails, so the frontend
+	// must know the connection is gone.
+	runtime.EventsEmit(cm.ctx, DisconnectedEvent, serverID)
+
 	if err != nil {
 		cm.log.Error("Error disconnecting", slog.String("serverID", serverID), slog.Any("error", err))
 		return err
 	}
 
-	runtime.EventsEmit(cm.ctx, DisconnectedEvent, serverID)
 	cm.log.Info("Disconnected from mongo server", slog.String("serverID", serverID))
 	return nil
 }

--- a/internal/databases/service.go
+++ b/internal/databases/service.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"time"
 	"vervet/internal/logging"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
+
+const operationTimeout = 30 * time.Second
 
 // ClientProvider provides access to active MongoDB connections
 type ClientProvider interface {
@@ -43,7 +46,10 @@ func (s *DatabasesService) GetDatabases(serverID string) ([]string, error) {
 		return nil, err
 	}
 
-	names, err := client.ListDatabaseNames(s.ctx, bson.D{})
+	ctx, cancel := context.WithTimeout(s.ctx, operationTimeout)
+	defer cancel()
+
+	names, err := client.ListDatabaseNames(ctx, bson.D{})
 	if err != nil {
 		s.log.Error("Failed to list databases", slog.String("serverID", serverID), slog.Any("error", err))
 		return nil, err
@@ -64,8 +70,11 @@ func (s *DatabasesService) GetDatabaseStatistics(serverID, dbName string) (map[s
 		return nil, err
 	}
 
+	ctx, cancel := context.WithTimeout(s.ctx, operationTimeout)
+	defer cancel()
+
 	var result bson.M
-	err = client.Database(dbName).RunCommand(s.ctx, bson.D{
+	err = client.Database(dbName).RunCommand(ctx, bson.D{
 		{Key: "dbStats", Value: 1},
 	}).Decode(&result)
 	if err != nil {
@@ -85,7 +94,10 @@ func (s *DatabasesService) DropDatabase(serverID, dbName string) error {
 		return err
 	}
 
-	err = client.Database(dbName).Drop(s.ctx)
+	ctx, cancel := context.WithTimeout(s.ctx, operationTimeout)
+	defer cancel()
+
+	err = client.Database(dbName).Drop(ctx)
 	if err != nil {
 		s.log.Error("Failed to drop database",
 			slog.String("serverID", serverID),

--- a/internal/servers/service.go
+++ b/internal/servers/service.go
@@ -154,6 +154,12 @@ func (sm *ServerService) UpdateServer(serverID, name, uri, parentID, colour stri
 		return fmt.Errorf("failed to find registered server with ID %s", serverID)
 	}
 
+	err = sm.connectionStrings.StoreRegisteredServerURI(serverID, uri)
+	if err != nil {
+		log.Error("Failed to securely store registeredServer URI", slog.Any("error", err))
+		return fmt.Errorf("failed to securely store registeredServer URI: %w", err)
+	}
+
 	server.Name = name
 	server.ParentID = parentID
 	server.Colour = colour
@@ -162,12 +168,6 @@ func (sm *ServerService) UpdateServer(serverID, name, uri, parentID, colour stri
 	if err != nil {
 		log.Error("Failed to save registered server metadata", slog.Any("error", err))
 		return fmt.Errorf("failed to save registered server metadata: %w", err)
-	}
-
-	err = sm.connectionStrings.StoreRegisteredServerURI(serverID, uri)
-	if err != nil {
-		log.Error("Failed to securely store registeredServer URI", slog.Any("error", err))
-		return fmt.Errorf("failed to securely store registeredServer URI: %w", err)
 	}
 
 	return nil
@@ -250,6 +250,12 @@ func (sm *ServerService) UpdateServerWithConfig(serverID, name, parentID, colour
 		return fmt.Errorf("failed to find registered server with ID %s", serverID)
 	}
 
+	err = sm.connectionStrings.StoreConnectionConfig(serverID, cfg)
+	if err != nil {
+		log.Error("Failed to securely store connection config", slog.Any("error", err))
+		return fmt.Errorf("failed to securely store connection config: %w", err)
+	}
+
 	server.Name = name
 	server.ParentID = parentID
 	server.Colour = colour
@@ -258,12 +264,6 @@ func (sm *ServerService) UpdateServerWithConfig(serverID, name, parentID, colour
 	if err != nil {
 		log.Error("Failed to save registered server metadata", slog.Any("error", err))
 		return fmt.Errorf("failed to save registered server metadata: %w", err)
-	}
-
-	err = sm.connectionStrings.StoreConnectionConfig(serverID, cfg)
-	if err != nil {
-		log.Error("Failed to securely store connection config", slog.Any("error", err))
-		return fmt.Errorf("failed to securely store connection config: %w", err)
 	}
 
 	return nil

--- a/internal/servers/service.go
+++ b/internal/servers/service.go
@@ -41,6 +41,9 @@ func (sm *ServerService) Init(ctx context.Context) {
 }
 
 func (sm *ServerService) GetServers() ([]models.RegisteredServer, error) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
 	sm.log.Debug("Getting All models.RegisteredServers")
 	registeredServers, err := sm.store.LoadServers()
 	if err != nil {
@@ -51,6 +54,9 @@ func (sm *ServerService) GetServers() ([]models.RegisteredServer, error) {
 }
 
 func (sm *ServerService) GetServer(id string) (*models.RegisteredServer, error) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
 	log := sm.log.With(slog.String("serverID", id))
 	log.Debug("Getting Server Configuration for Server")
 	registeredServers, err := sm.store.LoadServers()

--- a/internal/servers/service.go
+++ b/internal/servers/service.go
@@ -12,8 +12,11 @@ import (
 	"vervet/internal/oidc"
 
 	"github.com/google/uuid"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 )
+
+const ConfigParseErrorEvent = "config-parse-error"
 
 type ServerService struct {
 	ctx               context.Context
@@ -48,6 +51,12 @@ func (sm *ServerService) GetServers() ([]models.RegisteredServer, error) {
 	registeredServers, err := sm.store.LoadServers()
 	if err != nil {
 		sm.log.Error("error getting models.RegisteredServers", slog.Any("error", err))
+		if registeredServers != nil {
+			// Store returned fallback data (e.g. empty list on parse error)
+			// — emit a warning event so the frontend can alert the user
+			runtime.EventsEmit(sm.ctx, ConfigParseErrorEvent, err.Error())
+			return registeredServers, nil
+		}
 		return nil, fmt.Errorf("error getting models.RegisteredServers: %w", err)
 	}
 	return registeredServers, nil

--- a/internal/servers/service_test.go
+++ b/internal/servers/service_test.go
@@ -246,6 +246,28 @@ func TestRemoveNode(t *testing.T) {
 	})
 }
 
+func TestUpdateServer_KeyringFailureDoesNotPersistMetadata(t *testing.T) {
+	t.Run("metadata unchanged when keyring store fails", func(t *testing.T) {
+		mockStore := &mockServerStore{
+			servers: []models.RegisteredServer{
+				{ID: "1", Name: "Original Name"},
+			},
+		}
+		mockCSStore := &MockConnectionStringsStore{
+			uris: map[string]string{"1": "mongodb://localhost"},
+			err:  errors.New("keyring locked"),
+		}
+		sm := newTestServerService(mockStore, mockCSStore)
+
+		err := sm.UpdateServer("1", "New Name", "mongodb://newhost", "", "")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "keyring locked")
+		// Metadata should NOT have been updated since keyring failed
+		assert.Equal(t, "Original Name", mockStore.servers[0].Name)
+	})
+}
+
 func TestGetURI(t *testing.T) {
 	t.Run("successful get uri", func(t *testing.T) {
 		mockCSStore := &MockConnectionStringsStore{

--- a/internal/servers/store.go
+++ b/internal/servers/store.go
@@ -47,8 +47,8 @@ func (s *store) LoadServers() ([]models.RegisteredServer, error) {
 	}
 
 	if err = yaml.Unmarshal(b, &registeredServers); err != nil {
-		s.log.Error("error parsing registered servers", slog.Any("error", err))
-		return nil, fmt.Errorf("error parsing registered servers: %v", err)
+		s.log.Error("error parsing registered servers, returning empty list", slog.Any("error", err))
+		return make([]models.RegisteredServer, 0), nil
 	}
 
 	return registeredServers, nil

--- a/internal/servers/store.go
+++ b/internal/servers/store.go
@@ -48,7 +48,7 @@ func (s *store) LoadServers() ([]models.RegisteredServer, error) {
 
 	if err = yaml.Unmarshal(b, &registeredServers); err != nil {
 		s.log.Error("error parsing registered servers, returning empty list", slog.Any("error", err))
-		return make([]models.RegisteredServer, 0), nil
+		return make([]models.RegisteredServer, 0), fmt.Errorf("server configuration file is corrupted and could not be read — your server list may be empty until the file is repaired: %w", err)
 	}
 
 	return registeredServers, nil

--- a/internal/servers/store_test.go
+++ b/internal/servers/store_test.go
@@ -66,14 +66,15 @@ func TestLoadServers(t *testing.T) {
 		assert.Nil(t, servers)
 	})
 
-	t.Run("unmarshal error", func(t *testing.T) {
+	t.Run("unmarshal error falls back to empty list", func(t *testing.T) {
 		mockCfgStore := &MockConfigurationStore{
-			data: []byte(`invalid yaml`),
+			data: []byte(`invalid yaml: [[[`),
 		}
 		store := &store{cfgStore: mockCfgStore, log: slog.Default()}
 		servers, err := store.LoadServers()
-		assert.Error(t, err)
-		assert.Nil(t, servers)
+		assert.NoError(t, err)
+		assert.NotNil(t, servers)
+		assert.Len(t, servers, 0)
 	})
 }
 

--- a/internal/servers/store_test.go
+++ b/internal/servers/store_test.go
@@ -66,13 +66,14 @@ func TestLoadServers(t *testing.T) {
 		assert.Nil(t, servers)
 	})
 
-	t.Run("unmarshal error falls back to empty list", func(t *testing.T) {
+	t.Run("unmarshal error falls back to empty list with error", func(t *testing.T) {
 		mockCfgStore := &MockConfigurationStore{
 			data: []byte(`invalid yaml: [[[`),
 		}
 		store := &store{cfgStore: mockCfgStore, log: slog.Default()}
 		servers, err := store.LoadServers()
-		assert.NoError(t, err)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "corrupted")
 		assert.NotNil(t, servers)
 		assert.Len(t, servers, 0)
 	})


### PR DESCRIPTION
## Summary

Fixes 8 resiliency issues identified during a code review audit, where unhappy paths could leave the user stuck with no way to self-correct:

- **Connection lifecycle (Critical):** `ClientRegistry.Disconnect` now always removes the client from its map even on error, preventing orphaned connections that block reconnection. `ConnectionManager` always emits the disconnect event. Frontend `browserStore` checks disconnect results and the connect toggle properly cleans up state.
- **Operation timeouts (Important):** All database and collection MongoDB operations now use a 30s timeout instead of the app-lifetime context, preventing indefinite UI hangs on unresponsive servers.
- **Server service thread safety (Important):** `GetServers`/`GetServer` now hold a read lock. `UpdateServer`/`UpdateServerWithConfig` store the URI in the keyring before saving metadata, matching `AddServer`'s pattern.
- **YAML resilience (Important):** Corrupted `connections.yaml` now falls back to an empty server list instead of propagating an unrecoverable error.
- **Keyring goroutine leak (Important):** Keyring operations now cache "unavailable" state with a 1-minute cooldown, preventing goroutine accumulation on WSL2/locked keyring environments.

## Test plan
- [x] All Go tests pass (`go test ./internal/...`)
- [x] Frontend lint clean (`bun run lint`)
- [x] Manual: Connect to a server, kill the MongoDB process, attempt disconnect — should succeed and allow reconnection
- [x] Manual: Start app with corrupted `~/.config/vervet/connections.yaml` — should show empty server list, not crash