### PR TITLE
fixes #130 - EJSON global support

### DIFF
--- a/frontend/src/features/completion/completionContext.test.ts
+++ b/frontend/src/features/completion/completionContext.test.ts
@@ -478,4 +478,30 @@ describe('analyzeContext', () => {
       expect(ctx.prefix).toBe('ag')
     })
   })
+
+  describe('EJSON completions', () => {
+    it('returns EJSON_METHOD after EJSON.', () => {
+      const ctx = analyzeContext('EJSON.')
+      expect(ctx.type).toBe('EJSON_METHOD')
+      expect(ctx.prefix).toBe('')
+    })
+
+    it('returns EJSON_METHOD with partial prefix', () => {
+      const ctx = analyzeContext('EJSON.str')
+      expect(ctx.type).toBe('EJSON_METHOD')
+      expect(ctx.prefix).toBe('str')
+    })
+
+    it('returns EJSON_METHOD for parse prefix', () => {
+      const ctx = analyzeContext('EJSON.pa')
+      expect(ctx.type).toBe('EJSON_METHOD')
+      expect(ctx.prefix).toBe('pa')
+    })
+
+    it('returns KEYWORD for standalone EJSON prefix', () => {
+      const ctx = analyzeContext('EJ')
+      expect(ctx.type).toBe('KEYWORD')
+      expect(ctx.prefix).toBe('EJ')
+    })
+  })
 })

--- a/frontend/src/features/completion/completionContext.ts
+++ b/frontend/src/features/completion/completionContext.ts
@@ -10,6 +10,7 @@ export type CompletionContextType =
   | 'UPDATE_OPERATOR'
   | 'AGG_EXPRESSION'
   | 'USE_DATABASE'
+  | 'EJSON_METHOD'
 
 export interface CompletionContext {
   type: CompletionContextType
@@ -145,6 +146,15 @@ function analyzeContextCore(textBeforeCursor: string): CompletionContext {
       collection: insideBracesMatch[1],
       prefix: insideBracesMatch[2] || '',
       insideQuotes: false,
+    }
+  }
+
+  // EJSON.| → EJSON_METHOD
+  const ejsonMatch = trimmed.match(/EJSON\.(\w*)$/)
+  if (ejsonMatch) {
+    return {
+      type: 'EJSON_METHOD',
+      prefix: ejsonMatch[1] || '',
     }
   }
 

--- a/frontend/src/features/completion/completionData.ts
+++ b/frontend/src/features/completion/completionData.ts
@@ -309,6 +309,29 @@ export const updateOperators = [
   { label: '$bit', detail: 'Performs bitwise AND, OR and XOR updates of integer values' },
 ]
 
+export const ejsonMethods = [
+  {
+    label: 'stringify',
+    detail: '(value, replacer?, space?) - Convert to Extended JSON string',
+    snippet: 'stringify($1)$0',
+  },
+  {
+    label: 'parse',
+    detail: '(str) - Parse an Extended JSON string',
+    snippet: "parse('$1')$0",
+  },
+  {
+    label: 'serialize',
+    detail: '(value) - Convert to Extended JSON object representation',
+    snippet: 'serialize($1)$0',
+  },
+  {
+    label: 'deserialize',
+    detail: '(value) - Convert Extended JSON object to BSON types',
+    snippet: 'deserialize($1)$0',
+  },
+]
+
 export const dbMethods = [
   {
     label: 'runCommand',

--- a/frontend/src/features/completion/useMonacoCompletions.ts
+++ b/frontend/src/features/completion/useMonacoCompletions.ts
@@ -8,6 +8,7 @@ import {
   updateOperators,
   aggExpressions,
   dbMethods,
+  ejsonMethods,
 } from './completionData'
 import { getCollectionSchema, getCollectionNames, getDatabaseNames } from './useSchemaCache'
 import { useTabStore } from '@/features/tabs/tabs'
@@ -266,6 +267,18 @@ async function getSuggestions(
         }))
     }
 
