### PR TITLE
fixes #129 - core database methods

### DIFF
--- a/frontend/src/features/completion/completionData.ts
+++ b/frontend/src/features/completion/completionData.ts
@@ -330,4 +330,49 @@ export const dbMethods = [
     detail: '(name) - Returns a collection object',
     snippet: "getCollection('$1')$0",
   },
+  {
+    label: 'getCollectionNames',
+    detail: '(filter?) - List collection names in the database',
+    snippet: 'getCollectionNames()$0',
+  },
+  {
+    label: 'getCollectionInfos',
+    detail: '(filter?) - List collection info objects',
+    snippet: 'getCollectionInfos()$0',
+  },
+  {
+    label: 'createCollection',
+    detail: '(name) - Create a new collection',
+    snippet: "createCollection('$1')$0",
+  },
+  {
+    label: 'dropDatabase',
+    detail: '() - Drop the current database',
+    snippet: 'dropDatabase()$0',
+  },
+  {
+    label: 'stats',
+    detail: '() - Database statistics',
+    snippet: 'stats()$0',
+  },
+  {
+    label: 'version',
+    detail: '() - MongoDB server version',
+    snippet: 'version()$0',
+  },
+  {
+    label: 'getSiblingDB',
+    detail: '(name) - Switch to another database',
+    snippet: "getSiblingDB('$1')$0",
+  },
+  {
+    label: 'getMongo',
+    detail: '() - Returns the connection object',
+    snippet: 'getMongo()$0',
+  },
+  {
+    label: 'aggregate',
+    detail: '(pipeline) - Run a database-level aggregation',
+    snippet: 'aggregate([$1])$0',
+  },
 ]

