### PR TITLE
fix: multi-line expressions in shell query wrapper

### DIFF
--- a/internal/shell/error_remap.go
+++ b/internal/shell/error_remap.go
@@ -1,0 +1,102 @@
+package shell
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// wrapperPrefixOnLine1 is the text the wrapper injects before the first
+// line of the user's body. Error columns on wrapped line 2 (user line 1)
+// need to subtract this length.
+const wrapperPrefixOnLine1 = "const __result = (() => { "
+
+// lineNumberRE matches a source-snippet line in a mongosh error trace, e.g.
+// `  15 |      ]` or `> 17 | return ) })();`. Captures the leading
+// whitespace, optional `>` marker, line number, separator, and source text.
+var lineNumberRE = regexp.MustCompile(`^(\s*)(>?\s*)(\d+)(\s*\|\s*)(.*)$`)
+
+// caretLineRE matches the caret indicator line, e.g. `     | ^`. Captures
+// the leading column (spaces) and the caret itself so we can adjust it
+// when the preceding error line was on wrapped line 2.
+var caretLineRE = regexp.MustCompile(`^(\s*\|\s*)(\^+)(.*)$`)
+
+// remapError rewrites mongosh error output so line numbers and source
+// snippets refer to the user's original query rather than the wrapped
+// script. Lines that point into wrapper code (before the body or after
+// the trailer) are dropped.
+func remapError(errMsg, userQuery string) string {
+	trimmed := strings.TrimSpace(userQuery)
+	if trimmed == "" {
+		return errMsg
+	}
+	userLines := strings.Split(trimmed, "\n")
+	inLines := strings.Split(errMsg, "\n")
+
+	out := make([]string, 0, len(inLines))
+	lastWasHighlight := false
+	lastWasOnFirstUserLine := false
+
+	for _, line := range inLines {
+		if m := lineNumberRE.FindStringSubmatch(line); m != nil {
+			lineNum, err := strconv.Atoi(m[3])
+			if err != nil {
+				out = append(out, line)
+				lastWasHighlight = false
+				continue
+			}
+			userLine := lineNum - 1
+			if userLine < 1 || userLine > len(userLines) {
+				lastWasHighlight = false
+				continue
+			}
+			isHighlight := strings.Contains(m[2], ">")
+			out = append(out, fmt.Sprintf("%s%s%d | %s", m[1], m[2], userLine, userLines[userLine-1]))
+			lastWasHighlight = isHighlight
+			lastWasOnFirstUserLine = isHighlight && userLine == 1
+			continue
+		}
+
+		if lastWasHighlight {
+			if m := caretLineRE.FindStringSubmatch(line); m != nil {
+				if lastWasOnFirstUserLine {
+					out = append(out, adjustCaretColumn(line, m, len(wrapperPrefixOnLine1)))
+				} else {
+					out = append(out, line)
+				}
+				lastWasHighlight = false
+				lastWasOnFirstUserLine = false
+				continue
+			}
+		}
+
+		out = append(out, line)
+		lastWasHighlight = false
+		lastWasOnFirstUserLine = false
+	}
+
+	return strings.Join(out, "\n")
+}
+
+// adjustCaretColumn shifts the caret left by offset columns. If the caret
+// would end up at or before the pipe, it is clamped to the first column
+// after the pipe.
+func adjustCaretColumn(line string, m []string, offset int) string {
+	prefix := m[1]
+	caret := m[2]
+	rest := m[3]
+
+	// prefix is like "     | ". Find the pipe position, then count spaces
+	// between the pipe and caret.
+	pipeIdx := strings.IndexByte(prefix, '|')
+	if pipeIdx < 0 {
+		return line
+	}
+	spacesAfterPipe := len(prefix) - pipeIdx - 1
+	newSpaces := spacesAfterPipe - offset
+	if newSpaces < 1 {
+		newSpaces = 1
+	}
+	return prefix[:pipeIdx+1] + strings.Repeat(" ", newSpaces) + caret + rest
+}

