### PR TITLE
feat: import robustness improvements

### DIFF
--- a/frontend/src/features/server-pane/serverStore.ts
+++ b/frontend/src/features/server-pane/serverStore.ts
@@ -244,6 +244,15 @@ export const useServerStore = defineStore('server', {
       }
 
       await this.refreshServers(true)
+
+      const warnings = importResult.data?.warnings || []
+      if (warnings.length > 0) {
+        const notifier = useNotifier()
+        notifier.warning(warnings.join('\n'), {
+          title: i18nGlobal.t('serverPane.importWarningsTitle'),
+        })
+      }
+
       return { success: true }
     },
     async deleteGroup(groupId: string) {

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -445,6 +445,7 @@ export default {
       },
     },
     importServers: 'Import Servers...',
+    importWarningsTitle: 'Import Warnings',
     exportServers: 'Export Servers...',
     exportServersMenu: 'Export/Import',
     importServersMenuItem: 'Import Servers...',

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"vervet/internal/models"
+	"vervet/internal/servers"
 )
 
 type ServersProvider interface {
@@ -18,7 +19,7 @@ type ServersProvider interface {
 	UpdateServerWithConfig(serverID, name, parentID, colour string, cfg models.ConnectionConfig) error
 	GetConnectionConfig(serverID string) (models.ConnectionConfig, error)
 	ExportServers(serverIDs []string, includeSensitiveData bool) ([]byte, error)
-	ImportServers(data []byte) ([]models.RegisteredServer, error)
+	ImportServers(data []byte) (*servers.ImportResult, error)
 }
 
 // ServersProxy exposes the ServerService to the UI
@@ -143,10 +144,10 @@ func (sp *ServersProxy) ExportServers(serverIDs []string, includeSensitiveData b
 	return SuccessResult(string(data))
 }
 
-func (sp *ServersProxy) ImportServers(jsonData string) Result[[]models.RegisteredServer] {
-	imported, err := sp.sm.ImportServers([]byte(jsonData))
+func (sp *ServersProxy) ImportServers(jsonData string) Result[servers.ImportResult] {
+	result, err := sp.sm.ImportServers([]byte(jsonData))
 	if err != nil {
-		return FailResult[[]models.RegisteredServer](err)
+		return FailResult[servers.ImportResult](err)
 	}
-	return SuccessResult(imported)
+	return SuccessResult(*result)
 }

--- a/internal/api/servers_test.go
+++ b/internal/api/servers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"vervet/internal/models"
+	"vervet/internal/servers"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -78,11 +79,11 @@ func (m *MockServersProvider) ExportServers(serverIDs []string, includeSensitive
 	return []byte(`{"version":1,"servers":[]}`), nil
 }
 
-func (m *MockServersProvider) ImportServers(data []byte) ([]models.RegisteredServer, error) {
+func (m *MockServersProvider) ImportServers(data []byte) (*servers.ImportResult, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
-	return []models.RegisteredServer{}, nil
+	return &servers.ImportResult{Created: []models.RegisteredServer{}}, nil
 }
 
 func TestServersProxy_GetServers(t *testing.T) {

--- a/internal/infrastructure/store.go
+++ b/internal/infrastructure/store.go
@@ -58,12 +58,29 @@ func (s *cfgStore) Read() ([]byte, error) {
 }
 
 func (s *cfgStore) Save(data []byte) error {
-	if err := os.WriteFile(s.ConfigPath, data, 0600); err != nil {
+	f, err := os.Create(s.ConfigPath)
+	if err != nil {
 		if s.log != nil {
-			s.log.Error("Error saving configuration", slog.Any("error", err))
+			s.log.Error("Error creating configuration file for save", slog.Any("error", err))
 		}
 		return fmt.Errorf("error saving configuration: %w", err)
 	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		if s.log != nil {
+			s.log.Error("Error writing configuration", slog.Any("error", err))
+		}
+		return fmt.Errorf("error saving configuration: %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		if s.log != nil {
+			s.log.Error("Error syncing configuration to disk", slog.Any("error", err))
+		}
+		return fmt.Errorf("error saving configuration: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/servers/export.go
+++ b/internal/servers/export.go
@@ -119,6 +119,14 @@ func stripCredentials(uri string) string {
 	return parsed.String()
 }
 
+// escapePathSegment escapes `/` and `\` in a group name so it can be safely
+// embedded in a `/`-delimited parent path. Escape `\` first to avoid double-escaping.
+func escapePathSegment(name string) string {
+	name = strings.ReplaceAll(name, `\`, `\\`)
+	name = strings.ReplaceAll(name, `/`, `\/`)
+	return name
+}
+
 // buildParentPath walks up the parent chain and returns a slash-delimited path of ancestor names.
 func buildParentPath(parentID string, servers []models.RegisteredServer) string {
 	if parentID == "" {
@@ -132,7 +140,7 @@ func buildParentPath(parentID string, servers []models.RegisteredServer) string 
 		if srv == nil {
 			break
 		}
-		parts = append(parts, srv.Name)
+		parts = append(parts, escapePathSegment(srv.Name))
 		current = srv.ParentID
 	}
 

--- a/internal/servers/export_test.go
+++ b/internal/servers/export_test.go
@@ -253,3 +253,21 @@ func TestExportServers_NoColourOmitted(t *testing.T) {
 	_, hasColour := serverMap["colour"]
 	assert.False(t, hasColour, "expected 'colour' key to be omitted from JSON when empty")
 }
+
+func TestBuildParentPath_EscapesSlashInName(t *testing.T) {
+	servers := []models.RegisteredServer{
+		{ID: "g1", Name: "Dev/Test", IsGroup: true},
+		{ID: "g2", Name: "Sub\\Group", IsGroup: true, ParentID: "g1"},
+	}
+	path := buildParentPath("g2", servers)
+	assert.Equal(t, `Dev\/Test/Sub\\Group`, path)
+}
+
+func TestBuildParentPath_NoEscapingNeeded(t *testing.T) {
+	servers := []models.RegisteredServer{
+		{ID: "g1", Name: "Production", IsGroup: true},
+		{ID: "g2", Name: "US-East", IsGroup: true, ParentID: "g1"},
+	}
+	path := buildParentPath("g2", servers)
+	assert.Equal(t, "Production/US-East", path)
+}

--- a/internal/servers/export_test.go
+++ b/internal/servers/export_test.go
@@ -207,14 +207,14 @@ func TestExportImport_RoundTrip(t *testing.T) {
 	importConnStore := &MockConnectionStringsStore{uris: make(map[string]string)}
 	importSvc := newTestServerService(importStore, importConnStore)
 
-	imported, err := importSvc.ImportServers(data)
+	importResult, err := importSvc.ImportServers(data)
 	require.NoError(t, err)
-	assert.Len(t, imported, 3) // group + 2 servers
+	assert.Len(t, importResult.Created, 3) // group + 2 servers
 
 	// Verify structure is preserved
 	byName := make(map[string]*models.RegisteredServer)
-	for i := range imported {
-		byName[imported[i].Name] = &imported[i]
+	for i := range importResult.Created {
+		byName[importResult.Created[i].Name] = &importResult.Created[i]
 	}
 
 	assert.True(t, byName["Production"].IsGroup)

--- a/internal/servers/export_test.go
+++ b/internal/servers/export_test.go
@@ -254,6 +254,45 @@ func TestExportServers_NoColourOmitted(t *testing.T) {
 	assert.False(t, hasColour, "expected 'colour' key to be omitted from JSON when empty")
 }
 
+func TestExportImport_RoundTripWithSlashInName(t *testing.T) {
+	store := &mockServerStore{
+		servers: []models.RegisteredServer{
+			{ID: "g1", Name: "Dev/Test", IsGroup: true},
+			{ID: "s1", Name: "Primary", ParentID: "g1", Colour: "#FF0000"},
+		},
+	}
+	connStore := &mockConnStoreWithConfigs{
+		MockConnectionStringsStore: MockConnectionStringsStore{uris: make(map[string]string)},
+		configs: map[string]models.ConnectionConfig{
+			"s1": {URI: "mongodb://localhost:27017", AuthMethod: models.AuthNone},
+		},
+	}
+	exportSvc := newTestServerService(store, connStore)
+
+	data, err := exportSvc.ExportServers([]string{"g1", "s1"}, true)
+	require.NoError(t, err)
+
+	importStore := &mockServerStore{servers: []models.RegisteredServer{}}
+	importConnStore := &MockConnectionStringsStore{uris: make(map[string]string)}
+	importSvc := newTestServerService(importStore, importConnStore)
+
+	importResult, err := importSvc.ImportServers(data)
+	require.NoError(t, err)
+	assert.Len(t, importResult.Created, 2)
+
+	byName := make(map[string]*models.RegisteredServer)
+	for i := range importResult.Created {
+		byName[importResult.Created[i].Name] = &importResult.Created[i]
+	}
+
+	group := byName["Dev/Test"]
+	server := byName["Primary"]
+	require.NotNil(t, group, "group 'Dev/Test' should exist with original name")
+	require.NotNil(t, server)
+	assert.True(t, group.IsGroup)
+	assert.Equal(t, group.ID, server.ParentID)
+}
+
 func TestBuildParentPath_EscapesSlashInName(t *testing.T) {
 	servers := []models.RegisteredServer{
 		{ID: "g1", Name: "Dev/Test", IsGroup: true},

--- a/internal/servers/import.go
+++ b/internal/servers/import.go
@@ -63,9 +63,10 @@ func (sm *ServerService) ImportServers(data []byte) (*ImportResult, error) {
 		}
 
 		if entry.IsGroup {
-			path := entry.Name
+			escapedName := escapePathSegment(entry.Name)
+			path := escapedName
 			if entry.Parent != "" {
-				path = entry.Parent + "/" + entry.Name
+				path = rebuildEscapedPath(entry.Parent) + "/" + escapedName
 			}
 
 			// Skip duplicate groups (same name and parent path).
@@ -146,18 +147,61 @@ func (sm *ServerService) ImportServers(data []byte) (*ImportResult, error) {
 	return &ImportResult{Created: created}, nil
 }
 
-// resolveParentPath takes a slash-delimited path (e.g. "Infra/Databases") and returns
-// the ID of the deepest group, creating any missing intermediate groups as needed.
+// splitEscapedPath splits a parent path on unescaped `/` delimiters.
+// `\/` is a literal `/` in a name, `\\` is a literal `\`.
+func splitEscapedPath(path string) []string {
+	var parts []string
+	var current strings.Builder
+	i := 0
+	for i < len(path) {
+		if path[i] == '\\' && i+1 < len(path) {
+			// Escaped character — consume both bytes literally
+			current.WriteByte(path[i])
+			current.WriteByte(path[i+1])
+			i += 2
+		} else if path[i] == '/' {
+			parts = append(parts, unescapePathSegment(current.String()))
+			current.Reset()
+			i++
+		} else {
+			current.WriteByte(path[i])
+			i++
+		}
+	}
+	parts = append(parts, unescapePathSegment(current.String()))
+	return parts
+}
+
+// unescapePathSegment reverses escapePathSegment: `\/` → `/`, `\\` → `\`.
+func unescapePathSegment(s string) string {
+	s = strings.ReplaceAll(s, `\/`, `/`)
+	s = strings.ReplaceAll(s, `\\`, `\`)
+	return s
+}
+
+// rebuildEscapedPath splits and re-escapes a parent path to normalise it for map lookups.
+func rebuildEscapedPath(path string) string {
+	parts := splitEscapedPath(path)
+	escaped := make([]string, len(parts))
+	for i, p := range parts {
+		escaped[i] = escapePathSegment(p)
+	}
+	return strings.Join(escaped, "/")
+}
+
+// resolveParentPath takes an escaped slash-delimited path (e.g. "Infra/Databases" or "Dev\/Test")
+// and returns the ID of the deepest group, creating any missing intermediate groups as needed.
 func resolveParentPath(path string, groupPaths map[string]string, servers *[]models.RegisteredServer, created *[]models.RegisteredServer) string {
-	parts := strings.Split(path, "/")
+	parts := splitEscapedPath(path)
 	currentPath := ""
 	parentID := ""
 
 	for _, part := range parts {
+		escapedPart := escapePathSegment(part)
 		if currentPath == "" {
-			currentPath = part
+			currentPath = escapedPart
 		} else {
-			currentPath = currentPath + "/" + part
+			currentPath = currentPath + "/" + escapedPart
 		}
 
 		if id, ok := groupPaths[currentPath]; ok {
@@ -182,7 +226,8 @@ func resolveParentPath(path string, groupPaths map[string]string, servers *[]mod
 	return parentID
 }
 
-// buildExistingGroupPaths builds a map of path -> ID for all existing groups.
+// buildExistingGroupPaths builds a map of escaped-path -> ID for all existing groups.
+// buildParentPath already returns escaped paths, so we only need to escape the group name itself.
 func buildExistingGroupPaths(servers []models.RegisteredServer) map[string]string {
 	paths := make(map[string]string)
 	for _, srv := range servers {
@@ -190,10 +235,11 @@ func buildExistingGroupPaths(servers []models.RegisteredServer) map[string]strin
 			continue
 		}
 		path := buildParentPath(srv.ParentID, servers)
+		escapedName := escapePathSegment(srv.Name)
 		if path == "" {
-			path = srv.Name
+			path = escapedName
 		} else {
-			path = path + "/" + srv.Name
+			path = path + "/" + escapedName
 		}
 		paths[path] = srv.ID
 	}

--- a/internal/servers/import.go
+++ b/internal/servers/import.go
@@ -16,6 +16,35 @@ type ImportResult struct {
 	Warnings []string                  `json:"warnings"`
 }
 
+const maxNameLength = 128
+
+// sanitiseName cleans an entry name: trims whitespace, truncates to maxNameLength,
+// and falls back to "Unnamed-{index}" if empty. Returns the sanitised name and
+// any warning messages produced.
+func sanitiseName(name string, index int) (string, []string) {
+	var warnings []string
+	original := name
+
+	trimmed := strings.TrimSpace(name)
+	trimWarning := trimmed != original
+
+	name = trimmed
+
+	if len(name) > maxNameLength {
+		name = name[:maxNameLength]
+		warnings = append(warnings, fmt.Sprintf("entry at index %d: name truncated to %d characters", index, maxNameLength))
+	}
+
+	if name == "" {
+		name = fmt.Sprintf("Unnamed-%d", index)
+		warnings = append(warnings, fmt.Sprintf("entry at index %d: name was empty, using %q", index, name))
+	} else if trimWarning {
+		warnings = append(warnings, fmt.Sprintf("entry at index %d: name trimmed from %q", index, original))
+	}
+
+	return name, warnings
+}
+
 // ImportServers parses a JSON export file and creates all servers and groups,
 // storing connection configs in the keyring. It returns an ImportResult with the list of created RegisteredServers.
 func (sm *ServerService) ImportServers(data []byte) (*ImportResult, error) {
@@ -29,12 +58,6 @@ func (sm *ServerService) ImportServers(data []byte) (*ImportResult, error) {
 
 	if file.Version != 1 {
 		return nil, fmt.Errorf("unsupported export format version: %d", file.Version)
-	}
-
-	for i, entry := range file.Servers {
-		if strings.TrimSpace(entry.Name) == "" {
-			return nil, fmt.Errorf("server at index %d has an empty name", i)
-		}
 	}
 
 	servers, err := sm.store.LoadServers()
@@ -55,8 +78,13 @@ func (sm *ServerService) ImportServers(data []byte) (*ImportResult, error) {
 	existingServerURIs := sm.buildExistingServerKeys(servers)
 
 	var created []models.RegisteredServer
+	var warnings []string
 
-	for _, entry := range file.Servers {
+	for i, entry := range file.Servers {
+		sanitised, nameWarnings := sanitiseName(entry.Name, i)
+		warnings = append(warnings, nameWarnings...)
+		entry.Name = sanitised
+
 		parentID := ""
 		if entry.Parent != "" {
 			parentID = resolveParentPath(entry.Parent, groupPaths, &servers, &created)
@@ -144,7 +172,7 @@ func (sm *ServerService) ImportServers(data []byte) (*ImportResult, error) {
 		return nil, fmt.Errorf("failed to save servers: %w", err)
 	}
 
-	return &ImportResult{Created: created}, nil
+	return &ImportResult{Created: created, Warnings: warnings}, nil
 }
 
 // splitEscapedPath splits a parent path on unescaped `/` delimiters.

--- a/internal/servers/import.go
+++ b/internal/servers/import.go
@@ -98,7 +98,16 @@ func (sm *ServerService) ImportServers(data []byte) (*ImportResult, error) {
 			}
 
 			// Skip duplicate groups (same name and parent path).
-			if _, exists := groupPaths[path]; exists {
+			if existingID, exists := groupPaths[path]; exists {
+				// Backfill colour if the auto-created group has none
+				if entry.Colour != "" {
+					for j := range servers {
+						if servers[j].ID == existingID && servers[j].Colour == "" {
+							servers[j].Colour = entry.Colour
+							break
+						}
+					}
+				}
 				continue
 			}
 
@@ -114,38 +123,39 @@ func (sm *ServerService) ImportServers(data []byte) (*ImportResult, error) {
 			created = append(created, srv)
 			groupPaths[path] = newID
 		} else {
-			cfg := models.ConnectionConfig{}
-			var isCluster, isSrv bool
-
-			if entry.ConnectionConfig != nil {
-				authMethod := deriveAuthMethod(entry.ConnectionConfig)
-				cfg = models.ConnectionConfig{
-					URI:        entry.ConnectionConfig.URI,
-					AuthMethod: authMethod,
-				}
-
-				if entry.ConnectionConfig.OIDCConfig != nil {
-					cfg.OIDCConfig = &models.OIDCConfig{
-						ProviderURL:      entry.ConnectionConfig.OIDCConfig.ProviderURL,
-						ClientID:         entry.ConnectionConfig.OIDCConfig.ClientID,
-						Scopes:           entry.ConnectionConfig.OIDCConfig.Scopes,
-						WorkloadIdentity: entry.ConnectionConfig.OIDCConfig.WorkloadIdentity,
-					}
-				}
-
-				cs, parseErr := connstring.Parse(entry.ConnectionConfig.URI)
-				if parseErr == nil {
-					isCluster = len(cs.Hosts) > 1
-					isSrv = cs.Scheme == connstring.SchemeMongoDBSRV
-				}
-
-				// Skip duplicate servers (same name, parent, and URI).
-				serverKey := parentID + "\x00" + entry.Name + "\x00" + cfg.URI
-				if existingServerURIs[serverKey] {
-					continue
-				}
-				existingServerURIs[serverKey] = true
+			if entry.ConnectionConfig == nil {
+				warnings = append(warnings, fmt.Sprintf("skipped %q: no connection configuration", entry.Name))
+				continue
 			}
+
+			authMethod := deriveAuthMethod(entry.ConnectionConfig)
+			cfg := models.ConnectionConfig{
+				URI:        entry.ConnectionConfig.URI,
+				AuthMethod: authMethod,
+			}
+
+			if entry.ConnectionConfig.OIDCConfig != nil {
+				cfg.OIDCConfig = &models.OIDCConfig{
+					ProviderURL:      entry.ConnectionConfig.OIDCConfig.ProviderURL,
+					ClientID:         entry.ConnectionConfig.OIDCConfig.ClientID,
+					Scopes:           entry.ConnectionConfig.OIDCConfig.Scopes,
+					WorkloadIdentity: entry.ConnectionConfig.OIDCConfig.WorkloadIdentity,
+				}
+			}
+
+			var isCluster, isSrv bool
+			cs, parseErr := connstring.Parse(entry.ConnectionConfig.URI)
+			if parseErr == nil {
+				isCluster = len(cs.Hosts) > 1
+				isSrv = cs.Scheme == connstring.SchemeMongoDBSRV
+			}
+
+			// Skip duplicate servers (same name, parent, and URI).
+			serverKey := parentID + "\x00" + entry.Name + "\x00" + cfg.URI
+			if existingServerURIs[serverKey] {
+				continue
+			}
+			existingServerURIs[serverKey] = true
 
 			newID := uuid.New().String()
 			srv := models.RegisteredServer{
@@ -157,14 +167,14 @@ func (sm *ServerService) ImportServers(data []byte) (*ImportResult, error) {
 				IsCluster: isCluster,
 				IsSrv:     isSrv,
 			}
+
+			if err := sm.connectionStrings.StoreConnectionConfig(newID, cfg); err != nil {
+				warnings = append(warnings, fmt.Sprintf("skipped %q: failed to store credentials — %v", entry.Name, err))
+				continue
+			}
+
 			servers = append(servers, srv)
 			created = append(created, srv)
-
-			if entry.ConnectionConfig != nil {
-				if err := sm.connectionStrings.StoreConnectionConfig(newID, cfg); err != nil {
-					return nil, fmt.Errorf("failed to store connection config for %q: %w", entry.Name, err)
-				}
-			}
 		}
 	}
 

--- a/internal/servers/import.go
+++ b/internal/servers/import.go
@@ -10,9 +10,15 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 )
 
+// ImportResult holds the outcome of an import operation.
+type ImportResult struct {
+	Created  []models.RegisteredServer `json:"created"`
+	Warnings []string                  `json:"warnings"`
+}
+
 // ImportServers parses a JSON export file and creates all servers and groups,
-// storing connection configs in the keyring. It returns the list of created RegisteredServers.
-func (sm *ServerService) ImportServers(data []byte) ([]models.RegisteredServer, error) {
+// storing connection configs in the keyring. It returns an ImportResult with the list of created RegisteredServers.
+func (sm *ServerService) ImportServers(data []byte) (*ImportResult, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
@@ -137,7 +143,7 @@ func (sm *ServerService) ImportServers(data []byte) ([]models.RegisteredServer, 
 		return nil, fmt.Errorf("failed to save servers: %w", err)
 	}
 
-	return created, nil
+	return &ImportResult{Created: created}, nil
 }
 
 // resolveParentPath takes a slash-delimited path (e.g. "Infra/Databases") and returns

--- a/internal/servers/import_test.go
+++ b/internal/servers/import_test.go
@@ -498,3 +498,102 @@ func TestImportServers_EmptyNameFallback(t *testing.T) {
 	assert.Equal(t, "Unnamed-0", result.Created[0].Name)
 	assert.Len(t, result.Warnings, 1)
 }
+
+func TestImportServers_SkipsMissingConnectionConfig(t *testing.T) {
+	mockStore := &mockServerStore{servers: nil}
+	mockCS := &MockConnectionStringsStore{uris: make(map[string]string)}
+	svc := newTestServerService(mockStore, mockCS)
+
+	data, _ := json.Marshal(exportFile{
+		Version: 1,
+		Servers: []exportServerEntry{
+			{Name: "No Config Server"},
+			{
+				Name: "Has Config",
+				ConnectionConfig: &exportConnectionConfig{
+					URI: "mongodb://localhost:27017", AuthMethod: "none",
+				},
+			},
+		},
+	})
+
+	result, err := svc.ImportServers(data)
+	require.NoError(t, err)
+	assert.Len(t, result.Created, 1)
+	assert.Equal(t, "Has Config", result.Created[0].Name)
+	assert.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "No Config Server")
+	assert.Contains(t, result.Warnings[0], "no connection configuration")
+}
+
+func TestImportServers_ContinuesAfterKeyringFailure(t *testing.T) {
+	mockStore := &mockServerStore{servers: nil}
+	innerCS := &MockConnectionStringsStore{uris: make(map[string]string)}
+	countingMock := &countingConnectionStringsStore{
+		inner:      innerCS,
+		failAtCall: 0, // fail the first StoreConnectionConfig call
+	}
+	svc := newTestServerService(mockStore, countingMock)
+
+	data, _ := json.Marshal(exportFile{
+		Version: 1,
+		Servers: []exportServerEntry{
+			{
+				Name: "Server A",
+				ConnectionConfig: &exportConnectionConfig{
+					URI: "mongodb://a:27017", AuthMethod: "none",
+				},
+			},
+			{
+				Name: "Server B",
+				ConnectionConfig: &exportConnectionConfig{
+					URI: "mongodb://b:27017", AuthMethod: "none",
+				},
+			},
+		},
+	})
+
+	result, err := svc.ImportServers(data)
+	require.NoError(t, err)
+	assert.Len(t, result.Created, 1)
+	assert.Equal(t, "Server B", result.Created[0].Name)
+	assert.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "Server A")
+	assert.Contains(t, result.Warnings[0], "failed to store credentials")
+}
+
+func TestImportServers_OutOfOrderGroupGetsColour(t *testing.T) {
+	mockStore := &mockServerStore{servers: nil}
+	mockCS := &MockConnectionStringsStore{uris: make(map[string]string)}
+	svc := newTestServerService(mockStore, mockCS)
+
+	// Server references "Infra" before the group entry appears
+	data, _ := json.Marshal(exportFile{
+		Version: 1,
+		Servers: []exportServerEntry{
+			{
+				Name:   "My Server",
+				Parent: "Infra",
+				ConnectionConfig: &exportConnectionConfig{
+					URI: "mongodb://localhost:27017", AuthMethod: "none",
+				},
+			},
+			{Name: "Infra", IsGroup: true, Colour: "#00ff00"},
+		},
+	})
+
+	result, err := svc.ImportServers(data)
+	require.NoError(t, err)
+
+	// Find the Infra group in the saved servers
+	var infraGroup *models.RegisteredServer
+	for i := range mockStore.servers {
+		if mockStore.servers[i].Name == "Infra" && mockStore.servers[i].IsGroup {
+			infraGroup = &mockStore.servers[i]
+			break
+		}
+	}
+	require.NotNil(t, infraGroup)
+	assert.Equal(t, "#00ff00", infraGroup.Colour, "auto-created group should get colour from explicit entry")
+	assert.Len(t, result.Created, 2)
+}

--- a/internal/servers/import_test.go
+++ b/internal/servers/import_test.go
@@ -351,3 +351,74 @@ func TestImportServers_DifferentURINotDuplicate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, result.Created, 1) // different URI, not a duplicate
 }
+
+func TestImportServers_SlashInGroupName(t *testing.T) {
+	mockStore := &mockServerStore{servers: nil}
+	mockCS := &MockConnectionStringsStore{uris: make(map[string]string)}
+	svc := newTestServerService(mockStore, mockCS)
+
+	data, _ := json.Marshal(exportFile{
+		Version: 1,
+		Servers: []exportServerEntry{
+			{Name: "Dev/Test", IsGroup: true},
+			{
+				Name:   "My Server",
+				Parent: `Dev\/Test`,
+				ConnectionConfig: &exportConnectionConfig{
+					URI:        "mongodb://localhost:27017",
+					AuthMethod: "none",
+				},
+			},
+		},
+	})
+
+	result, err := svc.ImportServers(data)
+
+	require.NoError(t, err)
+	assert.Len(t, result.Created, 2)
+
+	byName := make(map[string]*models.RegisteredServer)
+	for i := range result.Created {
+		byName[result.Created[i].Name] = &result.Created[i]
+	}
+	group := byName["Dev/Test"]
+	server := byName["My Server"]
+	require.NotNil(t, group)
+	require.NotNil(t, server)
+	assert.True(t, group.IsGroup)
+	assert.Equal(t, group.ID, server.ParentID)
+}
+
+func TestImportServers_BackslashInGroupName(t *testing.T) {
+	mockStore := &mockServerStore{servers: nil}
+	mockCS := &MockConnectionStringsStore{uris: make(map[string]string)}
+	svc := newTestServerService(mockStore, mockCS)
+
+	data, _ := json.Marshal(exportFile{
+		Version: 1,
+		Servers: []exportServerEntry{
+			{Name: `Path\Group`, IsGroup: true},
+			{
+				Name:   "My Server",
+				Parent: `Path\\Group`,
+				ConnectionConfig: &exportConnectionConfig{
+					URI:        "mongodb://localhost:27017",
+					AuthMethod: "none",
+				},
+			},
+		},
+	})
+
+	result, err := svc.ImportServers(data)
+
+	require.NoError(t, err)
+	assert.Len(t, result.Created, 2)
+
+	byName := make(map[string]*models.RegisteredServer)
+	for i := range result.Created {
+		byName[result.Created[i].Name] = &result.Created[i]
+	}
+	require.NotNil(t, byName[`Path\Group`])
+	require.NotNil(t, byName["My Server"])
+	assert.Equal(t, byName[`Path\Group`].ID, byName["My Server"].ParentID)
+}

--- a/internal/servers/import_test.go
+++ b/internal/servers/import_test.go
@@ -597,3 +597,53 @@ func TestImportServers_OutOfOrderGroupGetsColour(t *testing.T) {
 	assert.Equal(t, "#00ff00", infraGroup.Colour, "auto-created group should get colour from explicit entry")
 	assert.Len(t, result.Created, 2)
 }
+
+func TestImportServers_FullIntegration(t *testing.T) {
+	mockStore := &mockServerStore{servers: nil}
+	innerCS := &MockConnectionStringsStore{uris: make(map[string]string)}
+	// Fail the first StoreConnectionConfig call (the long-named server)
+	mockCS := &countingConnectionStringsStore{
+		inner:      innerCS,
+		failAtCall: 0,
+	}
+	svc := newTestServerService(mockStore, mockCS)
+
+	longName := strings.Repeat("x", 200)
+	data, _ := json.Marshal(exportFile{
+		Version: 1,
+		Servers: []exportServerEntry{
+			{Name: "  Production  ", IsGroup: true, Colour: "#ff0000"},
+			{
+				Name:   longName,
+				Parent: "Production",
+				ConnectionConfig: &exportConnectionConfig{
+					URI: "mongodb://a:27017", AuthMethod: "none",
+				},
+			},
+			{
+				Name:   "Server B",
+				Parent: "Production",
+				ConnectionConfig: &exportConnectionConfig{
+					URI: "mongodb://b:27017", AuthMethod: "none",
+				},
+			},
+			{Name: "No Config Server"},
+		},
+	})
+
+	result, err := svc.ImportServers(data)
+	require.NoError(t, err)
+
+	// Production group + Server B should be created (longName fails keyring, No Config skipped)
+	assert.Len(t, result.Created, 2)
+
+	names := make([]string, len(result.Created))
+	for i, c := range result.Created {
+		names[i] = c.Name
+	}
+	assert.Contains(t, names, "Production")  // trimmed
+	assert.Contains(t, names, "Server B")    // succeeded
+
+	// Warnings: trim, truncate+keyring fail, no config
+	assert.GreaterOrEqual(t, len(result.Warnings), 3)
+}

--- a/internal/servers/import_test.go
+++ b/internal/servers/import_test.go
@@ -28,14 +28,14 @@ func TestImportServers_BasicImport(t *testing.T) {
 		},
 	})
 
-	created, err := svc.ImportServers(data)
+	result, err := svc.ImportServers(data)
 
 	require.NoError(t, err)
-	assert.Len(t, created, 1)
-	assert.Equal(t, "My Server", created[0].Name)
-	assert.Equal(t, "#ff0000", created[0].Colour)
-	assert.NotEmpty(t, created[0].ID)
-	assert.False(t, created[0].IsGroup)
+	assert.Len(t, result.Created, 1)
+	assert.Equal(t, "My Server", result.Created[0].Name)
+	assert.Equal(t, "#ff0000", result.Created[0].Colour)
+	assert.NotEmpty(t, result.Created[0].ID)
+	assert.False(t, result.Created[0].IsGroup)
 }
 
 func TestImportServers_GroupHierarchy(t *testing.T) {
@@ -61,13 +61,13 @@ func TestImportServers_GroupHierarchy(t *testing.T) {
 		},
 	})
 
-	created, err := svc.ImportServers(data)
+	result, err := svc.ImportServers(data)
 
 	require.NoError(t, err)
-	assert.Len(t, created, 2)
+	assert.Len(t, result.Created, 2)
 
-	group := created[0]
-	server := created[1]
+	group := result.Created[0]
+	server := result.Created[1]
 	assert.True(t, group.IsGroup)
 	assert.Equal(t, "Infra", group.Name)
 	assert.Equal(t, group.ID, server.ParentID)
@@ -92,15 +92,15 @@ func TestImportServers_AutoCreateMissingGroups(t *testing.T) {
 		},
 	})
 
-	created, err := svc.ImportServers(data)
+	result, err := svc.ImportServers(data)
 
 	require.NoError(t, err)
-	assert.Len(t, created, 3) // Infra, Databases, My Server
+	assert.Len(t, result.Created, 3) // Infra, Databases, My Server
 
 	// Find the groups and server
 	byName := make(map[string]*models.RegisteredServer)
-	for i := range created {
-		byName[created[i].Name] = &created[i]
+	for i := range result.Created {
+		byName[result.Created[i].Name] = &result.Created[i]
 	}
 	infra := byName["Infra"]
 	databases := byName["Databases"]
@@ -185,10 +185,10 @@ func TestImportServers_DeriveAuthMethod(t *testing.T) {
 		},
 	})
 
-	created, err := svc.ImportServers(data)
+	result, err := svc.ImportServers(data)
 
 	require.NoError(t, err)
-	assert.Len(t, created, 1)
+	assert.Len(t, result.Created, 1)
 	// The connection config should have been stored - verify via the mock
 	assert.Len(t, mockCS.uris, 1)
 }
@@ -219,12 +219,12 @@ func TestImportServers_NoColourVariants(t *testing.T) {
 		},
 	})
 
-	created, err := svc.ImportServers(data)
+	result, err := svc.ImportServers(data)
 
 	require.NoError(t, err)
-	assert.Len(t, created, 2)
-	assert.Equal(t, "", created[0].Colour)
-	assert.Equal(t, "", created[1].Colour)
+	assert.Len(t, result.Created, 2)
+	assert.Equal(t, "", result.Created[0].Colour)
+	assert.Equal(t, "", result.Created[1].Colour)
 }
 
 func TestImportServers_StoresConnectionConfig(t *testing.T) {
@@ -245,13 +245,13 @@ func TestImportServers_StoresConnectionConfig(t *testing.T) {
 		},
 	})
 
-	created, err := svc.ImportServers(data)
+	result, err := svc.ImportServers(data)
 
 	require.NoError(t, err)
-	assert.Len(t, created, 1)
+	assert.Len(t, result.Created, 1)
 
 	// Verify the connection config was stored in the keyring mock
-	storedURI, ok := mockCS.uris[created[0].ID]
+	storedURI, ok := mockCS.uris[result.Created[0].ID]
 	assert.True(t, ok)
 	assert.Equal(t, "mongodb://localhost:27017", storedURI)
 }
@@ -277,9 +277,9 @@ func TestImportServers_SkipDuplicateServer(t *testing.T) {
 		},
 	})
 
-	created, err := svc.ImportServers(data)
+	result, err := svc.ImportServers(data)
 	require.NoError(t, err)
-	assert.Len(t, created, 0) // duplicate skipped
+	assert.Len(t, result.Created, 0) // duplicate skipped
 }
 
 func TestImportServers_SkipDuplicateGroup(t *testing.T) {
@@ -298,9 +298,9 @@ func TestImportServers_SkipDuplicateGroup(t *testing.T) {
 		},
 	})
 
-	created, err := svc.ImportServers(data)
+	result, err := svc.ImportServers(data)
 	require.NoError(t, err)
-	assert.Len(t, created, 0) // duplicate skipped
+	assert.Len(t, result.Created, 0) // duplicate skipped
 }
 
 func TestImportServers_DuplicateGroupChildrenLinkToExisting(t *testing.T) {
@@ -320,10 +320,10 @@ func TestImportServers_DuplicateGroupChildrenLinkToExisting(t *testing.T) {
 		},
 	})
 
-	created, err := svc.ImportServers(data)
+	result, err := svc.ImportServers(data)
 	require.NoError(t, err)
-	assert.Len(t, created, 1) // only the server, not the duplicate group
-	assert.Equal(t, "existing-g1", created[0].ParentID) // linked to existing group
+	assert.Len(t, result.Created, 1) // only the server, not the duplicate group
+	assert.Equal(t, "existing-g1", result.Created[0].ParentID) // linked to existing group
 }
 
 func TestImportServers_DifferentURINotDuplicate(t *testing.T) {
@@ -347,7 +347,7 @@ func TestImportServers_DifferentURINotDuplicate(t *testing.T) {
 		},
 	})
 
-	created, err := svc.ImportServers(data)
+	result, err := svc.ImportServers(data)
 	require.NoError(t, err)
-	assert.Len(t, created, 1) // different URI, not a duplicate
+	assert.Len(t, result.Created, 1) // different URI, not a duplicate
 }

--- a/internal/servers/import_test.go
+++ b/internal/servers/import_test.go
@@ -2,6 +2,7 @@ package servers
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"vervet/internal/models"
 
@@ -161,11 +162,11 @@ func TestImportServers_MissingName(t *testing.T) {
 		},
 	})
 
-	_, err := svc.ImportServers(data)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "index 0")
-	assert.Contains(t, err.Error(), "name")
+	result, err := svc.ImportServers(data)
+	require.NoError(t, err)
+	assert.Len(t, result.Created, 1)
+	assert.Equal(t, "Unnamed-0", result.Created[0].Name)
+	assert.Len(t, result.Warnings, 1)
 }
 
 func TestImportServers_DeriveAuthMethod(t *testing.T) {
@@ -421,4 +422,79 @@ func TestImportServers_BackslashInGroupName(t *testing.T) {
 	require.NotNil(t, byName[`Path\Group`])
 	require.NotNil(t, byName["My Server"])
 	assert.Equal(t, byName[`Path\Group`].ID, byName["My Server"].ParentID)
+}
+
+func TestImportServers_SanitisesWhitespace(t *testing.T) {
+	mockStore := &mockServerStore{servers: nil}
+	mockCS := &MockConnectionStringsStore{uris: make(map[string]string)}
+	svc := newTestServerService(mockStore, mockCS)
+
+	data, _ := json.Marshal(exportFile{
+		Version: 1,
+		Servers: []exportServerEntry{
+			{
+				Name: "  My Server  ",
+				ConnectionConfig: &exportConnectionConfig{
+					URI: "mongodb://localhost:27017", AuthMethod: "none",
+				},
+			},
+		},
+	})
+
+	result, err := svc.ImportServers(data)
+	require.NoError(t, err)
+	assert.Len(t, result.Created, 1)
+	assert.Equal(t, "My Server", result.Created[0].Name)
+	assert.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "trimmed")
+}
+
+func TestImportServers_TruncatesLongName(t *testing.T) {
+	mockStore := &mockServerStore{servers: nil}
+	mockCS := &MockConnectionStringsStore{uris: make(map[string]string)}
+	svc := newTestServerService(mockStore, mockCS)
+
+	longName := strings.Repeat("a", 200)
+	data, _ := json.Marshal(exportFile{
+		Version: 1,
+		Servers: []exportServerEntry{
+			{
+				Name: longName,
+				ConnectionConfig: &exportConnectionConfig{
+					URI: "mongodb://localhost:27017", AuthMethod: "none",
+				},
+			},
+		},
+	})
+
+	result, err := svc.ImportServers(data)
+	require.NoError(t, err)
+	assert.Len(t, result.Created, 1)
+	assert.Len(t, result.Created[0].Name, 128)
+	assert.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "truncated")
+}
+
+func TestImportServers_EmptyNameFallback(t *testing.T) {
+	mockStore := &mockServerStore{servers: nil}
+	mockCS := &MockConnectionStringsStore{uris: make(map[string]string)}
+	svc := newTestServerService(mockStore, mockCS)
+
+	data, _ := json.Marshal(exportFile{
+		Version: 1,
+		Servers: []exportServerEntry{
+			{
+				Name: "   ",
+				ConnectionConfig: &exportConnectionConfig{
+					URI: "mongodb://localhost:27017", AuthMethod: "none",
+				},
+			},
+		},
+	})
+
+	result, err := svc.ImportServers(data)
+	require.NoError(t, err)
+	assert.Len(t, result.Created, 1)
+	assert.Equal(t, "Unnamed-0", result.Created[0].Name)
+	assert.Len(t, result.Warnings, 1)
 }

--- a/internal/servers/service_test.go
+++ b/internal/servers/service_test.go
@@ -268,6 +268,42 @@ func TestUpdateServer_KeyringFailureDoesNotPersistMetadata(t *testing.T) {
 	})
 }
 
+// countingConnectionStringsStore fails StoreConnectionConfig at a specific call index.
+type countingConnectionStringsStore struct {
+	inner      connectionStrings.Store
+	failAtCall int
+	callCount  int
+}
+
+func (m *countingConnectionStringsStore) StoreConnectionConfig(id string, cfg models.ConnectionConfig) error {
+	idx := m.callCount
+	m.callCount++
+	if idx == m.failAtCall {
+		return errors.New("simulated keyring failure")
+	}
+	return m.inner.StoreConnectionConfig(id, cfg)
+}
+
+func (m *countingConnectionStringsStore) StoreRegisteredServerURI(id, uri string) error {
+	return m.inner.StoreRegisteredServerURI(id, uri)
+}
+
+func (m *countingConnectionStringsStore) GetRegisteredServerURI(id string) (string, error) {
+	return m.inner.GetRegisteredServerURI(id)
+}
+
+func (m *countingConnectionStringsStore) DeleteRegisteredServerURI(id string) error {
+	return m.inner.DeleteRegisteredServerURI(id)
+}
+
+func (m *countingConnectionStringsStore) GetConnectionConfig(id string) (models.ConnectionConfig, error) {
+	return m.inner.GetConnectionConfig(id)
+}
+
+func (m *countingConnectionStringsStore) UpdateRefreshToken(id string, refreshToken string) error {
+	return m.inner.UpdateRefreshToken(id, refreshToken)
+}
+
 func TestGetURI(t *testing.T) {
 	t.Run("successful get uri", func(t *testing.T) {
 		mockCSStore := &MockConnectionStringsStore{


### PR DESCRIPTION
## Summary

- **Escaped parent paths:** Group names containing `/` or `\` no longer corrupt the parent path hierarchy during export/import — uses escape format (`\/`, `\\`)
- **Best-effort import:** Keyring write failures and missing connection configs skip the affected entry with a warning instead of aborting the entire import
- **Name sanitisation:** Entry names are trimmed, truncated to 128 chars, and given fallback names if empty
- **Group colour backfill:** Auto-created intermediate groups pick up colour from later explicit entries
- **Fsync after YAML write:** Ensures data reaches disk before returning, preventing stale reads on Windows
- **Frontend warnings:** Import warnings are surfaced to the user via notification after import

## Test Plan

- [x] All Go tests pass (`go test ./internal/...`)
- [x] All frontend tests pass (245 Vitest tests)
- [x] Integration test covers combined sanitisation + keyring failure + missing config scenario
- [x] Round-trip test with `/` in group names verifies export→import preserves names
- [x] Manual test: import a file with a server missing `connectionConfig` — should skip with warning
- [x] Manual test: import a file with whitespace-padded names — should trim and warn