--- a/internal/queryengine/db_commands_integration_test.go
+++ b/internal/queryengine/db_commands_integration_test.go
@@ -67,3 +67,146 @@ func TestIntegration_RunCommand_InvalidCommand_Errors(t *testing.T) {
 	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.runCommand({ notARealCommand: 1 })`)
 	assert.Error(t, err)
 }
+
+// --- Core database methods ---
+
+func TestIntegration_GetCollectionNames(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	// Create two collections
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.alpha.insertOne({ x: 1 })`)
+	require.NoError(t, err)
+	_, err = engine.ExecuteQuery(ctx, testURI, db, `db.beta.insertOne({ x: 1 })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getCollectionNames()`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "alpha")
+	assert.Contains(t, result.RawOutput, "beta")
+}
+
+func TestIntegration_GetCollectionInfos(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.infocoll.insertOne({ x: 1 })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getCollectionInfos()`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "infocoll")
+}
+
+func TestIntegration_CreateCollection(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.createCollection("newcoll")`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "ok")
+
+	// Verify collection exists
+	names, err := testClient.Database(db).ListCollectionNames(ctx, map[string]any{})
+	require.NoError(t, err)
+	assert.Contains(t, names, "newcoll")
+}
+
+func TestIntegration_DropDatabase(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+
+	engine := NewGojaEngine(testClient)
+	// Create something so the db exists
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.temp.insertOne({ x: 1 })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.dropDatabase()`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "ok")
+}
+
+func TestIntegration_Stats(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.statscoll.insertOne({ x: 1 })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.stats()`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "collections")
+}
+
+func TestIntegration_Version(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.version()`)
+	require.NoError(t, err)
+	// Should return a version string like "7.0.x"
+	assert.NotEmpty(t, result.RawOutput)
+	assert.Contains(t, result.RawOutput, ".")
+}
+
+func TestIntegration_GetSiblingDB(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	siblingDB := db + "_sibling"
+	defer testClient.Database(db).Drop(ctx)
+	defer testClient.Database(siblingDB).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	// Insert into sibling database via getSiblingDB
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.getSiblingDB("`+siblingDB+`").crossdb.insertOne({ from: "sibling" })`)
+	require.NoError(t, err)
+
+	// Verify document exists in sibling database
+	var doc map[string]any
+	err = testClient.Database(siblingDB).Collection("crossdb").FindOne(ctx, map[string]any{}).Decode(&doc)
+	require.NoError(t, err)
+	assert.Equal(t, "sibling", doc["from"])
+}
+
+func TestIntegration_Aggregate_DbLevel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	// db.aggregate with $listLocalSessions or similar db-level pipeline
+	// Use $currentOp-style approach: create data then use $documents (MongoDB 5.1+)
+	// Simpler: just test that it runs and returns something
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.aggregate([{ $listLocalSessions: {} }])`)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}

--- a/internal/queryengine/goja_engine_test.go
+++ b/internal/queryengine/goja_engine_test.go
@@ -172,6 +172,50 @@ func TestDatabaseProxy_RunCommand_PanicsWithoutArgs(t *testing.T) {
 	assert.Error(t, err, "runCommand without args should error")
 }
 
+func TestDatabaseProxy_CoreMethods_AreFunctions(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	methods := []string{
+		"getCollectionNames", "getCollectionInfos", "createCollection",
+		"dropDatabase", "stats", "version", "getSiblingDB", "getMongo", "aggregate",
+	}
+	for _, m := range methods {
+		val, err := rt.RunString(`typeof db.` + m)
+		require.NoError(t, err, "method %s", m)
+		assert.Equal(t, "function", val.Export(), "db.%s should be a function", m)
+	}
+}
+
+func TestDatabaseProxy_GetSiblingDB_ReturnsDifferentDb(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	val, err := rt.RunString(`db.getSiblingDB("other").getName()`)
+	require.NoError(t, err)
+	assert.Equal(t, "other", val.Export())
+}
+
+func TestDatabaseProxy_GetMongo_HasGetDB(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	val, err := rt.RunString(`db.getMongo().getDB("another").getName()`)
+	require.NoError(t, err)
+	assert.Equal(t, "another", val.Export())
+}
+
+func TestDatabaseProxy_CoreMethods_PanicWithoutClient(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	methods := []string{
+		`db.getCollectionNames()`,
+		`db.getCollectionInfos()`,
+		`db.createCollection("test")`,
+		`db.dropDatabase()`,
+		`db.stats()`,
+		`db.version()`,
+		`db.aggregate([])`,
+	}
+	for _, m := range methods {
+		_, err := rt.RunString(m)
+		assert.Error(t, err, "%s with nil client should error", m)
+	}
+}
+
 func TestMultiStatement_VariableThenCursor(t *testing.T) {
 	rt, _ := setupRuntime(t)
 	val, err := rt.RunString(`const filter = { status: "active" }; db.users.find(filter)`)

--- a/internal/queryengine/proxy_db.go
+++ b/internal/queryengine/proxy_db.go
@@ -7,10 +7,27 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+// dbMethodNames lists all intercepted db-level method names so the proxy
+// can distinguish them from collection name access.
+var dbMethodNames = map[string]bool{
+	"getName":            true,
+	"getCollection":      true,
+	"runCommand":         true,
+	"adminCommand":       true,
+	"getCollectionNames": true,
+	"getCollectionInfos": true,
+	"createCollection":   true,
+	"dropDatabase":       true,
+	"stats":              true,
+	"version":            true,
+	"getSiblingDB":       true,
+	"getMongo":           true,
+	"aggregate":          true,
+}
+
 // newDatabaseProxy creates a Goja Proxy object that intercepts property access.
 // Accessing db.someCollection returns a collection proxy for "someCollection".
-// Known db-level methods (getName, getCollection, runCommand, adminCommand)
-// are intercepted and return Go-backed functions.
+// Known db-level methods are intercepted and return Go-backed functions.
 func newDatabaseProxy(ec *execContext) goja.Value {
 	proxy := ec.rt.NewProxy(ec.rt.NewObject(), &goja.ProxyTrapConfig{
 		Get: func(target *goja.Object, property string, receiver goja.Value) (value goja.Value) {
@@ -25,6 +42,24 @@ func newDatabaseProxy(ec *execContext) goja.Value {
 				return ec.rt.ToValue(dbRunCommand(ec, ec.dbName))
 			case "adminCommand":
 				return ec.rt.ToValue(dbRunCommand(ec, "admin"))
+			case "getCollectionNames":
+				return ec.rt.ToValue(dbGetCollectionNames(ec))
+			case "getCollectionInfos":
+				return ec.rt.ToValue(dbGetCollectionInfos(ec))
+			case "createCollection":
+				return ec.rt.ToValue(dbCreateCollection(ec))
+			case "dropDatabase":
+				return ec.rt.ToValue(dbDropDatabase(ec))
+			case "stats":
+				return ec.rt.ToValue(dbStats(ec))
+			case "version":
+				return ec.rt.ToValue(dbVersion(ec))
+			case "getSiblingDB":
+				return ec.rt.ToValue(dbGetSiblingDB(ec))
+			case "getMongo":
+				return ec.rt.ToValue(dbGetMongo(ec))
+			case "aggregate":
+				return ec.rt.ToValue(dbAggregate(ec))
 			}
 			return newCollectionProxy(ec, property)
 		},
@@ -33,13 +68,17 @@ func newDatabaseProxy(ec *execContext) goja.Value {
 	return ec.rt.ToValue(proxy)
 }
 
+func requireClient(ec *execContext) {
+	if ec.client == nil {
+		panic(ec.rt.NewGoError(fmt.Errorf("no MongoDB client available")))
+	}
+}
+
 // dbRunCommand returns a Goja-callable function that executes a command document
 // against the specified database via client.Database(dbName).RunCommand().
 func dbRunCommand(ec *execContext, dbName string) func(goja.FunctionCall) goja.Value {
 	return func(call goja.FunctionCall) goja.Value {
-		if ec.client == nil {
-			panic(ec.rt.NewGoError(fmt.Errorf("no MongoDB client available")))
-		}
+		requireClient(ec)
 		if len(call.Arguments) == 0 {
 			panic(ec.rt.NewGoError(fmt.Errorf("runCommand requires a command document")))
 		}
@@ -54,5 +93,189 @@ func dbRunCommand(ec *execContext, dbName string) func(goja.FunctionCall) goja.V
 		}
 
 		return ec.rt.ToValue(result)
+	}
+}
+
+// dbGetCollectionNames returns a function: db.getCollectionNames(filter?) → string[]
+func dbGetCollectionNames(ec *execContext) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		requireClient(ec)
+
+		filter := bson.D{}
+		if len(call.Arguments) > 0 && !goja.IsUndefined(call.Arguments[0]) {
+			raw := exportValue(call.Arguments[0])
+			if converted, ok := convertToBson(raw).(bson.D); ok {
+				filter = converted
+			}
+		}
+
+		names, err := ec.client.Database(ec.dbName).ListCollectionNames(ec.ctx, filter)
+		if err != nil {
+			panic(ec.rt.NewGoError(fmt.Errorf("getCollectionNames: %w", err)))
+		}
+
+		return ec.rt.ToValue(names)
+	}
+}
+
+// dbGetCollectionInfos returns a function: db.getCollectionInfos(filter?) → object[]
+func dbGetCollectionInfos(ec *execContext) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		requireClient(ec)
+
+		filter := bson.D{}
+		if len(call.Arguments) > 0 && !goja.IsUndefined(call.Arguments[0]) {
+			raw := exportValue(call.Arguments[0])
+			if converted, ok := convertToBson(raw).(bson.D); ok {
+				filter = converted
+			}
+		}
+
+		cursor, err := ec.client.Database(ec.dbName).ListCollections(ec.ctx, filter)
+		if err != nil {
+			panic(ec.rt.NewGoError(fmt.Errorf("getCollectionInfos: %w", err)))
+		}
+
+		var results []bson.M
+		if err := cursor.All(ec.ctx, &results); err != nil {
+			panic(ec.rt.NewGoError(fmt.Errorf("getCollectionInfos: %w", err)))
+		}
+
+		// Convert []bson.M to []any for Goja
+		out := make([]any, len(results))
+		for i, r := range results {
+			out[i] = r
+		}
+
+		return ec.rt.ToValue(out)
+	}
+}
+
+// dbCreateCollection returns a function: db.createCollection(name) → { ok: 1 }
+func dbCreateCollection(ec *execContext) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		requireClient(ec)
+		if len(call.Arguments) == 0 {
+			panic(ec.rt.NewGoError(fmt.Errorf("createCollection requires a name argument")))
+		}
+
+		name := call.Arguments[0].String()
+		err := ec.client.Database(ec.dbName).CreateCollection(ec.ctx, name)
+		if err != nil {
+			panic(ec.rt.NewGoError(fmt.Errorf("createCollection: %w", err)))
+		}
+
+		return ec.rt.ToValue(map[string]any{"ok": 1})
+	}
+}
+
+// dbDropDatabase returns a function: db.dropDatabase() → { ok: 1, dropped: "dbName" }
+func dbDropDatabase(ec *execContext) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		requireClient(ec)
+
+		err := ec.client.Database(ec.dbName).Drop(ec.ctx)
+		if err != nil {
+			panic(ec.rt.NewGoError(fmt.Errorf("dropDatabase: %w", err)))
+		}
+
+		return ec.rt.ToValue(map[string]any{"ok": 1, "dropped": ec.dbName})
+	}
+}
+
+// dbStats returns a function: db.stats() → object (runs {dbStats: 1})
+func dbStats(ec *execContext) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		requireClient(ec)
+
+		var result bson.M
+		err := ec.client.Database(ec.dbName).RunCommand(ec.ctx, bson.D{{Key: "dbStats", Value: 1}}).Decode(&result)
+		if err != nil {
+			panic(ec.rt.NewGoError(fmt.Errorf("stats: %w", err)))
+		}
+
+		return ec.rt.ToValue(result)
+	}
+}
+
+// dbVersion returns a function: db.version() → string
+func dbVersion(ec *execContext) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		requireClient(ec)
+
+		var result bson.M
+		err := ec.client.Database("admin").RunCommand(ec.ctx, bson.D{{Key: "buildInfo", Value: 1}}).Decode(&result)
+		if err != nil {
+			panic(ec.rt.NewGoError(fmt.Errorf("version: %w", err)))
+		}
+
+		ver, _ := result["version"].(string)
+		return ec.rt.ToValue(ver)
+	}
+}
+
+// dbGetSiblingDB returns a function: db.getSiblingDB(name) → db proxy for that database
+func dbGetSiblingDB(ec *execContext) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		if len(call.Arguments) == 0 {
+			panic(ec.rt.NewGoError(fmt.Errorf("getSiblingDB requires a database name")))
+		}
+
+		siblingName := call.Arguments[0].String()
+		siblingEC := &execContext{
+			ctx:    ec.ctx,
+			client: ec.client,
+			dbName: siblingName,
+			rt:     ec.rt,
+		}
+		return newDatabaseProxy(siblingEC)
+	}
+}
+
+// dbGetMongo returns a function: db.getMongo() → a simple object representing the connection.
+// In Vervet this is a stub since connections are managed by the app, not scripts.
+func dbGetMongo(ec *execContext) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		obj := ec.rt.NewObject()
+		_ = obj.Set("getDB", func(name string) goja.Value {
+			siblingEC := &execContext{
+				ctx:    ec.ctx,
+				client: ec.client,
+				dbName: name,
+				rt:     ec.rt,
+			}
+			return newDatabaseProxy(siblingEC)
+		})
+		return obj
+	}
+}
+
+// dbAggregate returns a function: db.aggregate(pipeline) → results array
+func dbAggregate(ec *execContext) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		requireClient(ec)
+		if len(call.Arguments) == 0 {
+			panic(ec.rt.NewGoError(fmt.Errorf("aggregate requires a pipeline argument")))
+		}
+
+		pipelineRaw := exportValue(call.Arguments[0])
+		pipeline := convertToBson(pipelineRaw)
+
+		cursor, err := ec.client.Database(ec.dbName).Aggregate(ec.ctx, pipeline)
+		if err != nil {
+			panic(ec.rt.NewGoError(fmt.Errorf("aggregate: %w", err)))
+		}
+
+		var results []bson.M
+		if err := cursor.All(ec.ctx, &results); err != nil {
+			panic(ec.rt.NewGoError(fmt.Errorf("aggregate: %w", err)))
+		}
+
+		out := make([]any, len(results))
+		for i, r := range results {
+			out[i] = r
+		}
+
+		return ec.rt.ToValue(out)
 	}
 }


### PR DESCRIPTION
## Summary

- Add 9 db-level methods to the Goja query engine: `getCollectionNames`, `getCollectionInfos`, `createCollection`, `dropDatabase`, `stats`, `version`, `getSiblingDB`, `getMongo`, `aggregate`
- `getSiblingDB` returns a new db proxy for cross-database queries
- `getMongo().getDB()` provides mongosh-compatible connection object navigation
- Autocomplete entries for all new methods appear when typing `db.`
- Extracted `requireClient` helper to reduce boilerplate in proxy functions

## Changes

- `internal/queryengine/proxy_db.go` — 9 new method intercepts + helper functions
- `internal/queryengine/goja_engine_test.go` — unit tests for proxy intercepts, getSiblingDB chaining, getMongo.getDB chaining, nil-client errors
- `internal/queryengine/db_commands_integration_test.go` — 8 new integration tests
- `frontend/src/features/completion/completionData.ts` — 9 new `dbMethods` entries

## Test plan

- [x] `go test ./...` — all pass
- [x] `bun run test` — 245 tests pass
- [x] `bun run lint` — clean
- [x] `go test -tags integration ./internal/queryengine/...` — all integration tests pass