### PR TITLE
chore: bump version to 2026.04.5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vervet",
-  "version": "2026.04.4",
+  "version": "2026.04.5",
   "description": "A desktop Mongo DB tool",
   "productName": "Vervet",
   "author": "Sean Garrett <sean@blacktau.com>",

--- a/wails.json
+++ b/wails.json
@@ -11,7 +11,7 @@
     "email": "sean@blacktau.com"
   },
   "info": {
-    "productVersion": "2026.04.4",
+    "productVersion": "2026.04.5",
     "productName": "Vervet",
     "companyName": "Blacktau",
     "copyright": "Copyright 2026 Sean Garrett",


### PR DESCRIPTION
## Summary
- Bumps `wails.json` and `frontend/package.json` to `2026.04.5`
- Prep for `v2026.04.5` release tag

## Test plan
- [x] Merge, then tag `v2026.04.5` on `main` to trigger the release workflow