### PR TITLE
Type-to-confirm dialogs for destructive actions

### DIFF
--- a/frontend/src/app/App.vue
+++ b/frontend/src/app/App.vue
@@ -15,6 +15,7 @@ import AddDatabaseDialog from '@/features/data-browser/AddDatabaseDialog.vue'
 import AddCollectionDialog from '@/features/data-browser/AddCollectionDialog.vue'
 import CreateIndexDialog from '@/features/indexes/CreateIndexDialog.vue'
 import RenameCollectionDialog from '@/features/data-browser/RenameCollectionDialog.vue'
+import DestructiveConfirmDialog from '@/features/data-browser/DestructiveConfirmDialog.vue'
 import ServerPickerDialog from '@/features/workspaces/ServerPickerDialog.vue'
 import { useDataBrowserStore } from '@/features/data-browser/browserStore.ts'
 import { DialogType, useDialogStore } from '@/stores/dialog.ts'
@@ -104,6 +105,7 @@ watch(
         <add-collection-dialog v-if="dialogStore.isVisible(DialogType.AddCollection)" />
         <create-index-dialog v-if="dialogStore.isVisible(DialogType.CreateIndex)" />
         <rename-collection-dialog v-if="dialogStore.isVisible(DialogType.RenameCollection)" />
+        <destructive-confirm-dialog v-if="dialogStore.isVisible(DialogType.DestructiveConfirm)" />
         <server-picker-dialog v-if="dialogStore.isVisible(DialogType.ServerPicker)" />
       </n-dialog-provider>
     </n-notification-provider>

--- a/frontend/src/features/data-browser/DataBrowserTree.vue
+++ b/frontend/src/features/data-browser/DataBrowserTree.vue
@@ -11,6 +11,11 @@ import { useTabStore } from '@/features/tabs/tabs.ts'
 import DataTreeContextMenu from '@/features/data-browser/DataTreeContextMenu.vue'
 import { useDialogStore } from '@/stores/dialog.ts'
 import { useNotifier } from '@/utils/dialog.ts'
+import {
+  readCollectionImpact,
+  readDbImpact,
+  shouldEscalateCollectionDrop,
+} from '@/features/data-browser/statsImpact.ts'
 import * as collectionsProxy from 'wailsjs/go/api/CollectionsProxy'
 import * as databasesProxy from 'wailsjs/go/api/DatabasesProxy'
 
@@ -82,7 +87,7 @@ const renderPrefix = ({ option }: { option: DataTreeNode }) => {
   return null
 }
 
-function handleContextMenuSelect(key: string) {
+async function handleContextMenuSelect(key: string) {
   const node = contextMenu.selectedNode.value
   if (!node) return
 
@@ -174,15 +179,22 @@ function handleContextMenuSelect(key: string) {
       const serverId = parts[0]
       const dbName = parts[1]
       if (serverId && dbName) {
-        dialog.warning({
-          title: t('common.warning'),
-          content: t('dataBrowser.dialogs.dropDatabase.message', { name: dbName }),
-          positiveText: t('common.confirm'),
-          negativeText: t('common.cancel'),
-          onPositiveClick: async () => {
+        const statsResult = await databasesProxy.GetDatabaseStatistics(serverId, dbName)
+        const impact =
+          statsResult.isSuccess && statsResult.data
+            ? readDbImpact(statsResult.data as Record<string, unknown>)
+            : {}
+        dialogStore.openDestructiveConfirmDialog({
+          kind: 'database',
+          name: dbName,
+          impact,
+          onConfirm: async () => {
             const result = await databasesProxy.DropDatabase(serverId, dbName)
             if (!result.isSuccess) {
-              notifier.error(t(`errors.${result.errorCode}`), { title: t('errorTitles.dropDatabase'), detail: result.errorDetail })
+              notifier.error(t(`errors.${result.errorCode}`), {
+                title: t('errorTitles.dropDatabase'),
+                detail: result.errorDetail,
+              })
               return
             }
             await browserStore.refreshServerDatabases(serverId)
@@ -219,20 +231,48 @@ function handleContextMenuSelect(key: string) {
       const dbName = parts[1]
       const collectionName = parts[3]
       if (serverId && dbName && collectionName) {
-        dialog.warning({
-          title: t('common.warning'),
-          content: t('dataBrowser.dialogs.dropCollection.message', { name: collectionName }),
-          positiveText: t('common.confirm'),
-          negativeText: t('common.cancel'),
-          onPositiveClick: async () => {
-            const result = await collectionsProxy.DropCollection(serverId, dbName, collectionName)
-            if (!result.isSuccess) {
-              notifier.error(t(`errors.${result.errorCode}`), { title: t('errorTitles.dropCollection'), detail: result.errorDetail })
-              return
-            }
-            await browserStore.refreshDatabaseCollections(serverId, dbName)
-          },
-        })
+        const isView = node.type === DataNodeType.View
+        let impact: { documentCount?: number } = {}
+        let statsFetchFailed = false
+        if (!isView) {
+          const statsResult = await collectionsProxy.GetStatistics(serverId, dbName, collectionName)
+          if (statsResult.isSuccess && statsResult.data) {
+            impact = readCollectionImpact(statsResult.data as Record<string, unknown>)
+          } else {
+            statsFetchFailed = true
+          }
+        }
+        const documentCount = statsFetchFailed ? undefined : impact.documentCount
+        const escalate = shouldEscalateCollectionDrop({ isView, documentCount })
+
+        const doDrop = async () => {
+          const result = await collectionsProxy.DropCollection(serverId, dbName, collectionName)
+          if (!result.isSuccess) {
+            notifier.error(t(`errors.${result.errorCode}`), {
+              title: t('errorTitles.dropCollection'),
+              detail: result.errorDetail,
+            })
+            return
+          }
+          await browserStore.refreshDatabaseCollections(serverId, dbName)
+        }
+
+        if (escalate) {
+          dialogStore.openDestructiveConfirmDialog({
+            kind: 'collection',
+            name: collectionName,
+            impact,
+            onConfirm: doDrop,
+          })
+        } else {
+          dialog.warning({
+            title: t('common.warning'),
+            content: t('dataBrowser.dialogs.dropCollection.message', { name: collectionName }),
+            positiveText: t('common.confirm'),
+            negativeText: t('common.cancel'),
+            onPositiveClick: doDrop,
+          })
+        }
       }
     }
   }

--- a/frontend/src/features/data-browser/DestructiveConfirmDialog.vue
+++ b/frontend/src/features/data-browser/DestructiveConfirmDialog.vue
@@ -7,10 +7,8 @@ import {
   useDialogStore,
   type DestructiveConfirmData,
 } from '@/stores/dialog.ts'
-import { useNotifier } from '@/utils/dialog.ts'
 
 const dialogStore = useDialogStore()
-const notifier = useNotifier()
 const { t } = useI18n()
 
 const formRef = ref<FormInst | null>(null)
@@ -111,15 +109,9 @@ async function onConfirm() {
   }
 
   loading.value = true
-  try {
-    await data.value.onConfirm()
-  } catch (e) {
-    const err = e as Error
-    notifier.error(err.message)
-  } finally {
-    loading.value = false
-    dialogStore.closeDestructiveConfirmDialog()
-  }
+  await data.value.onConfirm()
+  loading.value = false
+  dialogStore.closeDestructiveConfirmDialog()
   return false
 }
 

--- a/frontend/src/features/data-browser/DestructiveConfirmDialog.vue
+++ b/frontend/src/features/data-browser/DestructiveConfirmDialog.vue
@@ -1,0 +1,180 @@
+<script lang="ts" setup>
+import { computed, reactive, ref, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { type FormInst, type FormItemRule } from 'naive-ui'
+import {
+  DialogType,
+  useDialogStore,
+  type DestructiveConfirmData,
+} from '@/stores/dialog.ts'
+import { useNotifier } from '@/utils/dialog.ts'
+
+const dialogStore = useDialogStore()
+const notifier = useNotifier()
+const { t } = useI18n()
+
+const formRef = ref<FormInst | null>(null)
+const loading = ref(false)
+
+const form = reactive({
+  typedName: '',
+})
+
+const data = ref<DestructiveConfirmData | null>(null)
+
+watchEffect(() => {
+  if (dialogStore.dialogs[DialogType.DestructiveConfirm].visible) {
+    data.value = dialogStore.getDialogData<DestructiveConfirmData>(DialogType.DestructiveConfirm) ?? null
+    form.typedName = ''
+    loading.value = false
+  } else {
+    data.value = null
+  }
+})
+
+const matches = computed(() => {
+  if (!data.value) {
+    return false
+  }
+  return form.typedName.trim() === data.value.name
+})
+
+const formRules = computed(() => ({
+  typedName: [
+    {
+      validator: (_rule: FormItemRule, value: string) => {
+        if (!data.value) {
+          return false
+        }
+        return (value ?? '').trim() === data.value.name
+      },
+      message: t('dataBrowser.dialogs.destructiveConfirm.mismatchHelp'),
+      trigger: 'input',
+    },
+  ],
+}))
+
+const title = computed(() => {
+  if (!data.value) {
+    return ''
+  }
+  return t(`dataBrowser.dialogs.destructiveConfirm.${data.value.kind}.title`)
+})
+
+const inputLabel = computed(() => {
+  if (!data.value) {
+    return ''
+  }
+  return t(`dataBrowser.dialogs.destructiveConfirm.${data.value.kind}.inputLabel`)
+})
+
+const impactText = computed(() => {
+  if (!data.value) {
+    return ''
+  }
+  const { kind, impact } = data.value
+  if (kind === 'database') {
+    const hasCollections = typeof impact.collectionCount === 'number'
+    const hasDocs = typeof impact.documentCount === 'number'
+    if (hasCollections && hasDocs) {
+      return t('dataBrowser.dialogs.destructiveConfirm.database.impactWithCounts', {
+        collections: impact.collectionCount!.toLocaleString(),
+        documents: impact.documentCount!.toLocaleString(),
+      })
+    }
+    if (hasCollections) {
+      return t('dataBrowser.dialogs.destructiveConfirm.database.impactCollectionsOnly', {
+        collections: impact.collectionCount!.toLocaleString(),
+      })
+    }
+    return t('dataBrowser.dialogs.destructiveConfirm.database.impactUnavailable')
+  }
+  if (typeof impact.documentCount === 'number') {
+    return t('dataBrowser.dialogs.destructiveConfirm.collection.impactDocuments', {
+      documents: impact.documentCount.toLocaleString(),
+    })
+  }
+  return t('dataBrowser.dialogs.destructiveConfirm.collection.impactUnavailable')
+})
+
+async function onConfirm() {
+  if (!data.value) {
+    return false
+  }
+  try {
+    await formRef.value?.validate()
+  } catch {
+    return false
+  }
+  if (!matches.value) {
+    return false
+  }
+
+  loading.value = true
+  try {
+    await data.value.onConfirm()
+  } catch (e) {
+    const err = e as Error
+    notifier.error(err.message)
+  } finally {
+    loading.value = false
+    dialogStore.closeDestructiveConfirmDialog()
+  }
+  return false
+}
+
+function onClose() {
+  dialogStore.closeDestructiveConfirmDialog()
+}
+</script>
+
+<template>
+  <n-modal
+    v-if="data"
+    v-model:show="dialogStore.dialogs[DialogType.DestructiveConfirm].visible"
+    :closable="false"
+    :mask-closable="false"
+    :negative-button-props="{ size: 'medium', disabled: loading }"
+    :negative-text="$t('dataBrowser.dialogs.destructiveConfirm.cancel')"
+    :positive-button-props="{
+      size: 'medium',
+      type: 'error',
+      disabled: !matches || loading,
+      loading: loading,
+    }"
+    :positive-text="$t('dataBrowser.dialogs.destructiveConfirm.confirm')"
+    :show-icon="false"
+    :title="title"
+    close-on-esc
+    preset="dialog"
+    transform-origin="center"
+    @esc="onClose"
+    @positive-click="onConfirm"
+    @negative-click="onClose">
+    <n-space vertical :size="16">
+      <n-alert type="warning" :bordered="false" :show-icon="true">
+        <i18n-t
+          :keypath="`dataBrowser.dialogs.destructiveConfirm.${data.kind}.warning`"
+          tag="span">
+          <template #name>
+            <n-text code>{{ data.name }}</n-text>
+          </template>
+        </i18n-t>
+      </n-alert>
+      <n-text depth="2">{{ impactText }}</n-text>
+      <n-form
+        ref="formRef"
+        :model="form"
+        :rules="formRules"
+        :show-require-mark="false"
+        label-placement="top">
+        <n-form-item :label="inputLabel" path="typedName">
+          <n-input
+            v-model:value="form.typedName"
+            :placeholder="data.name"
+            :autofocus="true" />
+        </n-form-item>
+      </n-form>
+    </n-space>
+  </n-modal>
+</template>

--- a/frontend/src/features/data-browser/statsImpact.ts
+++ b/frontend/src/features/data-browser/statsImpact.ts
@@ -1,0 +1,38 @@
+export type DbImpact = {
+  collectionCount?: number
+  documentCount?: number
+}
+
+export type CollectionImpact = {
+  documentCount?: number
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+export function readDbImpact(stats: Record<string, unknown>): DbImpact {
+  return {
+    collectionCount: asNumber(stats.collections),
+    documentCount: asNumber(stats.objects),
+  }
+}
+
+export function readCollectionImpact(stats: Record<string, unknown>): CollectionImpact {
+  return {
+    documentCount: asNumber(stats.count),
+  }
+}
+
+export function shouldEscalateCollectionDrop(input: {
+  isView: boolean
+  documentCount: number | undefined
+}): boolean {
+  if (input.isView) {
+    return false
+  }
+  if (input.documentCount === 0) {
+    return false
+  }
+  return true
+}

--- a/frontend/src/features/data-browser/tests/statsImpact.test.ts
+++ b/frontend/src/features/data-browser/tests/statsImpact.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'vitest'
+import {
+  readCollectionImpact,
+  readDbImpact,
+  shouldEscalateCollectionDrop,
+} from '@/features/data-browser/statsImpact.ts'
+
+describe('readDbImpact', () => {
+  test('extracts collections and objects when both are numbers', () => {
+    expect(readDbImpact({ collections: 14, objects: 412532 })).toEqual({
+      collectionCount: 14,
+      documentCount: 412532,
+    })
+  })
+
+  test('returns undefined fields when values are missing', () => {
+    expect(readDbImpact({})).toEqual({
+      collectionCount: undefined,
+      documentCount: undefined,
+    })
+  })
+
+  test('returns undefined fields when values are not numbers', () => {
+    expect(readDbImpact({ collections: '14', objects: null })).toEqual({
+      collectionCount: undefined,
+      documentCount: undefined,
+    })
+  })
+
+  test('handles only one field being present', () => {
+    expect(readDbImpact({ collections: 3 })).toEqual({
+      collectionCount: 3,
+      documentCount: undefined,
+    })
+  })
+})
+
+describe('readCollectionImpact', () => {
+  test('extracts count when it is a number', () => {
+    expect(readCollectionImpact({ count: 42 })).toEqual({ documentCount: 42 })
+  })
+
+  test('returns undefined when count is missing', () => {
+    expect(readCollectionImpact({})).toEqual({ documentCount: undefined })
+  })
+
+  test('returns undefined when count is not a number', () => {
+    expect(readCollectionImpact({ count: 'many' })).toEqual({ documentCount: undefined })
+  })
+})
+
+describe('shouldEscalateCollectionDrop', () => {
+  test('does not escalate for views', () => {
+    expect(shouldEscalateCollectionDrop({ isView: true, documentCount: 1_000_000 })).toBe(false)
+  })
+
+  test('does not escalate for empty collections', () => {
+    expect(shouldEscalateCollectionDrop({ isView: false, documentCount: 0 })).toBe(false)
+  })
+
+  test('escalates for non-empty collections', () => {
+    expect(shouldEscalateCollectionDrop({ isView: false, documentCount: 1 })).toBe(true)
+  })
+
+  test('escalates when count is unknown (fail-closed)', () => {
+    expect(shouldEscalateCollectionDrop({ isView: false, documentCount: undefined })).toBe(true)
+  })
+})

--- a/frontend/src/features/settings/settingsStore.ts
+++ b/frontend/src/features/settings/settingsStore.ts
@@ -6,8 +6,6 @@ import * as settingsProxy from 'wailsjs/go/api/SettingsProxy'
 import { type models } from 'wailsjs/go/models.ts'
 import { useNotifier } from '@/utils/dialog.ts'
 
-const theme = useOsTheme()
-
 type SettingsStore = models.Settings & {
   fontList: models.Font[]
   previousVersion?: models.Settings
@@ -125,7 +123,13 @@ export const useSettingsStore = defineStore('settings', {
     },
     isDark(): boolean {
       const th = this.general.theme || 'auto'
-      return th === 'dark' || (th === 'auto' && theme.value === 'dark')
+      if (th === 'dark') {
+        return true
+      }
+      if (th === 'light') {
+        return false
+      }
+      return useOsTheme().value === 'dark'
     },
   },
   actions: {

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -232,9 +232,26 @@ export default {
         message:
           'Are you sure you want to drop collection "{name}"? This action cannot be undone.',
       },
-      dropDatabase: {
-        message:
-          'Are you sure you want to drop database "{name}"? This will delete all collections and data within it. This action cannot be undone.',
+      destructiveConfirm: {
+        database: {
+          title: 'Drop database',
+          warning: 'You are about to permanently drop the database {name}. This cannot be undone.',
+          impactWithCounts:
+            'It contains {collections} collections and approximately {documents} documents.',
+          impactCollectionsOnly: 'It contains {collections} collections.',
+          impactUnavailable: 'Impact details unavailable.',
+          inputLabel: 'Type the database name to confirm:',
+        },
+        collection: {
+          title: 'Drop collection',
+          warning: 'You are about to permanently drop the collection {name}. This cannot be undone.',
+          impactDocuments: 'It contains approximately {documents} documents.',
+          impactUnavailable: 'Impact details unavailable.',
+          inputLabel: 'Type the collection name to confirm:',
+        },
+        confirm: 'Drop',
+        cancel: 'Cancel',
+        mismatchHelp: 'The name must match exactly.',
       },
     },
   },

--- a/frontend/src/stores/dialog.ts
+++ b/frontend/src/stores/dialog.ts
@@ -24,11 +24,24 @@ export const enum DialogType {
   RenameCollection = 'renameCollection',
   ServerPicker = 'serverPicker',
   Export = 'export',
+  DestructiveConfirm = 'destructiveConfirm',
 }
 
 export type ServerDialogData = {
   serverId: string
   mode: 'edit' | 'clone'
+}
+
+export type DestructiveConfirmKind = 'database' | 'collection'
+
+export type DestructiveConfirmData = {
+  kind: DestructiveConfirmKind
+  name: string
+  impact: {
+    collectionCount?: number
+    documentCount?: number
+  }
+  onConfirm: () => Promise<void>
 }
 
 export const useDialogStore = defineStore('dialog', {
@@ -70,6 +83,10 @@ export const useDialogStore = defineStore('dialog', {
         type: DialogMode.New,
       } as DialogState,
       [DialogType.Export]: {
+        visible: false,
+        type: DialogMode.New,
+      } as DialogState,
+      [DialogType.DestructiveConfirm]: {
         visible: false,
         type: DialogMode.New,
       } as DialogState,
@@ -183,6 +200,12 @@ export const useDialogStore = defineStore('dialog', {
     },
     openServerPickerDialog(data?: unknown) {
       this.showNewDialog(DialogType.ServerPicker, data)
+    },
+    openDestructiveConfirmDialog(data: DestructiveConfirmData) {
+      this.showNewDialog(DialogType.DestructiveConfirm, data)
+    },
+    closeDestructiveConfirmDialog() {
+      this.hide(DialogType.DestructiveConfirm)
     },
   },
   getters: {


### PR DESCRIPTION
## Summary

- Adds a Compass-style type-to-confirm dialog (`DestructiveConfirmDialog.vue`) that requires the user to type the exact database or collection name before a destructive drop proceeds.
- Drop database always escalates; drop collection only escalates when the collection is non-empty (stats fail-closed); views never escalate.
- Impact line shows collection/document counts using the user's system locale number formatting.

Fixes #182

## Test plan

- [x] `bun run test` — 270/270 pass (including new `statsImpact.test.ts`)
- [x] `bun run lint` — clean
- [x] Manual: drop non-empty database — dialog shows counts, Drop disabled until name matches
- [x] Manual: drop non-empty collection — type-to-confirm dialog
- [x] Manual: drop empty collection — old simple warning
- [x] Manual: drop view — old simple warning (no escalation regardless of row count)
- [x] Manual: cancel/Escape paths close without dropping; outside-click does nothing
- [x] Manual: simulate stats failure → dialog opens with "Impact details unavailable." (fail-closed)