--- a/internal/shell/error_remap_test.go
+++ b/internal/shell/error_remap_test.go
@@ -1,0 +1,108 @@
+package shell
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRemapError_MultiLineCreateRole(t *testing.T) {
+	userQuery := `use admin
+
+db.createRole(
+   {
+     role: "myClusterwideAdmin",
+     privileges: [],
+     roles: [
+       { role: "read", db: "admin" }
+     ]
+   }
+)`
+	// User query is 11 lines; wrapper adds leading empty line, so line 12
+	// of the wrapped script is user line 11 (the closing paren).
+	mongoshErr := `SyntaxError: Unexpected token, expected ","
+
+  10 |    }
+  11 |    }
+> 12 | return ) })();
+     | ^
+  13 | const __val = (typeof __result?.toArray === 'function') ? __result.toArray() : __result;`
+
+	got := remapError(mongoshErr, userQuery)
+
+	if strings.Contains(got, "})();") {
+		t.Errorf("wrapper trailer should be stripped; got:\n%s", got)
+	}
+	if strings.Contains(got, "__val") {
+		t.Errorf("wrapper lines should be stripped; got:\n%s", got)
+	}
+	if !strings.Contains(got, "> 11 | )") {
+		t.Errorf("expected remapped highlight on user line 11 (closing paren); got:\n%s", got)
+	}
+	if !strings.Contains(got, "10 |    }") {
+		t.Errorf("expected context line 10 remapped to user source; got:\n%s", got)
+	}
+}
+
+func TestRemapError_FirstLineErrorAdjustsColumn(t *testing.T) {
+	userQuery := `db.x.find({ bad: })`
+	mongoshErr := `SyntaxError: Unexpected token
+> 2 | const __result = (() => { db.x.find({ bad: }) })();
+    |                                             ^`
+
+	got := remapError(mongoshErr, userQuery)
+
+	if !strings.Contains(got, "> 1 | db.x.find({ bad: })") {
+		t.Errorf("expected user line 1 with original source; got:\n%s", got)
+	}
+	caretLine := findLineContaining(got, "^")
+	if caretLine == "" {
+		t.Fatalf("caret line missing; got:\n%s", got)
+	}
+	pipeIdx := strings.IndexByte(caretLine, '|')
+	caretIdx := strings.IndexByte(caretLine, '^')
+	if caretIdx-pipeIdx >= 30 {
+		t.Errorf("caret column not shifted left; got caret line %q", caretLine)
+	}
+}
+
+func TestRemapError_PlainStderrUnchanged(t *testing.T) {
+	err := `MongoServerError: not authorized on admin to execute command`
+	got := remapError(err, `db.whatever()`)
+	if got != err {
+		t.Errorf("non-trace error should pass through; got %q", got)
+	}
+}
+
+func TestRemapError_EmptyUserQuery(t *testing.T) {
+	got := remapError("anything", "")
+	if got != "anything" {
+		t.Errorf("empty user query should return input unchanged; got %q", got)
+	}
+}
+
+func TestRemapError_ContextLinesBeyondUserSource(t *testing.T) {
+	userQuery := `db.x.find({})`
+	mongoshErr := `SyntaxError: boom
+> 2 | const __result = (() => { db.x.find({}) })();
+  3 | const __val = ...
+  4 | try {`
+	got := remapError(mongoshErr, userQuery)
+	if strings.Contains(got, "__val") {
+		t.Errorf("wrapper context lines should be dropped; got:\n%s", got)
+	}
+	if strings.Contains(got, "try {") {
+		t.Errorf("wrapper context lines should be dropped; got:\n%s", got)
+	}
+	if !strings.Contains(got, "> 1 | db.x.find({})") {
+		t.Errorf("expected user line 1; got:\n%s", got)
+	}
+}
+
+func findLineContaining(s, substr string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, substr) {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -33,20 +33,11 @@ func CheckMongosh() bool {
 // string output for non-serializable results.
 //
 // The query is placed inside an IIFE with "return" prepended to the last
-// statement, so the last expression's value is captured and serialized.
+// top-level statement, so its value is captured and serialized. The start of
+// the last statement is found by scanning the source while tracking bracket
+// depth, strings, and comments — so multi-line expressions are handled.
 func wrapQuery(query string) string {
-	lines := strings.Split(strings.TrimSpace(query), "\n")
-	if len(lines) > 0 {
-		lastLine := strings.TrimSpace(lines[len(lines)-1])
-		// Only prepend return if the last line doesn't already have one
-		// and isn't a control structure or declaration
-		if !strings.HasPrefix(lastLine, "return ") &&
-			!strings.HasPrefix(lastLine, "//") &&
-			!strings.HasPrefix(lastLine, "}") {
-			lines[len(lines)-1] = "return " + lines[len(lines)-1]
-		}
-	}
-	body := strings.Join(lines, "\n")
+	body := prependReturnToLastStatement(strings.TrimSpace(query))
 
 	return fmt.Sprintf(`
 const __result = (() => { %s })();

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -102,7 +102,7 @@ func Execute(ctx context.Context, uri string, query string, cfg Config) (models.
 		}
 		errMsg := stderr.String() + stdout.String()
 		if len(errMsg) > 0 {
-			return models.QueryResult{}, fmt.Errorf("%s", errMsg)
+			return models.QueryResult{}, fmt.Errorf("%s", remapError(errMsg, query))
 		}
 		return models.QueryResult{}, fmt.Errorf("mongosh exited with: %w", err)
 	}

--- a/internal/shell/wrap.go
+++ b/internal/shell/wrap.go
@@ -1,0 +1,140 @@
+package shell
+
+import "strings"
+
+// skipKeywords are statement-starting tokens where prepending "return " would
+// be a syntax error or change meaning. When the last top-level statement
+// begins with one of these, we leave it alone.
+var skipKeywords = []string{
+	"return", "if", "else", "for", "while", "do", "switch", "case",
+	"break", "continue", "throw", "try", "catch", "finally",
+	"function", "class", "const", "let", "var", "import", "export",
+	"use ",
+}
+
+// prependReturnToLastStatement inserts "return " at the start of the final
+// top-level statement in src. Bracket depth, strings, and comments are
+// tracked so multi-line expressions and strings containing semicolons don't
+// confuse the scan. If the final statement begins with a skip keyword or a
+// closing brace, the source is returned unchanged.
+func prependReturnToLastStatement(src string) string {
+	if src == "" {
+		return src
+	}
+
+	start := lastStatementStart(src)
+	stmt := src[start:]
+	if stmt == "" {
+		return src
+	}
+	if stmt[0] == '}' || stmt[0] == '{' {
+		return src
+	}
+	for _, kw := range skipKeywords {
+		if hasKeywordPrefix(stmt, kw) {
+			return src
+		}
+	}
+
+	return src[:start] + "return " + stmt
+}
+
+// hasKeywordPrefix reports whether s begins with kw followed by a
+// non-identifier character (or end of string). Ensures we don't match
+// "returnSomething" when looking for "return".
+func hasKeywordPrefix(s, kw string) bool {
+	if !strings.HasPrefix(s, kw) {
+		return false
+	}
+	if len(s) == len(kw) {
+		return true
+	}
+	c := s[len(kw)]
+	if kw[len(kw)-1] == ' ' {
+		return true
+	}
+	return !isIdentChar(c)
+}
+
+func isIdentChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '$'
+}
+
+// lastStatementStart returns the byte offset of the last top-level statement
+// in src. A statement boundary is a semicolon or newline at bracket depth 0,
+// outside any string or comment.
+func lastStatementStart(src string) int {
+	lastBoundary := 0
+	depth := 0
+	i := 0
+	n := len(src)
+
+	for i < n {
+		c := src[i]
+
+		// Line comment
+		if c == '/' && i+1 < n && src[i+1] == '/' {
+			for i < n && src[i] != '\n' {
+				i++
+			}
+			continue
+		}
+		// Block comment
+		if c == '/' && i+1 < n && src[i+1] == '*' {
+			i += 2
+			for i+1 < n && !(src[i] == '*' && src[i+1] == '/') {
+				i++
+			}
+			if i+1 < n {
+				i += 2
+			} else {
+				i = n
+			}
+			continue
+		}
+		// Strings (single, double, backtick)
+		if c == '\'' || c == '"' || c == '`' {
+			quote := c
+			i++
+			for i < n && src[i] != quote {
+				if src[i] == '\\' && i+1 < n {
+					i += 2
+					continue
+				}
+				i++
+			}
+			if i < n {
+				i++
+			}
+			continue
+		}
+
+		switch c {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case ';', '\n':
+			if depth == 0 {
+				lastBoundary = i + 1
+			}
+		}
+		i++
+	}
+
+	// Advance past any additional whitespace-only / empty lines after the
+	// boundary so we don't end up pointing at blank lines.
+	for lastBoundary < n {
+		c := src[lastBoundary]
+		if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
+			break
+		}
+		lastBoundary++
+	}
+	if lastBoundary > n {
+		lastBoundary = n
+	}
+	return lastBoundary
+}

