### PR TITLE
fix: preserve structured results from eager query methods (#148)

### DIFF
--- a/internal/queryengine/bson_integration_test.go
+++ b/internal/queryengine/bson_integration_test.go
@@ -236,6 +236,47 @@ func TestIntegration_Regex_FindMatchesCorrectly(t *testing.T) {
 	assert.Len(t, result.Documents, 2, "expected 2 documents matching /alice/i")
 }
 
+// --- Issue #148: distinct on int64 field must preserve EJSON structure ---
+
+func TestIntegration_Issue148_DistinctLongs(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+
+	setup := `db.test.insertMany([
+		{ AField: 1, LongId: NumberLong("7151") },
+		{ AField: 1, LongId: NumberLong("11788") },
+		{ AField: 1, LongId: NumberLong("7151") },
+		{ AField: 2, LongId: NumberLong("99999") },
+	])`
+	_, err := engine.ExecuteQuery(ctx, testURI, db, setup)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getCollection("test").distinct("LongId", { AField: 1 })`)
+	require.NoError(t, err)
+
+	assert.Empty(t, result.RawOutput, "distinct result must not be stringified into RawOutput")
+	require.Len(t, result.Documents, 1)
+
+	doc, ok := result.Documents[0].(map[string]any)
+	require.True(t, ok, "expected map document, got %T", result.Documents[0])
+
+	values, ok := doc["values"].([]any)
+	require.True(t, ok, "expected values slice, got %T", doc["values"])
+	assert.Len(t, values, 2)
+
+	for _, v := range values {
+		m, ok := v.(map[string]any)
+		require.True(t, ok, "expected EJSON map for long, got %T", v)
+		_, hasLong := m["$numberLong"]
+		assert.True(t, hasLong, "expected $numberLong key, got %v", m)
+	}
+}
+
 func TestIntegration_Regex_NestedInOperator(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/internal/queryengine/goja_engine.go
+++ b/internal/queryengine/goja_engine.go
@@ -78,7 +78,7 @@ func (e *GojaEngine) ExecuteQuery(ctx context.Context, uri, dbName, query string
 
 		raw := val.Export()
 		if raw != nil {
-			result = models.QueryResult{RawOutput: fmt.Sprintf("%v", raw)}
+			result = exportedToResult(raw)
 		} else if val != nil && !goja.IsUndefined(val) && goja.IsNull(val) {
 			result = models.QueryResult{RawOutput: "null"}
 		}
@@ -86,4 +86,22 @@ func (e *GojaEngine) ExecuteQuery(ctx context.Context, uri, dbName, query string
 	}()
 
 	return result, err
+}
+
+// exportedToResult converts a value exported from the Goja runtime back into a
+// QueryResult. Structured values (arrays/objects) are preserved as Documents so
+// the frontend can render them as a tree/table; scalars fall back to RawOutput.
+func exportedToResult(raw any) models.QueryResult {
+	switch v := raw.(type) {
+	case []any:
+		docs := make([]any, len(v))
+		copy(docs, v)
+		return models.QueryResult{Documents: docs}
+	case map[string]any:
+		return models.QueryResult{Documents: []any{v}}
+	case string:
+		return models.QueryResult{RawOutput: v}
+	default:
+		return models.QueryResult{RawOutput: fmt.Sprintf("%v", raw)}
+	}
 }

--- a/internal/queryengine/goja_engine_test.go
+++ b/internal/queryengine/goja_engine_test.go
@@ -260,6 +260,37 @@ func TestDatabaseProxy_CoreMethods_PanicWithoutClient(t *testing.T) {
 	}
 }
 
+func TestExportedToResult_Slice_PreservesAsDocuments(t *testing.T) {
+	raw := []any{
+		map[string]any{"values": []any{
+			map[string]any{"$numberLong": "7151"},
+			map[string]any{"$numberLong": "11788"},
+		}},
+	}
+	result := exportedToResult(raw)
+	assert.Empty(t, result.RawOutput)
+	require.Len(t, result.Documents, 1)
+	doc, ok := result.Documents[0].(map[string]any)
+	require.True(t, ok)
+	values, ok := doc["values"].([]any)
+	require.True(t, ok)
+	assert.Len(t, values, 2)
+}
+
+func TestExportedToResult_Map_WrapsAsSingleDocument(t *testing.T) {
+	raw := map[string]any{"foo": "bar"}
+	result := exportedToResult(raw)
+	assert.Empty(t, result.RawOutput)
+	require.Len(t, result.Documents, 1)
+	assert.Equal(t, raw, result.Documents[0])
+}
+
+func TestExportedToResult_Scalar_FallsBackToRawOutput(t *testing.T) {
+	result := exportedToResult(int64(42))
+	assert.Empty(t, result.Documents)
+	assert.Equal(t, "42", result.RawOutput)
+}
+
 func TestMultiStatement_VariableThenCursor(t *testing.T) {
 	rt, _ := setupRuntime(t)
 	val, err := rt.RunString(`const filter = { status: "active" }; db.users.find(filter)`)


### PR DESCRIPTION
## Summary
- Fixes #148: `distinct` (and other eager methods like `aggregate`) displayed results as Go-formatted `map[$numberLong:7151]` strings instead of a proper document tree.
- Root cause: eager methods returned `QueryResult.Documents`, which round-tripped through Goja into a JS value. At the end of script execution, `val.Export()` + `fmt.Sprintf("%v", raw)` flattened the structured data into Go's default map-format string.
- Replaces that with `exportedToResult`: slices become `Documents`, maps become a single-document result, scalars still fall back to `RawOutput`.

## Test plan
- [x] Unit tests for `exportedToResult` (slice / map / scalar paths)
- [x] Integration test `TestIntegration_Issue148_DistinctLongs` — inserts `NumberLong` docs, runs `db.getCollection("test").distinct("LongId", { AField: 1 })` through `GojaEngine`, asserts result is structured `Documents` with `{$numberLong: "..."}` EJSON values
- [x] `go test ./...` passes
- [x] `go test -tags integration ./internal/queryengine/...` passes