### PR TITLE
fixes #132 - collection info methods: stats, isCapped, getIndexes, count, findAndModify, rename, validate

### DIFF
--- a/frontend/src/features/completion/completionData.ts
+++ b/frontend/src/features/completion/completionData.ts
@@ -98,6 +98,61 @@ export const mongoMethods = [
     detail: '(operations) - executes multiple write operations',
     snippet: 'bulkWrite([$1])$0',
   },
+  {
+    label: 'stats',
+    detail: '(scale?) - returns statistics about the collection',
+    snippet: 'stats()$0',
+  },
+  {
+    label: 'isCapped',
+    detail: '() - returns true if the collection is a capped collection',
+    snippet: 'isCapped()$0',
+  },
+  {
+    label: 'dataSize',
+    detail: '() - returns the uncompressed size of the collection in bytes',
+    snippet: 'dataSize()$0',
+  },
+  {
+    label: 'storageSize',
+    detail: '() - returns the allocated storage size of the collection in bytes',
+    snippet: 'storageSize()$0',
+  },
+  {
+    label: 'totalIndexSize',
+    detail: '() - returns the total size of all indexes on the collection in bytes',
+    snippet: 'totalIndexSize()$0',
+  },
+  {
+    label: 'totalSize',
+    detail: '() - returns the total storage size of the collection and its indexes in bytes',
+    snippet: 'totalSize()$0',
+  },
+  {
+    label: 'getIndexes',
+    detail: '() - lists the indexes on the collection (alias for listIndexes)',
+    snippet: 'getIndexes()$0',
+  },
+  {
+    label: 'count',
+    detail: '(filter?) - counts matching documents (legacy; prefer countDocuments)',
+    snippet: 'count({$1})$0',
+  },
+  {
+    label: 'renameCollection',
+    detail: '(newName, dropTarget?) - renames the collection',
+    snippet: 'renameCollection("$1")$0',
+  },
+  {
+    label: 'validate',
+    detail: '(full?) - validates the collection',
+    snippet: 'validate()$0',
+  },
+  {
+    label: 'findAndModify',
+    detail: '(spec) - finds and modifies a document (legacy; prefer findOneAnd*)',
+    snippet: 'findAndModify({$1})$0',
+  },
 ]
 
 export const queryOperators = [

--- a/internal/queryengine/collection_info_integration_test.go
+++ b/internal/queryengine/collection_info_integration_test.go
@@ -1,0 +1,188 @@
+//go:build integration
+
+package queryengine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestIntegration_CollectionStats(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertMany([{ x: 1 }, { x: 2 }])`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.stats()`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "ns")
+}
+
+func TestIntegration_CollectionIsCapped_False(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertOne({ x: 1 })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.isCapped()`)
+	require.NoError(t, err)
+	assert.Equal(t, "false", result.RawOutput)
+}
+
+func TestIntegration_CollectionIsCapped_True(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	err := testClient.Database(db).CreateCollection(ctx, "capped",
+		options.CreateCollection().SetCapped(true).SetSizeInBytes(4096))
+	require.NoError(t, err)
+
+	engine := NewGojaEngine(testClient)
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.capped.isCapped()`)
+	require.NoError(t, err)
+	assert.Equal(t, "true", result.RawOutput)
+}
+
+func TestIntegration_CollectionSizeHelpers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertMany([{ x: 1 }, { x: 2 }])`)
+	require.NoError(t, err)
+
+	for _, method := range []string{"dataSize", "storageSize", "totalSize", "totalIndexSize"} {
+		result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.`+method+`()`)
+		require.NoError(t, err, method)
+		assert.NotEmpty(t, result.RawOutput, method)
+	}
+}
+
+func TestIntegration_CollectionGetIndexes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertOne({ x: 1 })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.getIndexes()`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "_id_")
+}
+
+func TestIntegration_CollectionCount(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertMany([{ x: 1 }, { x: 2 }, { x: 3 }])`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.count({})`)
+	require.NoError(t, err)
+	assert.Equal(t, "3", result.RawOutput)
+}
+
+func TestIntegration_CollectionRename(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.oldname.insertOne({ x: 1 })`)
+	require.NoError(t, err)
+
+	_, err = engine.ExecuteQuery(ctx, testURI, db, `db.oldname.renameCollection("newname")`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.newname.count({})`)
+	require.NoError(t, err)
+	assert.Equal(t, "1", result.RawOutput)
+}
+
+func TestIntegration_CollectionValidate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertOne({ x: 1 })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.validate()`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "valid")
+}
+
+func TestIntegration_CollectionFindAndModify_Update(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertOne({ x: 1, name: "old" })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `
+		db.test.findAndModify({
+			query: { x: 1 },
+			update: { $set: { name: "new" } },
+			new: true
+		})
+	`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "new")
+}
+
+func TestIntegration_CollectionFindAndModify_Remove(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.insertOne({ x: 1 })`)
+	require.NoError(t, err)
+
+	_, err = engine.ExecuteQuery(ctx, testURI, db, `db.test.findAndModify({ query: { x: 1 }, remove: true })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.count({})`)
+	require.NoError(t, err)
+	assert.Equal(t, "0", result.RawOutput)
+}

--- a/internal/queryengine/proxy_collection.go
+++ b/internal/queryengine/proxy_collection.go
@@ -75,5 +75,7 @@ func newCollectionProxy(ec *execContext, collName string) goja.Value {
 		})
 	}
 
+	setCollectionInfoMethods(obj, ec, collName)
+
 	return obj
 }

--- a/internal/queryengine/proxy_collection_info.go
+++ b/internal/queryengine/proxy_collection_info.go
@@ -1,0 +1,285 @@
+package queryengine
+
+import (
+	"fmt"
+
+	"github.com/dop251/goja"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// collStatsMap runs the collStats command and returns the result document.
+func collStatsMap(ec *execContext, collName string, scale int) (bson.M, error) {
+	cmd := bson.D{{Key: "collStats", Value: collName}}
+	if scale > 0 {
+		cmd = append(cmd, bson.E{Key: "scale", Value: scale})
+	}
+	var result bson.M
+	if err := ec.client.Database(ec.dbName).RunCommand(ec.ctx, cmd).Decode(&result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// collStatsField runs collStats and returns a single numeric field from the result.
+func collStatsField(ec *execContext, collName, field string) (any, error) {
+	stats, err := collStatsMap(ec, collName, 0)
+	if err != nil {
+		return nil, err
+	}
+	return stats[field], nil
+}
+
+// setCollectionInfoMethods attaches info/stats/legacy methods to a collection proxy object.
+func setCollectionInfoMethods(obj *goja.Object, ec *execContext, collName string) {
+	rt := ec.rt
+
+	_ = obj.Set("stats", func(call goja.FunctionCall) goja.Value {
+		requireClient(ec)
+		scale := 0
+		if len(call.Arguments) > 0 {
+			// Accept either a scale number or an options object { scale: n }
+			arg := call.Arguments[0].Export()
+			switch v := arg.(type) {
+			case int64:
+				scale = int(v)
+			case float64:
+				scale = int(v)
+			case map[string]any:
+				if s, ok := v["scale"]; ok {
+					switch n := s.(type) {
+					case int64:
+						scale = int(n)
+					case float64:
+						scale = int(n)
+					}
+				}
+			}
+		}
+		result, err := collStatsMap(ec, collName, scale)
+		if err != nil {
+			panic(rt.NewGoError(fmt.Errorf("stats: %w", err)))
+		}
+		return rt.ToValue(result)
+	})
+
+	_ = obj.Set("isCapped", func() goja.Value {
+		requireClient(ec)
+		stats, err := collStatsMap(ec, collName, 0)
+		if err != nil {
+			panic(rt.NewGoError(fmt.Errorf("isCapped: %w", err)))
+		}
+		if v, ok := stats["capped"].(bool); ok {
+			return rt.ToValue(v)
+		}
+		return rt.ToValue(false)
+	})
+
+	_ = obj.Set("dataSize", func() goja.Value {
+		requireClient(ec)
+		v, err := collStatsField(ec, collName, "size")
+		if err != nil {
+			panic(rt.NewGoError(fmt.Errorf("dataSize: %w", err)))
+		}
+		return rt.ToValue(v)
+	})
+
+	_ = obj.Set("storageSize", func() goja.Value {
+		requireClient(ec)
+		v, err := collStatsField(ec, collName, "storageSize")
+		if err != nil {
+			panic(rt.NewGoError(fmt.Errorf("storageSize: %w", err)))
+		}
+		return rt.ToValue(v)
+	})
+
+	_ = obj.Set("totalIndexSize", func() goja.Value {
+		requireClient(ec)
+		v, err := collStatsField(ec, collName, "totalIndexSize")
+		if err != nil {
+			panic(rt.NewGoError(fmt.Errorf("totalIndexSize: %w", err)))
+		}
+		return rt.ToValue(v)
+	})
+
+	_ = obj.Set("totalSize", func() goja.Value {
+		requireClient(ec)
+		stats, err := collStatsMap(ec, collName, 0)
+		if err != nil {
+			panic(rt.NewGoError(fmt.Errorf("totalSize: %w", err)))
+		}
+		total := toInt64(stats["storageSize"]) + toInt64(stats["totalIndexSize"])
+		return rt.ToValue(total)
+	})
+
+	_ = obj.Set("getIndexes", func() goja.Value {
+		requireClient(ec)
+		op := CapturedOp{Collection: collName, Method: "listIndexes"}
+		result, err := dispatch(ec.ctx, ec.client, ec.dbName, op)
+		if err != nil {
+			panic(rt.NewGoError(err))
+		}
+		return toGojaValue(rt, result)
+	})
+
+	_ = obj.Set("count", func(call goja.FunctionCall) goja.Value {
+		requireClient(ec)
+		filter := bson.D{}
+		if len(call.Arguments) > 0 {
+			filter = toBsonDoc(call.Arguments[0].Export())
+		}
+		count, err := ec.client.Database(ec.dbName).Collection(collName).CountDocuments(ec.ctx, filter)
+		if err != nil {
+			panic(rt.NewGoError(fmt.Errorf("count: %w", err)))
+		}
+		return rt.ToValue(count)
+	})
+
+	_ = obj.Set("renameCollection", func(call goja.FunctionCall) goja.Value {
+		requireClient(ec)
+		if len(call.Arguments) < 1 {
+			panic(rt.NewGoError(fmt.Errorf("renameCollection requires a new name")))
+		}
+		newName, ok := call.Arguments[0].Export().(string)
+		if !ok {
+			panic(rt.NewGoError(fmt.Errorf("renameCollection: new name must be a string")))
+		}
+		dropTarget := false
+		if len(call.Arguments) > 1 {
+			if b, ok := call.Arguments[1].Export().(bool); ok {
+				dropTarget = b
+			}
+		}
+		cmd := bson.D{
+			{Key: "renameCollection", Value: ec.dbName + "." + collName},
+			{Key: "to", Value: ec.dbName + "." + newName},
+			{Key: "dropTarget", Value: dropTarget},
+		}
+		var result bson.M
+		if err := ec.client.Database("admin").RunCommand(ec.ctx, cmd).Decode(&result); err != nil {
+			panic(rt.NewGoError(fmt.Errorf("renameCollection: %w", err)))
+		}
+		return rt.ToValue(result)
+	})
+
+	_ = obj.Set("validate", func(call goja.FunctionCall) goja.Value {
+		requireClient(ec)
+		cmd := bson.D{{Key: "validate", Value: collName}}
+		if len(call.Arguments) > 0 {
+			arg := call.Arguments[0].Export()
+			switch v := arg.(type) {
+			case bool:
+				cmd = append(cmd, bson.E{Key: "full", Value: v})
+			case map[string]any:
+				for k, val := range v {
+					cmd = append(cmd, bson.E{Key: k, Value: convertToBson(val)})
+				}
+			}
+		}
+		var result bson.M
+		if err := ec.client.Database(ec.dbName).RunCommand(ec.ctx, cmd).Decode(&result); err != nil {
+			panic(rt.NewGoError(fmt.Errorf("validate: %w", err)))
+		}
+		return rt.ToValue(result)
+	})
+
+	_ = obj.Set("findAndModify", func(call goja.FunctionCall) goja.Value {
+		requireClient(ec)
+		if len(call.Arguments) < 1 {
+			panic(rt.NewGoError(fmt.Errorf("findAndModify requires a spec document")))
+		}
+		spec, ok := call.Arguments[0].Export().(map[string]any)
+		if !ok {
+			panic(rt.NewGoError(fmt.Errorf("findAndModify: spec must be an object")))
+		}
+		result, err := runFindAndModify(ec, collName, spec)
+		if err != nil {
+			panic(rt.NewGoError(err))
+		}
+		return rt.ToValue(result)
+	})
+}
+
+func toInt64(v any) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case int32:
+		return int64(n)
+	case int:
+		return int64(n)
+	case float64:
+		return int64(n)
+	}
+	return 0
+}
+
+// runFindAndModify executes the legacy findAndModify operation against the named collection.
+// Delegates to FindOneAndDelete when spec.remove is truthy, otherwise FindOneAndUpdate.
+func runFindAndModify(ec *execContext, collName string, spec map[string]any) (bson.M, error) {
+	coll := ec.client.Database(ec.dbName).Collection(collName)
+	filter := bson.D{}
+	if q, ok := spec["query"]; ok && q != nil {
+		filter = toBsonDoc(q)
+	}
+
+	returnNew := false
+	if v, ok := spec["new"].(bool); ok {
+		returnNew = v
+	}
+	upsert := false
+	if v, ok := spec["upsert"].(bool); ok {
+		upsert = v
+	}
+
+	if remove, _ := spec["remove"].(bool); remove {
+		opts := options.FindOneAndDelete()
+		if sort, ok := spec["sort"]; ok && sort != nil {
+			opts.SetSort(toBsonDoc(sort))
+		}
+		if fields, ok := spec["fields"]; ok && fields != nil {
+			opts.SetProjection(toBsonDoc(fields))
+		}
+		var result bson.M
+		err := coll.FindOneAndDelete(ec.ctx, filter, opts).Decode(&result)
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("findAndModify: %w", err)
+		}
+		return result, nil
+	}
+
+	update, ok := spec["update"]
+	if !ok || update == nil {
+		return nil, fmt.Errorf("findAndModify requires either remove: true or an update document")
+	}
+
+	opts := options.FindOneAndUpdate()
+	if returnNew {
+		opts.SetReturnDocument(options.After)
+	} else {
+		opts.SetReturnDocument(options.Before)
+	}
+	if upsert {
+		opts.SetUpsert(true)
+	}
+	if sort, ok := spec["sort"]; ok && sort != nil {
+		opts.SetSort(toBsonDoc(sort))
+	}
+	if fields, ok := spec["fields"]; ok && fields != nil {
+		opts.SetProjection(toBsonDoc(fields))
+	}
+
+	var result bson.M
+	err := coll.FindOneAndUpdate(ec.ctx, filter, convertToBson(update), opts).Decode(&result)
+	if err == mongo.ErrNoDocuments {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("findAndModify: %w", err)
+	}
+	return result, nil
+}

--- a/internal/queryengine/proxy_collection_info_test.go
+++ b/internal/queryengine/proxy_collection_info_test.go
@@ -1,0 +1,55 @@
+package queryengine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectionProxy_InfoMethodsExist(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	val, err := rt.RunString(`
+		const c = db.users;
+		typeof c.stats === 'function' &&
+		typeof c.isCapped === 'function' &&
+		typeof c.dataSize === 'function' &&
+		typeof c.storageSize === 'function' &&
+		typeof c.totalSize === 'function' &&
+		typeof c.totalIndexSize === 'function' &&
+		typeof c.getIndexes === 'function' &&
+		typeof c.count === 'function' &&
+		typeof c.renameCollection === 'function' &&
+		typeof c.validate === 'function' &&
+		typeof c.findAndModify === 'function'
+	`)
+	require.NoError(t, err)
+	assert.Equal(t, true, val.Export())
+}
+
+func TestCollectionProxy_InfoMethods_PanicWithoutClient(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	_, err := rt.RunString(`db.users.stats()`)
+	assert.Error(t, err)
+}
+
+func TestCollectionProxy_RenameCollection_RequiresName(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	_, err := rt.RunString(`db.users.renameCollection()`)
+	assert.Error(t, err)
+}
+
+func TestCollectionProxy_FindAndModify_RequiresSpec(t *testing.T) {
+	rt, _ := setupRuntime(t)
+	_, err := rt.RunString(`db.users.findAndModify()`)
+	assert.Error(t, err)
+}
+
+func TestToInt64(t *testing.T) {
+	assert.Equal(t, int64(5), toInt64(int64(5)))
+	assert.Equal(t, int64(5), toInt64(int32(5)))
+	assert.Equal(t, int64(5), toInt64(int(5)))
+	assert.Equal(t, int64(5), toInt64(float64(5.7)))
+	assert.Equal(t, int64(0), toInt64("not a number"))
+	assert.Equal(t, int64(0), toInt64(nil))
+}


### PR DESCRIPTION
## Summary
- Adds eleven collection methods missing from autocomplete and execution: `stats`, `isCapped`, `dataSize`, `storageSize`, `totalSize`, `totalIndexSize`, `getIndexes`, `count`, `renameCollection`, `validate`, `findAndModify`
- Info methods delegate to `collStats`; `findAndModify` mirrors the mongosh legacy spec and maps to `FindOneAndUpdate`/`FindOneAndDelete`

Closes #132

Lower-priority items deferred per the issue: `watch`, `getPlanCache`, `initializeOrderedBulkOp`/`initializeUnorderedBulkOp`, collection-level `explain()`.

## Test plan
- [x] Unit tests (proxy method presence, arg validation, `toInt64` helper)
- [x] Integration tests (testcontainers mongo:7) covering all eleven methods
- [x] Frontend `bun run lint` passes