+    case 'EJSON_METHOD':
+      return ejsonMethods
+        .filter((m) => m.label.startsWith(ctx.prefix))
+        .map((m) => ({
+          label: m.label,
+          kind: monaco.languages.CompletionItemKind.Method,
+          detail: m.detail,
+          insertText: m.snippet,
+          insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+          range,
+        }))
+
     case 'KEYWORD': {
       const keywords: monaco.languages.CompletionItem[] = [
         {
@@ -280,6 +293,13 @@ async function getSuggestions(
           kind: monaco.languages.CompletionItemKind.Keyword,
           detail: 'Switch database',
           insertText: 'use',
+          range,
+        },
+        {
+          label: 'EJSON',
+          kind: monaco.languages.CompletionItemKind.Variable,
+          detail: 'Extended JSON utilities',
+          insertText: 'EJSON',
           range,
         },
       ]

--- a/internal/queryengine/ejson.go
+++ b/internal/queryengine/ejson.go
@@ -1,0 +1,150 @@
+package queryengine
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/dop251/goja"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// registerEJSON registers the EJSON global object in the Goja runtime,
+// providing mongosh-compatible Extended JSON methods:
+//   - EJSON.stringify(value, replacer?, space?) → string
+//   - EJSON.parse(str) → object
+//   - EJSON.serialize(value) → object (Extended JSON representation)
+//   - EJSON.deserialize(value) → object (BSON types from Extended JSON)
+func registerEJSON(rt *goja.Runtime) error {
+	ejson := rt.NewObject()
+
+	if err := ejson.Set("stringify", ejsonStringify(rt)); err != nil {
+		return fmt.Errorf("failed to set EJSON.stringify: %w", err)
+	}
+	if err := ejson.Set("parse", ejsonParse(rt)); err != nil {
+		return fmt.Errorf("failed to set EJSON.parse: %w", err)
+	}
+	if err := ejson.Set("serialize", ejsonSerialize(rt)); err != nil {
+		return fmt.Errorf("failed to set EJSON.serialize: %w", err)
+	}
+	if err := ejson.Set("deserialize", ejsonDeserialize(rt)); err != nil {
+		return fmt.Errorf("failed to set EJSON.deserialize: %w", err)
+	}
+
+	return rt.Set("EJSON", ejson)
+}
+
+// ejsonStringify converts a JS value to an Extended JSON string (relaxed mode).
+// Usage: EJSON.stringify(value) or EJSON.stringify(value, null, 2) for indented output.
+func ejsonStringify(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		if len(call.Arguments) == 0 {
+			panic(rt.NewGoError(fmt.Errorf("EJSON.stringify requires a value argument")))
+		}
+
+		raw := exportValue(call.Arguments[0])
+		bsonDoc := convertToBson(raw)
+
+		// Check for indent (third argument, like JSON.stringify)
+		indent := ""
+		if len(call.Arguments) >= 3 && !goja.IsUndefined(call.Arguments[2]) && !goja.IsNull(call.Arguments[2]) {
+			switch v := call.Arguments[2].Export().(type) {
+			case int64:
+				for i := int64(0); i < v; i++ {
+					indent += " "
+				}
+			case float64:
+				for i := 0; i < int(v); i++ {
+					indent += " "
+				}
+			case string:
+				indent = v
+			}
+		}
+
+		var data []byte
+		var err error
+		if indent != "" {
+			data, err = bson.MarshalExtJSONIndent(bsonDoc, false, false, "", indent)
+		} else {
+			data, err = bson.MarshalExtJSON(bsonDoc, false, false)
+		}
+		if err != nil {
+			panic(rt.NewGoError(fmt.Errorf("EJSON.stringify: %w", err)))
+		}
+
+		return rt.ToValue(string(data))
+	}
+}
+
+// ejsonParse parses an Extended JSON string into a JS object.
+// Usage: EJSON.parse(str)
+func ejsonParse(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		if len(call.Arguments) == 0 {
+			panic(rt.NewGoError(fmt.Errorf("EJSON.parse requires a string argument")))
+		}
+
+		str := call.Arguments[0].String()
+
+		var result bson.M
+		if err := bson.UnmarshalExtJSON([]byte(str), false, &result); err != nil {
+			panic(rt.NewGoError(fmt.Errorf("EJSON.parse: %w", err)))
+		}
+
+		return rt.ToValue(result)
+	}
+}
+
+// ejsonSerialize converts a JS value to its Extended JSON object representation.
+// Unlike stringify, this returns a JS object (not a string) where BSON types
+// are represented as Extended JSON objects (e.g. {$oid: "..."}, {$numberLong: "..."}).
+// Usage: EJSON.serialize(value)
+func ejsonSerialize(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		if len(call.Arguments) == 0 {
+			panic(rt.NewGoError(fmt.Errorf("EJSON.serialize requires a value argument")))
+		}
+
+		raw := exportValue(call.Arguments[0])
+		bsonDoc := convertToBson(raw)
+
+		// Marshal to Extended JSON, then unmarshal to a generic map
+		data, err := bson.MarshalExtJSON(bsonDoc, false, false)
+		if err != nil {
+			panic(rt.NewGoError(fmt.Errorf("EJSON.serialize: %w", err)))
+		}
+
+		var result any
+		if err := json.Unmarshal(data, &result); err != nil {
+			panic(rt.NewGoError(fmt.Errorf("EJSON.serialize: %w", err)))
+		}
+
+		return rt.ToValue(result)
+	}
+}
+
+// ejsonDeserialize converts an Extended JSON object representation back to
+// a JS object with native BSON types. This is the inverse of serialize.
+// Usage: EJSON.deserialize(obj)
+func ejsonDeserialize(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		if len(call.Arguments) == 0 {
+			panic(rt.NewGoError(fmt.Errorf("EJSON.deserialize requires a value argument")))
+		}
+
+		raw := call.Arguments[0].Export()
+
+		// Marshal the JS object to JSON, then unmarshal via Extended JSON parser
+		data, err := json.Marshal(raw)
+		if err != nil {
+			panic(rt.NewGoError(fmt.Errorf("EJSON.deserialize: %w", err)))
+		}
+
+		var result bson.M
+		if err := bson.UnmarshalExtJSON(data, false, &result); err != nil {
+			panic(rt.NewGoError(fmt.Errorf("EJSON.deserialize: %w", err)))
+		}
+
+		return rt.ToValue(result)
+	}
+}

