### PR TITLE
fixes #128 - support db.runCommand() and db.adminCommand()

### DIFF
--- a/frontend/src/features/completion/completionData.ts
+++ b/frontend/src/features/completion/completionData.ts
@@ -308,3 +308,26 @@ export const updateOperators = [
   // bitwise
   { label: '$bit', detail: 'Performs bitwise AND, OR and XOR updates of integer values' },
 ]
+
+export const dbMethods = [
+  {
+    label: 'runCommand',
+    detail: '(command) - Run a database command',
+    snippet: 'runCommand({$1})$0',
+  },
+  {
+    label: 'adminCommand',
+    detail: '(command) - Run an admin database command',
+    snippet: 'adminCommand({$1})$0',
+  },
+  {
+    label: 'getName',
+    detail: '() - Returns the current database name',
+    snippet: 'getName()$0',
+  },
+  {
+    label: 'getCollection',
+    detail: '(name) - Returns a collection object',
+    snippet: "getCollection('$1')$0",
+  },
+]

--- a/frontend/src/features/completion/useMonacoCompletions.ts
+++ b/frontend/src/features/completion/useMonacoCompletions.ts
@@ -7,6 +7,7 @@ import {
   aggStages,
   updateOperators,
   aggExpressions,
+  dbMethods,
 } from './completionData'
 import { getCollectionSchema, getCollectionNames, getDatabaseNames } from './useSchemaCache'
 import { useTabStore } from '@/features/tabs/tabs'
