### PR TITLE
fix: query tab quick wins — shortcuts, limit hint, theme-aware result styling

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,7 @@
+build/
+.idea/
+frontend/dist/
+frontend/node_modules/
+frontend/package.json.md5
+frontend/bun.lock
+.git

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ frontend/dist
 test-results
 .worktrees
 .superpowers
+frontend/.opencode
+AGENTS.md

--- a/frontend/src/features/queries/QueryTab.vue
+++ b/frontend/src/features/queries/QueryTab.vue
@@ -16,6 +16,7 @@ import {
 } from '@heroicons/vue/24/outline'
 import ListTreeIcon from '@/features/icon/ListTreeIcon.vue'
 import { useSettingsStore } from '@/features/settings/settingsStore'
+import { isMacOS } from '@/init/environment'
 import { ref, onMounted, computed, watch, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { CollectionContext } from '@/features/results-document-tree/useDocumentContextMenu'
@@ -38,8 +39,8 @@ const filenameBarStyle = computed(() => ({
 
 const messagesFontSize = computed(() => settingsStore.terminal.font.size || 13)
 
-const messagesFontKey = computed(() =>
-  `${settingsStore.terminal.font.family}-${settingsStore.terminal.font.size}`,
+const messagesFontKey = computed(
+  () => `${settingsStore.terminal.font.family}-${settingsStore.terminal.font.size}`,
 )
 
 const messagesLogStyle = computed(() => {
@@ -81,7 +82,27 @@ const resizeOffset = computed(() => {
   return queryContentRef.value?.getBoundingClientRect().top ?? 0
 })
 
+const modKey = isMacOS() ? 'Cmd' : 'Ctrl'
+
+const runButtonTooltip = computed(() => {
+  if (!queryState.value.selectedDatabase) {
+    return t('errors.no_database_selected')
+  }
+  if (queryStore.mongoshAvailable === false) {
+    return t('errors.shell_not_found')
+  }
+  return `${t('query.run')} (F5 / ${modKey}+Enter)`
+})
+
+const openFileTooltip = computed(() => `${t('query.openFile')} (${modKey}+O)`)
+const saveFileTooltip = computed(() => `${t('query.saveFile')} (${modKey}+S)`)
+const saveFileAsTooltip = computed(() => `${t('query.saveFileAs')} (${modKey}+Shift+S)`)
+
 const hasDocuments = computed(() => queryState.value.documents.length > 0)
+const limitTruncated = computed(() => {
+  const limit = queryState.value.activeLimit
+  return limit !== null && queryState.value.documents.length >= limit
+})
 const hasRawOutput = computed(() => queryState.value.rawOutput !== '')
 const hasExecuted = computed(() => queryState.value.messages.length > 0)
 const hasNoResults = computed(
@@ -193,7 +214,7 @@ watch(
     if (item) {
       item.filePath = newPath ?? undefined
     }
-  }
+  },
 )
 
 onMounted(async () => {
@@ -210,28 +231,36 @@ onMounted(async () => {
       id: 'vervet.openFile',
       label: 'Open File',
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyO],
-      run: () => { openFile() },
+      run: () => {
+        openFile()
+      },
     })
 
     editor.value.addAction({
       id: 'vervet.saveFile',
       label: 'Save File',
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS],
-      run: () => { saveFile() },
+      run: () => {
+        saveFile()
+      },
     })
 
     editor.value.addAction({
       id: 'vervet.saveFileAs',
       label: 'Save File As',
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyS],
-      run: () => { saveFileAs() },
+      run: () => {
+        saveFileAs()
+      },
     })
 
     editor.value.addAction({
       id: 'vervet.runQuery',
       label: 'Run Query',
-      keybindings: [monaco.KeyCode.F5],
-      run: () => { runQuery() },
+      keybindings: [monaco.KeyCode.F5, monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+      run: () => {
+        runQuery()
+      },
     })
 
     editor.value.onDidChangeModelContent(() => {
@@ -263,20 +292,24 @@ watch(
     <div class="toolbar">
       <n-space align="center">
         <span class="database-label">
-          {{ t('query.database') }}: <strong>{{ queryState.selectedDatabase }}</strong>
+          {{ t('query.database') }}:
+          <strong>{{ queryState.selectedDatabase }}</strong>
         </span>
-        <n-button
-          v-if="!queryState.loading"
-          type="primary"
-          size="small"
-          :disabled="!queryState.selectedDatabase || queryStore.mongoshAvailable === false"
-          @click="runQuery"
-        >
-          <template #icon>
-            <n-icon :component="PlayIcon" />
+        <n-tooltip v-if="!queryState.loading" delay="800">
+          <template #trigger>
+            <n-button
+              type="primary"
+              size="small"
+              :disabled="!queryState.selectedDatabase || queryStore.mongoshAvailable === false"
+              @click="runQuery">
+              <template #icon>
+                <n-icon :component="PlayIcon" />
+              </template>
+              {{ t('query.run') }}
+            </n-button>
           </template>
-          {{ t('query.run') }}
-        </n-button>
+          {{ runButtonTooltip }}
+        </n-tooltip>
         <n-button v-else type="warning" size="small" @click="cancelQuery">
           <template #icon>
             <n-icon :component="StopIcon" />
@@ -293,7 +326,7 @@ watch(
               </template>
             </n-button>
           </template>
-          {{ t('query.openFile') }}
+          {{ openFileTooltip }}
         </n-tooltip>
         <n-tooltip>
           <template #trigger>
@@ -303,7 +336,7 @@ watch(
               </template>
             </n-button>
           </template>
-          {{ t('query.saveFile') }}
+          {{ saveFileTooltip }}
         </n-tooltip>
         <n-tooltip>
           <template #trigger>
@@ -313,14 +346,18 @@ watch(
               </template>
             </n-button>
           </template>
-          {{ t('query.saveFileAs') }}
+          {{ saveFileAsTooltip }}
         </n-tooltip>
       </n-space>
     </div>
     <div v-if="queryStore.mongoshAvailable === false" class="mongosh-warning">
-      {{ t('query.mongoshNotFound') }}
+      {{ t('errors.shell_not_found') }}
     </div>
-    <div v-if="queryState.filePath" class="filename-bar" :style="filenameBarStyle" :title="queryState.filePath">
+    <div
+      v-if="queryState.filePath"
+      class="filename-bar"
+      :style="filenameBarStyle"
+      :title="queryState.filePath">
       <span class="filename-text">{{ fileName }}</span>
       <span v-if="queryState.isDirty" class="dirty-indicator">&bull;</span>
     </div>
@@ -328,8 +365,7 @@ watch(
       <vertical-resizeable-wrapper
         v-model:size="editorHeight"
         :min-size="100"
-        :offset="resizeOffset"
-      >
+        :offset="resizeOffset">
         <div class="editor-pane">
           <div ref="editorContainer" class="monaco-container" />
         </div>
@@ -341,17 +377,18 @@ watch(
           size="small"
           :animated="false"
           :closable="false"
-          pane-style="display: flex; flex-direction: column; flex: 1; min-height: 0; padding-top: 0;"
-        >
+          pane-style="display: flex; flex-direction: column; flex: 1; min-height: 0; padding-top: 0;">
           <template #suffix>
-            <n-space v-if="hasDocuments && queryState.activeResultTab === 'results'" :size="4" style="margin-right: 8px">
+            <n-space
+              v-if="hasDocuments && queryState.activeResultTab === 'results'"
+              :size="4"
+              style="margin-right: 8px">
               <n-tooltip>
                 <template #trigger>
                   <n-button
                     size="small"
                     :type="queryState.resultView === 'table' ? 'primary' : 'default'"
-                    @click="setResultView('table')"
-                  >
+                    @click="setResultView('table')">
                     <template #icon>
                       <n-icon :component="ListTreeIcon" />
                     </template>
@@ -364,8 +401,7 @@ watch(
                   <n-button
                     size="small"
                     :type="queryState.resultView === 'json' ? 'primary' : 'default'"
-                    @click="setResultView('json')"
-                  >
+                    @click="setResultView('json')">
                     <template #icon>
                       <n-icon :component="CodeBracketIcon" />
                     </template>
@@ -374,14 +410,13 @@ watch(
                 {{ t('query.jsonView') }}
               </n-tooltip>
             </n-space>
-            <n-space v-if="queryState.activeResultTab === 'messages'" :size="4" style="margin-right: 8px">
+            <n-space
+              v-if="queryState.activeResultTab === 'messages'"
+              :size="4"
+              style="margin-right: 8px">
               <n-tooltip>
                 <template #trigger>
-                  <n-button
-                    size="small"
-                    :disabled="!queryState.messages"
-                    @click="clearMessages"
-                  >
+                  <n-button size="small" :disabled="!queryState.messages" @click="clearMessages">
                     <template #icon>
                       <n-icon :component="TrashIcon" />
                     </template>
@@ -407,6 +442,9 @@ watch(
               queryState.error
             }}</pre>
             <template v-else-if="hasDocuments">
+              <div v-if="limitTruncated" class="limit-hint">
+                {{ t('query.limitInEffect', { limit: queryState.activeLimit }) }}
+              </div>
               <div v-if="queryState.resultView === 'table'" class="structured-results">
                 <document-tree-table
                   :documents="queryState.documents"
@@ -431,8 +469,7 @@ watch(
               :font-size="messagesFontSize"
               :style="messagesLogStyle"
               language="vervet-log"
-              trim
-            />
+              trim />
           </n-tab-pane>
         </n-tabs>
       </div>
@@ -595,6 +632,15 @@ watch(
     user-select: text;
     cursor: text;
   }
+}
+
+.limit-hint {
+  flex-shrink: 0;
+  padding: 4px 8px;
+  font-size: 12px;
+  color: var(--n-text-color-3);
+  background-color: color-mix(in srgb, var(--n-warning-color) 12%, transparent);
+  border-bottom: 1px solid var(--n-border-color);
 }
 
 .structured-results {

--- a/frontend/src/features/queries/queryStore.ts
+++ b/frontend/src/features/queries/queryStore.ts
@@ -47,6 +47,8 @@ export interface QueryState {
   isDirty: boolean
   savedContent: string | null
   currentContent: string
+  /** The limit() from the last executed query, when the result may be truncated */
+  activeLimit: number | null
   /** Lazily computed JSON — only populated when the JSON view is first accessed */
   _rawJsonCache: string | null
 }
@@ -75,8 +77,18 @@ function createQueryState(database: string): QueryState {
     isDirty: false,
     savedContent: null,
     currentContent: '',
+    activeLimit: null,
     _rawJsonCache: null,
   }
+}
+
+function parseLimit(query: string): number | null {
+  const match = query.match(/\.limit\s*\(\s*(\d+)\s*\)/)
+  if (!match) {
+    return null
+  }
+  const n = Number(match[1])
+  return Number.isFinite(n) && n > 0 ? n : null
 }
 
 export const useQueryStore = defineStore('query', {
@@ -179,16 +191,13 @@ export const useQueryStore = defineStore('query', {
       state.rawOutput = ''
       state.error = ''
       state.selectedDocIndex = 0
+      state.activeLimit = parseLimit(query)
       state.messages += `${timestamp} [INFO] ${i18nGlobal.t('query.messages.executing')}\n`
 
       const startTime = Date.now()
 
       try {
-        const result = await shellProxy.ExecuteQuery(
-          serverId,
-          state.selectedDatabase,
-          query,
-        )
+        const result = await shellProxy.ExecuteQuery(serverId, state.selectedDatabase, query)
 
         if (state.cancelled || state.executionId !== thisExecution) {
           return
@@ -273,14 +282,11 @@ export const useQueryStore = defineStore('query', {
     },
 
     async openFile(queryId: string): Promise<string | null> {
-      const result = await filesProxy.SelectFile(
-        i18nGlobal.t('query.openFileDialogTitle'),
-        [
-          { displayName: i18nGlobal.t('query.filterJavascript'), pattern: '*.js' },
-          { displayName: i18nGlobal.t('query.filterMongodb'), pattern: '*.mongodb' },
-          { displayName: i18nGlobal.t('query.filterAllFiles'), pattern: '*.*' },
-        ],
-      )
+      const result = await filesProxy.SelectFile(i18nGlobal.t('query.openFileDialogTitle'), [
+        { displayName: i18nGlobal.t('query.filterJavascript'), pattern: '*.js' },
+        { displayName: i18nGlobal.t('query.filterMongodb'), pattern: '*.mongodb' },
+        { displayName: i18nGlobal.t('query.filterAllFiles'), pattern: '*.*' },
+      ])
       if (!result.isSuccess || !result.data) {
         return null
       }

--- a/frontend/src/features/queries/typeColorMap.ts
+++ b/frontend/src/features/queries/typeColorMap.ts
@@ -1,4 +1,4 @@
-export const typeColorMap: Record<string, string> = {
+export const typeColorMapDark: Record<string, string> = {
   string: '#ce9178',
   int32: '#b5cea8',
   double: '#b5cea8',
@@ -20,3 +20,27 @@ export const typeColorMap: Record<string, string> = {
   object: 'var(--n-td-text-color)',
   array: 'var(--n-td-text-color)',
 }
+
+export const typeColorMapLight: Record<string, string> = {
+  string: '#a31515',
+  int32: '#098658',
+  double: '#098658',
+  long: '#098658',
+  decimal128: '#098658',
+  boolean: '#0550ae',
+  null: '#6a6a6a',
+  objectId: '#795e26',
+  date: '#af00db',
+  binary: '#6a6a6a',
+  uuid: '#795e26',
+  uuidLegacy: '#795e26',
+  md5: '#6a6a6a',
+  regex: '#cc3333',
+  timestamp: '#098658',
+  minKey: '#6a6a6a',
+  maxKey: '#6a6a6a',
+  document: 'var(--n-td-text-color)',
+  object: 'var(--n-td-text-color)',
+  array: 'var(--n-td-text-color)',
+}
+

--- a/frontend/src/features/results-document-tree/DocumentTreeTable.vue
+++ b/frontend/src/features/results-document-tree/DocumentTreeTable.vue
@@ -1,11 +1,12 @@
 <script lang="ts" setup>
 import { computed, h, onBeforeUnmount, onMounted, reactive, ref, toRef, watch, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { DataTableColumns, DataTableRowKey } from 'naive-ui'
+import { type DataTableColumns, type DataTableRowKey, useDialog, useThemeVars } from 'naive-ui'
 import { buildTreeData } from './documentTreeUtils'
 import type { DocumentRow } from './types'
-import { typeColorMap } from '@/features/queries/typeColorMap'
+import { typeColorMapDark, typeColorMapLight } from '@/features/queries/typeColorMap'
 import { useDocumentContextMenu, type CollectionContext } from './useDocumentContextMenu'
+import { useSettingsStore } from '@/features/settings/settingsStore'
 import { useNotifier } from '@/utils/dialog'
 import { resolveRawValue } from './resolveRawValue'
 import { humanizeEjson, toJsExpression } from './humanizeEjson'
@@ -30,6 +31,16 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const themeVars = useThemeVars()
+const settingsStore = useSettingsStore()
+
+const typeColorMap = computed(() =>
+  settingsStore.isDark ? typeColorMapDark : typeColorMapLight,
+)
+
+const wrapperStyle = computed(() => ({
+  '--vervet-selection-bg': `color-mix(in srgb, ${themeVars.value.primaryColor} 24%, transparent)`,
+}))
 
 const treeData = computed(() => buildTreeData(props.documents))
 
@@ -38,7 +49,9 @@ const checkedKeys = ref<DataTableRowKey[]>([])
 
 // Context menu
 const collectionContextRef = toRef(props, 'collectionContext')
-const contextMenu = useDocumentContextMenu(collectionContextRef as Ref<CollectionContext | undefined>)
+const contextMenu = useDocumentContextMenu(
+  collectionContextRef as Ref<CollectionContext | undefined>,
+)
 const notifier = useNotifier()
 const dialog = useDialog()
 
@@ -53,7 +66,11 @@ const viewDocument = ref<unknown>(null)
 const editDocument = ref<unknown>(null)
 const editMode = ref<'edit' | 'insert'>('edit')
 
-function collectKeysToDepth(rows: DocumentRow[], depth: number, currentDepth: number = 0): string[] {
+function collectKeysToDepth(
+  rows: DocumentRow[],
+  depth: number,
+  currentDepth: number = 0,
+): string[] {
   if (currentDepth >= depth) {
     return []
   }
@@ -67,12 +84,16 @@ function collectKeysToDepth(rows: DocumentRow[], depth: number, currentDepth: nu
   return keys
 }
 
-watch(treeData, (data) => {
-  if (data.length > 0) {
-    const depth = props.defaultExpandDepth ?? 0
-    expandedKeys.value = collectKeysToDepth(data, depth)
-  }
-}, { immediate: true })
+watch(
+  treeData,
+  (data) => {
+    if (data.length > 0) {
+      const depth = props.defaultExpandDepth ?? 0
+      expandedKeys.value = collectKeysToDepth(data, depth)
+    }
+  },
+  { immediate: true },
+)
 
 const pagination = reactive({
   page: 1,
@@ -121,7 +142,7 @@ const columns = computed<DataTableColumns<DocumentRow>>(() => [
         'span',
         {
           style: {
-            color: typeColorMap[row.type] ?? 'var(--',
+            color: typeColorMap.value[row.type] ?? 'var(--n-td-text-color)',
             userSelect: 'text',
             cursor: 'text',
           },
@@ -193,7 +214,10 @@ function handleContextMenuSelect(key: string) {
         if (result.isSuccess) {
           emit('document-changed')
         } else {
-          notifier.error(t(`errors.${result.errorCode}`), { title: t('errorTitles.deleteDocument'), detail: result.errorDetail })
+          notifier.error(t(`errors.${result.errorCode}`), {
+            title: t('errorTitles.deleteDocument'),
+            detail: result.errorDetail,
+          })
         }
       },
     })
@@ -312,7 +336,7 @@ function rowClassName(row: DocumentRow): string {
 </script>
 
 <template>
-  <div ref="tableWrapper" class="table-wrapper" tabindex="-1">
+  <div ref="tableWrapper" class="table-wrapper" :style="wrapperStyle" tabindex="-1">
     <n-data-table
       :columns="columns"
       :data="treeData"
@@ -330,29 +354,29 @@ function rowClassName(row: DocumentRow): string {
       size="small"
       @update:expanded-row-keys="handleExpandedKeysUpdate"
       @update:checked-row-keys="handleCheckedKeysUpdate" />
-  <template v-if="enableContextMenu">
-    <DocumentContextMenu
-      :show="contextMenu.showMenu.value"
-      :x="contextMenu.menuX.value"
-      :y="contextMenu.menuY.value"
-      :options="contextMenu.menuOptions.value"
-      @select="handleContextMenuSelect"
-      @close="contextMenu.closeMenu" />
-    <DocumentViewDialog
-      v-model:show="showViewDialog"
-      :document="viewDocument"
-      :can-edit="!!collectionContext"
-      @edit="switchToEdit" />
-    <DocumentEditDialog
-      v-if="collectionContext"
-      v-model:show="showEditDialog"
-      :document="editDocument"
-      :mode="editMode"
-      :server-id="collectionContext.serverId"
-      :db-name="collectionContext.dbName"
-      :collection-name="collectionContext.collectionName"
-      @saved="handleDocumentSaved" />
-  </template>
+    <template v-if="enableContextMenu">
+      <DocumentContextMenu
+        :show="contextMenu.showMenu.value"
+        :x="contextMenu.menuX.value"
+        :y="contextMenu.menuY.value"
+        :options="contextMenu.menuOptions.value"
+        @select="handleContextMenuSelect"
+        @close="contextMenu.closeMenu" />
+      <DocumentViewDialog
+        v-model:show="showViewDialog"
+        :document="viewDocument"
+        :can-edit="!!collectionContext"
+        @edit="switchToEdit" />
+      <DocumentEditDialog
+        v-if="collectionContext"
+        v-model:show="showEditDialog"
+        :document="editDocument"
+        :mode="editMode"
+        :server-id="collectionContext.serverId"
+        :db-name="collectionContext.dbName"
+        :collection-name="collectionContext.collectionName"
+        @saved="handleDocumentSaved" />
+    </template>
   </div>
 </template>
 
@@ -366,7 +390,7 @@ function rowClassName(row: DocumentRow): string {
   background-color: var(--n-td-color-hover) !important;
 }
 :deep(.selected-row td) {
-  background-color: greenyellow !important;
+  background-color: var(--vervet-selection-bg) !important;
 }
 
 :deep(.n-data-table) {

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -333,6 +333,7 @@ export default {
     emptyState: 'Right-click a database or collection to open a query',
     noResults: 'No documents returned',
     documentCount: '{count} document(s)',
+    limitInEffect: 'Limit {limit} in effect — more documents may exist',
     key: 'Key',
     field: 'Field',
     value: 'Value',


### PR DESCRIPTION
## Summary
- Cmd/Ctrl+Enter and F5 both run queries; run/open/save buttons now show their shortcut in a tooltip.
- Results pane shows a "Limit in effect — more documents may exist" banner when the query ran with a `.limit(n)` and the result set fills that cap.
- Replaced the hardcoded `greenyellow` selected-row background with a theme-aware `color-mix` over the primary colour, so selection reads correctly in both light and dark themes.
- Split the document-tree type colour palette into dark (VS Code Dark+) and light (VS Code Light+ inspired) variants, chosen reactively from `settingsStore.isDark`. Int32 values in the light theme were previously near-invisible against the selection highlight.
- Minor: consolidated the mongosh-missing warning to use the shared `errors.shell_not_found` key.

## Test plan
- [x] `bun run lint` passes (eslint + vue-tsc)
- [x] Verified light + dark theme selection highlight via Playwright against `wails dev`
- [x] Verified type colours in both themes (string, int32, double, boolean, objectId)
- [x] Manual: run a real query with `.limit(25)` and confirm the limit banner appears
- [x] Manual: Cmd+Enter / Ctrl+Enter in the editor triggers the query
- [ ] Manual: tooltips on Run / Open / Save show the correct modifier on macOS vs Linux/Windows