--- a/internal/queryengine/ejson_integration_test.go
+++ b/internal/queryengine/ejson_integration_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package queryengine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_EJSON_Stringify_QueryResult(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	// Insert a document
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.ejsontest.insertOne({ name: "alice", age: 30 })`)
+	require.NoError(t, err)
+
+	// Use EJSON.stringify on a find result
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `
+		var docs = db.ejsontest.find({}).toArray();
+		EJSON.stringify(docs[0])
+	`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "alice")
+	assert.Contains(t, result.RawOutput, "$oid") // _id should be in Extended JSON format
+}
+
+func TestIntegration_EJSON_Stringify_WithIndent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `EJSON.stringify({ x: 1, y: 2 }, null, 2)`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "\n")
+}
+
+func TestIntegration_EJSON_Parse_ExtendedJSON(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	// Parse extended JSON, stringify it back, and verify roundtrip
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `
+		var doc = EJSON.parse('{"name": "from_ejson", "count": 42}');
+		EJSON.stringify(doc)
+	`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "from_ejson")
+	assert.Contains(t, result.RawOutput, "42")
+}
+
+func TestIntegration_EJSON_SerializeDeserialize_Roundtrip(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	// Insert, fetch via toArray to get plain docs, serialize/deserialize roundtrip
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.ejsontest.insertOne({ label: "original" })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `
+		var docs = db.ejsontest.find({ label: "original" }).toArray();
+		var doc = docs[0];
+		var serialized = EJSON.serialize(doc);
+		var deserialized = EJSON.deserialize(serialized);
+		deserialized.label
+	`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "original")
+}

--- a/internal/queryengine/ejson_test.go
+++ b/internal/queryengine/ejson_test.go
@@ -1,0 +1,162 @@
+package queryengine
+
+import (
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupEJSONRuntime(t *testing.T) *goja.Runtime {
+	t.Helper()
+	rt := goja.New()
+	require.NoError(t, registerBSONTypes(rt))
+	require.NoError(t, registerEJSON(rt))
+	return rt
+}
+
+func TestEJSON_Stringify_SimpleObject(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	val, err := rt.RunString(`EJSON.stringify({ name: "alice", age: 30 })`)
+	require.NoError(t, err)
+	s := val.String()
+	assert.Contains(t, s, `"name"`)
+	assert.Contains(t, s, `"alice"`)
+}
+
+func TestEJSON_Stringify_WithIndent(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	val, err := rt.RunString(`EJSON.stringify({ x: 1 }, null, 2)`)
+	require.NoError(t, err)
+	s := val.String()
+	// Indented output should contain newlines
+	assert.Contains(t, s, "\n")
+}
+
+func TestEJSON_Stringify_NoArgs_Panics(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	_, err := rt.RunString(`EJSON.stringify()`)
+	assert.Error(t, err)
+}
+
+func TestEJSON_Stringify_WithObjectId(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	val, err := rt.RunString(`EJSON.stringify({ _id: ObjectId("507f1f77bcf86cd799439011") })`)
+	require.NoError(t, err)
+	s := val.String()
+	assert.Contains(t, s, `$oid`)
+	assert.Contains(t, s, `507f1f77bcf86cd799439011`)
+}
+
+func TestEJSON_Parse_SimpleObject(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	val, err := rt.RunString(`
+		var obj = EJSON.parse('{"name": "bob", "age": 25}');
+		obj.name
+	`)
+	require.NoError(t, err)
+	assert.Equal(t, "bob", val.String())
+}
+
+func TestEJSON_Parse_WithExtendedJSON(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	val, err := rt.RunString(`
+		var obj = EJSON.parse('{"_id": {"$oid": "507f1f77bcf86cd799439011"}}');
+		typeof obj._id
+	`)
+	require.NoError(t, err)
+	// After parsing extended JSON, _id should be an ObjectID (object type in JS)
+	assert.Equal(t, "object", val.String())
+}
+
+func TestEJSON_Parse_NoArgs_Panics(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	_, err := rt.RunString(`EJSON.parse()`)
+	assert.Error(t, err)
+}
+
+func TestEJSON_Serialize_ReturnsObject(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	val, err := rt.RunString(`
+		var result = EJSON.serialize({ _id: ObjectId("507f1f77bcf86cd799439011") });
+		typeof result
+	`)
+	require.NoError(t, err)
+	// serialize returns an object, not a string
+	assert.Equal(t, "object", val.String())
+}
+
+func TestEJSON_Serialize_ContainsExtendedJSONKeys(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	val, err := rt.RunString(`
+		var result = EJSON.serialize({ _id: ObjectId("507f1f77bcf86cd799439011") });
+		result._id["$oid"]
+	`)
+	require.NoError(t, err)
+	assert.Equal(t, "507f1f77bcf86cd799439011", val.String())
+}
+
+func TestEJSON_Serialize_NoArgs_Panics(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	_, err := rt.RunString(`EJSON.serialize()`)
+	assert.Error(t, err)
+}
+
+func TestEJSON_Deserialize_FromExtendedJSON(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	val, err := rt.RunString(`
+		var obj = EJSON.deserialize({ _id: { "$oid": "507f1f77bcf86cd799439011" } });
+		typeof obj._id
+	`)
+	require.NoError(t, err)
+	// After deserializing, the $oid should become an ObjectID
+	assert.Equal(t, "object", val.String())
+}
+
+func TestEJSON_Deserialize_NoArgs_Panics(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	_, err := rt.RunString(`EJSON.deserialize()`)
+	assert.Error(t, err)
+}
+
+func TestEJSON_Roundtrip_StringifyParse(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	val, err := rt.RunString(`
+		var original = { name: "test", count: 42 };
+		var json = EJSON.stringify(original);
+		var parsed = EJSON.parse(json);
+		parsed.name === "test"
+	`)
+	require.NoError(t, err)
+	assert.Equal(t, true, val.Export())
+}
+
+func TestEJSON_Roundtrip_SerializeDeserialize(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	val, err := rt.RunString(`
+		var original = { _id: ObjectId("507f1f77bcf86cd799439011"), name: "test" };
+		var serialized = EJSON.serialize(original);
+		var deserialized = EJSON.deserialize(serialized);
+		typeof deserialized._id === "object" && deserialized.name === "test"
+	`)
+	require.NoError(t, err)
+	assert.Equal(t, true, val.Export())
+}
+
+func TestEJSON_IsRegisteredAsGlobal(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	val, err := rt.RunString(`typeof EJSON`)
+	require.NoError(t, err)
+	assert.Equal(t, "object", val.String())
+}
+
+func TestEJSON_HasAllMethods(t *testing.T) {
+	rt := setupEJSONRuntime(t)
+	methods := []string{"stringify", "parse", "serialize", "deserialize"}
+	for _, m := range methods {
+		val, err := rt.RunString(`typeof EJSON.` + m)
+		require.NoError(t, err, "method %s", m)
+		assert.Equal(t, "function", val.Export(), "EJSON.%s should be a function", m)
+	}
+}

--- a/internal/queryengine/goja_engine.go
+++ b/internal/queryengine/goja_engine.go
@@ -29,6 +29,10 @@ func (e *GojaEngine) ExecuteQuery(ctx context.Context, uri, dbName, query string
 		return models.QueryResult{}, err
 	}
 
+	if err := registerEJSON(rt); err != nil {
+		return models.QueryResult{}, err
+	}
+
 	db := newDatabaseProxy(ec)
 	if err := rt.Set("db", db); err != nil {
 		return models.QueryResult{}, fmt.Errorf("failed to set db global: %w", err)


### PR DESCRIPTION
## Summary
- Add `EJSON` global object to Goja runtime with `stringify`, `parse`, `serialize`, and `deserialize` methods for mongosh-compatible Extended JSON support
- Add Monaco editor autocomplete for `EJSON.` methods and `EJSON` as a keyword
- 16 unit tests, 4 integration tests, 4 completion context tests

## Test plan
- [x] Go unit tests pass (`go test ./internal/queryengine/...`)
- [x] Integration tests pass (`go test -tags integration ./internal/queryengine/...`)
- [x] Frontend tests pass (`bun run test`)
- [x] Lint and type-check pass (`bun run lint`)