@@ -162,11 +163,23 @@ async function getSuggestions(
 
   switch (ctx.type) {
     case 'COLLECTION_NAME': {
+      // db-level methods (runCommand, adminCommand, getName, getCollection)
+      const dbMethodItems: monaco.languages.CompletionItem[] = dbMethods
+        .filter((m) => m.label.startsWith(ctx.prefix))
+        .map((m) => ({
+          label: m.label,
+          kind: monaco.languages.CompletionItemKind.Method,
+          detail: m.detail,
+          insertText: m.snippet,
+          insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+          range,
+        }))
+
       if (!serverId || !dbName) {
-        return []
+        return dbMethodItems
       }
       const names = await getCollectionNames(serverId, dbName)
-      return names
+      const collectionItems = names
         .filter((n) => n.startsWith(ctx.prefix))
         .map((name) => ({
           label: name,
@@ -174,6 +187,7 @@ async function getSuggestions(
           insertText: name,
           range,
         }))
+      return [...dbMethodItems, ...collectionItems]
     }
 
     case 'COLLECTION_NAME_STRING': {

--- a/internal/queryengine/bson_integration_test.go
+++ b/internal/queryengine/bson_integration_test.go
@@ -28,6 +28,11 @@ var (
 func TestMain(m *testing.M) {
 	ctx := context.Background()
 
+	// Disable the Ryuk reaper container — it fails under rootless Podman
+	// because it needs Docker-socket-level access. Cleanup is handled by
+	// defer calls in tests and the TerminateContainer below.
+	os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+
 	mongoContainer, err := mongodb.Run(ctx, "mongo:7")
 	if err != nil {
 		log.Fatalf("failed to start MongoDB container: %v", err)

--- a/internal/queryengine/db_commands_integration_test.go
+++ b/internal/queryengine/db_commands_integration_test.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+package queryengine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_RunCommand_Ping(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.runCommand({ ping: 1 })`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "ok")
+}
+
+func TestIntegration_RunCommand_CollStats(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	// Create a collection first
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertOne({ x: 1 })`)
+	require.NoError(t, err)
+
+	// Run collStats
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.runCommand({ collStats: "test" })`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "ns")
+}
+
+func TestIntegration_AdminCommand_ListDatabases(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.adminCommand({ listDatabases: 1 })`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "databases")
+}
+
+func TestIntegration_RunCommand_InvalidCommand_Errors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.runCommand({ notARealCommand: 1 })`)
+	assert.Error(t, err)
+}

--- a/internal/queryengine/goja_engine_test.go
+++ b/internal/queryengine/goja_engine_test.go
@@ -146,6 +146,32 @@ func TestPrint_CapturesOutput(t *testing.T) {
 	assert.Equal(t, "hello", printed[0])
 }
 
+func TestDatabaseProxy_RunCommand_IsFunction(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	val, err := rt.RunString(`typeof db.runCommand`)
+	require.NoError(t, err)
+	assert.Equal(t, "function", val.Export())
+}
+
+func TestDatabaseProxy_AdminCommand_IsFunction(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	val, err := rt.RunString(`typeof db.adminCommand`)
+	require.NoError(t, err)
+	assert.Equal(t, "function", val.Export())
+}
+
+func TestDatabaseProxy_RunCommand_PanicsWithoutClient(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	_, err := rt.RunString(`db.runCommand({ ping: 1 })`)
+	assert.Error(t, err, "runCommand with nil client should error")
+}
+
+func TestDatabaseProxy_RunCommand_PanicsWithoutArgs(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	_, err := rt.RunString(`db.runCommand()`)
+	assert.Error(t, err, "runCommand without args should error")
+}
+
 func TestMultiStatement_VariableThenCursor(t *testing.T) {
 	rt, _ := setupRuntime(t)
 	val, err := rt.RunString(`const filter = { status: "active" }; db.users.find(filter)`)

--- a/internal/queryengine/proxy_db.go
+++ b/internal/queryengine/proxy_db.go
@@ -1,24 +1,58 @@
 package queryengine
 
-import "github.com/dop251/goja"
+import (
+	"fmt"
+
+	"github.com/dop251/goja"
+	"go.mongodb.org/mongo-driver/bson"
+)
 
 // newDatabaseProxy creates a Goja Proxy object that intercepts property access.
 // Accessing db.someCollection returns a collection proxy for "someCollection".
-// Accessing db.getName returns a function that returns the database name.
+// Known db-level methods (getName, getCollection, runCommand, adminCommand)
+// are intercepted and return Go-backed functions.
 func newDatabaseProxy(ec *execContext) goja.Value {
 	proxy := ec.rt.NewProxy(ec.rt.NewObject(), &goja.ProxyTrapConfig{
 		Get: func(target *goja.Object, property string, receiver goja.Value) (value goja.Value) {
-			if property == "getName" {
+			switch property {
+			case "getName":
 				return ec.rt.ToValue(func() string { return ec.dbName })
-			}
-			if property == "getCollection" {
+			case "getCollection":
 				return ec.rt.ToValue(func(name string) goja.Value {
 					return newCollectionProxy(ec, name)
 				})
+			case "runCommand":
+				return ec.rt.ToValue(dbRunCommand(ec, ec.dbName))
+			case "adminCommand":
+				return ec.rt.ToValue(dbRunCommand(ec, "admin"))
 			}
 			return newCollectionProxy(ec, property)
 		},
 	})
 
 	return ec.rt.ToValue(proxy)
+}
+
+// dbRunCommand returns a Goja-callable function that executes a command document
+// against the specified database via client.Database(dbName).RunCommand().
+func dbRunCommand(ec *execContext, dbName string) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		if ec.client == nil {
+			panic(ec.rt.NewGoError(fmt.Errorf("no MongoDB client available")))
+		}
+		if len(call.Arguments) == 0 {
+			panic(ec.rt.NewGoError(fmt.Errorf("runCommand requires a command document")))
+		}
+
+		cmdRaw := exportValue(call.Arguments[0])
+		cmdDoc := convertToBson(cmdRaw)
+
+		var result bson.M
+		err := ec.client.Database(dbName).RunCommand(ec.ctx, cmdDoc).Decode(&result)
+		if err != nil {
+			panic(ec.rt.NewGoError(fmt.Errorf("runCommand: %w", err)))
+		}
+
+		return ec.rt.ToValue(result)
+	}
 }


### PR DESCRIPTION
## Summary

- Add `db.runCommand({...})` and `db.adminCommand({...})` to the Goja query engine
- `runCommand` executes against the current database, `adminCommand` against the `admin` database
- Add db-level method autocomplete — `runCommand`, `adminCommand`, `getName`, `getCollection` now appear when typing `db.`

This is the highest-impact missing feature since it serves as an escape hatch for any MongoDB command the UI doesn't explicitly support (e.g. `db.runCommand({collStats: "mycoll"})`, `db.adminCommand({listDatabases: 1})`).

## Changes

- `internal/queryengine/proxy_db.go` — expanded db proxy `Get` trap with `runCommand`/`adminCommand` intercepts and `dbRunCommand` helper
- `internal/queryengine/goja_engine_test.go` — unit tests for proxy intercepts
- `internal/queryengine/db_commands_integration_test.go` — new integration test file for ping, collStats, listDatabases, and invalid command error handling
- `frontend/src/features/completion/completionData.ts` — new `dbMethods` export
- `frontend/src/features/completion/useMonacoCompletions.ts` — wire db methods into `COLLECTION_NAME` completions

## Test plan

- [x] `go test ./...` — all pass
- [x] `bun run test` — 245 tests pass
- [x] `bun run lint` — clean
- [x] `go test -tags integration ./internal/queryengine/...` — integration tests (requires Docker)