### PR TITLE
fixes #131 - cursor methods: explain, hint, maxTimeMS, batchSize, collation, comment

### DIFF
--- a/internal/queryengine/captured_op.go
+++ b/internal/queryengine/captured_op.go
@@ -10,4 +10,9 @@ type CapturedOp struct {
 	Limit      int64
 	Skip       int64
 	Sort       any
+	Hint       any
+	MaxTimeMS  int64
+	BatchSize  int32
+	Collation  map[string]any
+	Comment    string
 }

--- a/internal/queryengine/dispatch.go
+++ b/internal/queryengine/dispatch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"vervet/internal/models"
 
@@ -19,6 +20,8 @@ func dispatch(ctx context.Context, client *mongo.Client, dbName string, op Captu
 	switch op.Method {
 	case "find":
 		return dispatchFind(ctx, coll, op)
+	case "explainFind":
+		return dispatchExplainFind(ctx, client, dbName, op)
 	case "findOne":
 		return dispatchFindOne(ctx, coll, op)
 	case "insertOne":
@@ -80,15 +83,7 @@ func dispatchFind(ctx context.Context, coll *mongo.Collection, op CapturedOp) (m
 			opts.SetProjection(toBsonDoc(projMap))
 		}
 	}
-	if op.Limit > 0 {
-		opts.SetLimit(op.Limit)
-	}
-	if op.Skip > 0 {
-		opts.SetSkip(op.Skip)
-	}
-	if op.Sort != nil {
-		opts.SetSort(toBsonDoc(op.Sort))
-	}
+	applyFindOptions(opts, op)
 
 	cursor, err := coll.Find(ctx, filter, opts)
 	if err != nil {
@@ -104,6 +99,142 @@ func dispatchFind(ctx context.Context, coll *mongo.Collection, op CapturedOp) (m
 	result := docsToResult(results)
 	result.OperationType = "find"
 	return result, nil
+}
+
+// applyFindOptions applies the shared cursor-scoped options from op to the given FindOptions.
+func applyFindOptions(opts *options.FindOptions, op CapturedOp) {
+	if op.Limit > 0 {
+		opts.SetLimit(op.Limit)
+	}
+	if op.Skip > 0 {
+		opts.SetSkip(op.Skip)
+	}
+	if op.Sort != nil {
+		opts.SetSort(toBsonDoc(op.Sort))
+	}
+	if op.Hint != nil {
+		if hintStr, ok := op.Hint.(string); ok {
+			opts.SetHint(hintStr)
+		} else if hintMap, ok := op.Hint.(map[string]any); ok {
+			opts.SetHint(toBsonDoc(hintMap))
+		} else {
+			opts.SetHint(op.Hint)
+		}
+	}
+	if op.MaxTimeMS > 0 {
+		opts.SetMaxTime(time.Duration(op.MaxTimeMS) * time.Millisecond)
+	}
+	if op.BatchSize > 0 {
+		opts.SetBatchSize(op.BatchSize)
+	}
+	if op.Collation != nil {
+		opts.SetCollation(toCollation(op.Collation))
+	}
+	if op.Comment != "" {
+		opts.SetComment(op.Comment)
+	}
+}
+
+// toCollation converts a map[string]any into a driver *options.Collation.
+func toCollation(m map[string]any) *options.Collation {
+	c := &options.Collation{}
+	if v, ok := m["locale"].(string); ok {
+		c.Locale = v
+	}
+	if v, ok := m["caseLevel"].(bool); ok {
+		c.CaseLevel = v
+	}
+	if v, ok := m["caseFirst"].(string); ok {
+		c.CaseFirst = v
+	}
+	if v, ok := m["strength"]; ok {
+		switch n := v.(type) {
+		case int64:
+			c.Strength = int(n)
+		case int:
+			c.Strength = n
+		case float64:
+			c.Strength = int(n)
+		}
+	}
+	if v, ok := m["numericOrdering"].(bool); ok {
+		c.NumericOrdering = v
+	}
+	if v, ok := m["alternate"].(string); ok {
+		c.Alternate = v
+	}
+	if v, ok := m["maxVariable"].(string); ok {
+		c.MaxVariable = v
+	}
+	if v, ok := m["normalization"].(bool); ok {
+		c.Normalization = v
+	}
+	if v, ok := m["backwards"].(bool); ok {
+		c.Backwards = v
+	}
+	return c
+}
+
+// dispatchExplainFind runs an explain command describing the find/findOne query for a lazy cursor.
+func dispatchExplainFind(ctx context.Context, client *mongo.Client, dbName string, op CapturedOp) (models.QueryResult, error) {
+	verbosity := "queryPlanner"
+	if len(op.Args) > 2 {
+		if s, ok := op.Args[2].(string); ok && s != "" {
+			verbosity = s
+		}
+	}
+
+	findCmd := bson.D{{Key: "find", Value: op.Collection}}
+	if len(op.Args) > 0 && op.Args[0] != nil {
+		findCmd = append(findCmd, bson.E{Key: "filter", Value: toBsonDoc(op.Args[0])})
+	}
+	if len(op.Args) > 1 && op.Args[1] != nil {
+		if projMap, ok := op.Args[1].(map[string]any); ok {
+			findCmd = append(findCmd, bson.E{Key: "projection", Value: toBsonDoc(projMap)})
+		}
+	}
+	if op.Sort != nil {
+		findCmd = append(findCmd, bson.E{Key: "sort", Value: toBsonDoc(op.Sort)})
+	}
+	if op.Limit > 0 {
+		findCmd = append(findCmd, bson.E{Key: "limit", Value: op.Limit})
+	}
+	if op.Skip > 0 {
+		findCmd = append(findCmd, bson.E{Key: "skip", Value: op.Skip})
+	}
+	if op.Hint != nil {
+		if hintMap, ok := op.Hint.(map[string]any); ok {
+			findCmd = append(findCmd, bson.E{Key: "hint", Value: toBsonDoc(hintMap)})
+		} else {
+			findCmd = append(findCmd, bson.E{Key: "hint", Value: op.Hint})
+		}
+	}
+	if op.BatchSize > 0 {
+		findCmd = append(findCmd, bson.E{Key: "batchSize", Value: op.BatchSize})
+	}
+	if op.MaxTimeMS > 0 {
+		findCmd = append(findCmd, bson.E{Key: "maxTimeMS", Value: op.MaxTimeMS})
+	}
+	if op.Collation != nil {
+		findCmd = append(findCmd, bson.E{Key: "collation", Value: toBsonDoc(op.Collation)})
+	}
+	if op.Comment != "" {
+		findCmd = append(findCmd, bson.E{Key: "comment", Value: op.Comment})
+	}
+
+	cmd := bson.D{
+		{Key: "explain", Value: findCmd},
+		{Key: "verbosity", Value: verbosity},
+	}
+
+	var result bson.M
+	if err := client.Database(dbName).RunCommand(ctx, cmd).Decode(&result); err != nil {
+		return models.QueryResult{}, fmt.Errorf("explain failed: %w", err)
+	}
+
+	qr := singleToResult(result)
+	qr.OperationType = "explain"
+	return qr, nil
 }
 
 func dispatchFindOne(ctx context.Context, coll *mongo.Collection, op CapturedOp) (models.QueryResult, error) {

--- a/internal/queryengine/goja_engine_test.go
+++ b/internal/queryengine/goja_engine_test.go
@@ -87,6 +87,50 @@ func TestCollectionProxy_Find_CursorChainingUpdatesState(t *testing.T) {
 	assert.Equal(t, int64(5), cursor.skip)
 }
 
+func TestCollectionProxy_Find_CursorOptionMethodsExist(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	val, err := rt.RunString(`
+		const cursor = db.users.find({});
+		typeof cursor.hint === 'function' &&
+		typeof cursor.maxTimeMS === 'function' &&
+		typeof cursor.batchSize === 'function' &&
+		typeof cursor.collation === 'function' &&
+		typeof cursor.comment === 'function' &&
+		typeof cursor.explain === 'function'
+	`)
+	require.NoError(t, err)
+	assert.Equal(t, true, val.Export())
+}
+
+func TestCollectionProxy_Find_CursorOptionsChainingUpdatesState(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	val, err := rt.RunString(`
+		db.users.find({})
+			.hint({ name: 1 })
+			.maxTimeMS(5000)
+			.batchSize(100)
+			.collation({ locale: 'en', strength: 2 })
+			.comment('my-query')
+	`)
+	require.NoError(t, err)
+	cursor := extractLazyCursor(val)
+	require.NotNil(t, cursor)
+	assert.Equal(t, map[string]any{"name": int64(1)}, cursor.hint)
+	assert.Equal(t, int64(5000), cursor.maxTimeMS)
+	assert.Equal(t, int32(100), cursor.batchSize)
+	assert.Equal(t, "en", cursor.collation["locale"])
+	assert.Equal(t, "my-query", cursor.comment)
+}
+
+func TestCollectionProxy_Find_HintAcceptsString(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	val, err := rt.RunString(`db.users.find({}).hint('name_1')`)
+	require.NoError(t, err)
+	cursor := extractLazyCursor(val)
+	require.NotNil(t, cursor)
+	assert.Equal(t, "name_1", cursor.hint)
+}
+
 func TestCollectionProxy_FindOne_ReturnsCursorWithFindOneFlag(t *testing.T) {
 	rt, _ := setupRuntime(t)
 	val, err := rt.RunString(`db.users.findOne({ name: "alice" })`)

--- a/internal/queryengine/lazy_cursor.go
+++ b/internal/queryengine/lazy_cursor.go
@@ -23,6 +23,11 @@ type lazyCursor struct {
 	results    []any
 	index      int // for hasNext/next iteration
 	isFindOne  bool
+	hint       any
+	maxTimeMS  int64
+	batchSize  int32
+	collation  map[string]any
+	comment    string
 }
 
 func (c *lazyCursor) setLimit(n int64) error {
@@ -63,6 +68,11 @@ func (c *lazyCursor) execute() (models.QueryResult, error) {
 		Limit:      c.limit,
 		Skip:       c.skip,
 		Sort:       c.sort,
+		Hint:       c.hint,
+		MaxTimeMS:  c.maxTimeMS,
+		BatchSize:  c.batchSize,
+		Collation:  c.collation,
+		Comment:    c.comment,
 	}
 
 	if c.isFindOne {
@@ -78,6 +88,27 @@ func (c *lazyCursor) execute() (models.QueryResult, error) {
 	c.results = result.Documents
 	c.resolved = true
 	return result, nil
+}
+
+// explain runs an explain command for this cursor's find/findOne query.
+func (c *lazyCursor) explain(verbosity string) (models.QueryResult, error) {
+	op := CapturedOp{
+		Collection: c.collection,
+		Method:     "explainFind",
+		Args:       []any{c.filter, c.projection, verbosity},
+		Limit:      c.limit,
+		Skip:       c.skip,
+		Sort:       c.sort,
+		Hint:       c.hint,
+		MaxTimeMS:  c.maxTimeMS,
+		BatchSize:  c.batchSize,
+		Collation:  c.collation,
+		Comment:    c.comment,
+	}
+	if c.isFindOne {
+		op.Limit = 1
+	}
+	return dispatch(c.ec.ctx, c.ec.client, c.ec.dbName, op)
 }
 
 // toGojaObject wraps this lazyCursor as a Goja object with chainable and
@@ -110,6 +141,54 @@ func (c *lazyCursor) toGojaObject() goja.Value {
 				panic(rt.NewGoError(err))
 			}
 		}
+		return obj
+	})
+
+	_ = obj.Set("hint", func(call goja.FunctionCall) goja.Value {
+		if c.resolved {
+			panic(rt.NewGoError(fmt.Errorf("cursor already executed — cannot set hint")))
+		}
+		if len(call.Arguments) > 0 {
+			c.hint = call.Arguments[0].Export()
+		}
+		return obj
+	})
+
+	_ = obj.Set("maxTimeMS", func(n int64) goja.Value {
+		if c.resolved {
+			panic(rt.NewGoError(fmt.Errorf("cursor already executed — cannot set maxTimeMS")))
+		}
+		c.maxTimeMS = n
+		return obj
+	})
+
+	_ = obj.Set("batchSize", func(n int32) goja.Value {
+		if c.resolved {
+			panic(rt.NewGoError(fmt.Errorf("cursor already executed — cannot set batchSize")))
+		}
+		c.batchSize = n
+		return obj
+	})
+
+	_ = obj.Set("collation", func(call goja.FunctionCall) goja.Value {
+		if c.resolved {
+			panic(rt.NewGoError(fmt.Errorf("cursor already executed — cannot set collation")))
+		}
+		if len(call.Arguments) > 0 {
+			spec, ok := call.Arguments[0].Export().(map[string]any)
+			if !ok {
+				panic(rt.NewGoError(fmt.Errorf("collation argument must be an object")))
+			}
+			c.collation = spec
+		}
+		return obj
+	})
+
+	_ = obj.Set("comment", func(s string) goja.Value {
+		if c.resolved {
+			panic(rt.NewGoError(fmt.Errorf("cursor already executed — cannot set comment")))
+		}
+		c.comment = s
 		return obj
 	})
 
@@ -205,6 +284,20 @@ func (c *lazyCursor) toGojaObject() goja.Value {
 		doc := c.results[c.index]
 		c.index++
 		return rt.ToValue(doc)
+	})
+
+	_ = obj.Set("explain", func(call goja.FunctionCall) goja.Value {
+		verbosity := "queryPlanner"
+		if len(call.Arguments) > 0 {
+			if s, ok := call.Arguments[0].Export().(string); ok && s != "" {
+				verbosity = s
+			}
+		}
+		result, err := c.explain(verbosity)
+		if err != nil {
+			panic(rt.NewGoError(err))
+		}
+		return toGojaValue(rt, result)
 	})
 
 	// No-op

--- a/internal/queryengine/lazy_cursor_integration_test.go
+++ b/internal/queryengine/lazy_cursor_integration_test.go
@@ -1,0 +1,116 @@
+//go:build integration
+
+package queryengine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_Cursor_Explain(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertMany([{ x: 1 }, { x: 2 }])`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.find({ x: 1 }).explain()`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "queryPlanner")
+}
+
+func TestIntegration_Cursor_ExplainWithVerbosity(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertOne({ x: 1 })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.find({ x: 1 }).explain("executionStats")`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "executionStats")
+}
+
+func TestIntegration_Cursor_Hint(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertMany([{ x: 1 }, { x: 2 }, { x: 3 }])`)
+	require.NoError(t, err)
+	_, err = engine.ExecuteQuery(ctx, testURI, db, `db.test.createIndex({ x: 1 })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.find({}).hint({ x: 1 })`)
+	require.NoError(t, err)
+	assert.Len(t, result.Documents, 3)
+}
+
+func TestIntegration_Cursor_BatchSizeAndMaxTimeMS(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertMany([{ x: 1 }, { x: 2 }, { x: 3 }])`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.find({}).batchSize(2).maxTimeMS(5000)`)
+	require.NoError(t, err)
+	assert.Len(t, result.Documents, 3)
+}
+
+func TestIntegration_Cursor_Collation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertMany([{ s: "a" }, { s: "A" }])`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.find({ s: "a" }).collation({ locale: "en", strength: 2 })`)
+	require.NoError(t, err)
+	assert.Len(t, result.Documents, 2)
+}
+
+func TestIntegration_Cursor_Comment(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertOne({ x: 1 })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.find({ x: 1 }).comment("tagged-query")`)
+	require.NoError(t, err)
+	assert.Len(t, result.Documents, 1)
+}

--- a/internal/queryengine/lazy_cursor_test.go
+++ b/internal/queryengine/lazy_cursor_test.go
@@ -51,3 +51,12 @@ func TestLazyCursor_SetSortAfterResolve_Errors(t *testing.T) {
 	err := c.setSort(map[string]any{"name": int64(1)})
 	assert.Error(t, err)
 }
+
+func TestLazyCursor_CursorOptionsFieldsDefaults(t *testing.T) {
+	c := &lazyCursor{}
+	assert.Nil(t, c.hint)
+	assert.Equal(t, int64(0), c.maxTimeMS)
+	assert.Equal(t, int32(0), c.batchSize)
+	assert.Nil(t, c.collation)
+	assert.Equal(t, "", c.comment)
+}


### PR DESCRIPTION
## Summary
- Wires six no-op cursor methods through the lazy cursor and dispatch layer
- Chaining methods (`hint`, `maxTimeMS`, `batchSize`, `collation`, `comment`) store state on the cursor and apply via `FindOptions`
- `explain(verbosity?)` runs the explain command, defaulting to `queryPlanner`

Closes #131

## Test plan
- [x] Unit tests for chainable setters and default state
- [x] Integration tests (testcontainers mongo:7) covering all six methods