--- a/internal/shell/wrap_test.go
+++ b/internal/shell/wrap_test.go
@@ -1,0 +1,138 @@
+package shell
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrependReturn_SingleLineExpression(t *testing.T) {
+	got := prependReturnToLastStatement(`db.users.find({})`)
+	want := `return db.users.find({})`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestPrependReturn_MultilineExpression(t *testing.T) {
+	src := `db.createRole(
+  {
+    role: "x",
+    privileges: []
+  }
+)`
+	got := prependReturnToLastStatement(src)
+	if !strings.HasPrefix(got, "return db.createRole(") {
+		t.Errorf("expected return prepended to full createRole call, got: %q", got)
+	}
+	if !strings.Contains(got, `role: "x"`) {
+		t.Errorf("body lost; got: %q", got)
+	}
+}
+
+func TestPrependReturn_MongoshDirectiveFollowedByExpression(t *testing.T) {
+	src := `use admin
+
+db.createRole(
+  { role: "x", privileges: [], roles: [] }
+)`
+	got := prependReturnToLastStatement(src)
+	if !strings.Contains(got, "use admin") {
+		t.Errorf("use directive stripped: %q", got)
+	}
+	if !strings.Contains(got, "return db.createRole(") {
+		t.Errorf("return not prepended to last statement: %q", got)
+	}
+}
+
+func TestPrependReturn_LeadingComments(t *testing.T) {
+	src := `// header comment
+// another
+db.users.find({})`
+	got := prependReturnToLastStatement(src)
+	want := `// header comment
+// another
+return db.users.find({})`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestPrependReturn_AlreadyHasReturn(t *testing.T) {
+	src := `return db.x.find({})`
+	got := prependReturnToLastStatement(src)
+	if got != src {
+		t.Errorf("should not double-prepend; got %q", got)
+	}
+}
+
+func TestPrependReturn_ClosingBraceLeftAlone(t *testing.T) {
+	src := `if (true) {
+  db.x.find({})
+}`
+	got := prependReturnToLastStatement(src)
+	if got != src {
+		t.Errorf("should not prepend return to closing brace; got %q", got)
+	}
+}
+
+func TestPrependReturn_ControlFlowKeywords(t *testing.T) {
+	cases := []string{
+		`const x = 1`,
+		`let y = 2`,
+		`var z = 3`,
+		`if (x) { doThing() }`,
+		`for (const i of xs) { f(i) }`,
+		`function foo() { return 1 }`,
+	}
+	for _, src := range cases {
+		got := prependReturnToLastStatement(src)
+		if got != src {
+			t.Errorf("should not prepend return before keyword; src=%q got=%q", src, got)
+		}
+	}
+}
+
+func TestPrependReturn_StringWithBrackets(t *testing.T) {
+	src := `db.x.find({ name: "a)b(c" })`
+	got := prependReturnToLastStatement(src)
+	want := `return db.x.find({ name: "a)b(c" })`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestPrependReturn_SemicolonSeparatedStatements(t *testing.T) {
+	src := `var a = 1; db.x.find({})`
+	got := prependReturnToLastStatement(src)
+	want := `var a = 1; return db.x.find({})`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestPrependReturn_Empty(t *testing.T) {
+	got := prependReturnToLastStatement("")
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestPrependReturn_CommentWithBrackets(t *testing.T) {
+	src := `// example: db.x.find({ a: 1 })
+db.y.find({})`
+	got := prependReturnToLastStatement(src)
+	want := `// example: db.x.find({ a: 1 })
+return db.y.find({})`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestPrependReturn_TrailingBlankLines(t *testing.T) {
+	src := "db.x.find({})\n\n\n"
+	got := prependReturnToLastStatement(strings.TrimSpace(src))
+	want := `return db.x.find({})`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Problem
Running a multi-line `db.createRole({...})` (or any call where the last line is just a closing bracket) produced a cryptic `SyntaxError: Unexpected token, expected ","` because the wrapper prepended `return` to the final line (`)`), yielding `return )`.

## Fix
Scan the source tracking bracket depth, strings, and comments to find the start of the last top-level statement, then prepend `return` there. Correctly handles:
- Multi-line calls with closing brackets on the last line
- Mongosh `use <db>` directives followed by an expression
- Strings and comments that contain brackets/semicolons
- Control-flow keywords (`if`, `for`, `const`, etc.) left alone

## Test plan
- [x] `go test ./internal/shell/...` — 12 new unit test cases covering multi-line, directives, strings, comments, keywords
- [x] Manual: run the `db.createRole({...})` query from the bug report