### PR TITLE
Support db.createView in the query engine

### DIFF
--- a/internal/queryengine/db_commands_integration_test.go
+++ b/internal/queryengine/db_commands_integration_test.go
@@ -125,6 +125,26 @@ func TestIntegration_CreateCollection(t *testing.T) {
 	assert.Contains(t, names, "newcoll")
 }
 
+func TestIntegration_CreateView(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient)
+	_, err := engine.ExecuteQuery(ctx, testURI, db, `db.src.insertOne({ x: 1, y: 2 })`)
+	require.NoError(t, err)
+
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.createView("myview", "src", [{ $project: { x: 1 } }])`)
+	require.NoError(t, err)
+	assert.Contains(t, result.RawOutput, "ok")
+
+	infos, err := testClient.Database(db).ListCollectionNames(ctx, map[string]any{"name": "myview"})
+	require.NoError(t, err)
+	assert.Contains(t, infos, "myview")
+}
+
 func TestIntegration_DropDatabase(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/internal/queryengine/goja_engine_test.go
+++ b/internal/queryengine/goja_engine_test.go
@@ -220,7 +220,7 @@ func TestDatabaseProxy_RunCommand_PanicsWithoutArgs(t *testing.T) {
 func TestDatabaseProxy_CoreMethods_AreFunctions(t *testing.T) {
 	rt, _ := setupRuntime(t)
 	methods := []string{
-		"getCollectionNames", "getCollectionInfos", "createCollection",
+		"getCollectionNames", "getCollectionInfos", "createCollection", "createView",
 		"dropDatabase", "stats", "version", "getSiblingDB", "getMongo", "aggregate",
 	}
 	for _, m := range methods {
@@ -250,6 +250,7 @@ func TestDatabaseProxy_CoreMethods_PanicWithoutClient(t *testing.T) {
 		`db.getCollectionNames()`,
 		`db.getCollectionInfos()`,
 		`db.createCollection("test")`,
+		`db.createView("v", "src", [])`,
 		`db.dropDatabase()`,
 		`db.stats()`,
 		`db.version()`,

--- a/internal/queryengine/proxy_db.go
+++ b/internal/queryengine/proxy_db.go
@@ -16,6 +16,7 @@ var dbMethodNames = map[string]bool{
 	"getCollectionNames":       true,
 	"getCollectionInfos":       true,
 	"createCollection":         true,
+	"createView":               true,
 	"dropDatabase":             true,
 	"stats":                    true,
 	"version":                  true,
@@ -66,6 +67,8 @@ func newDatabaseProxy(ec *execContext) goja.Value {
 				return ec.rt.ToValue(dbGetCollectionInfos(ec))
 			case "createCollection":
 				return ec.rt.ToValue(dbCreateCollection(ec))
+			case "createView":
+				return ec.rt.ToValue(dbCreateView(ec))
 			case "dropDatabase":
 				return ec.rt.ToValue(dbDropDatabase(ec))
 			case "stats":

--- a/internal/queryengine/proxy_db_collections.go
+++ b/internal/queryengine/proxy_db_collections.go
@@ -80,6 +80,44 @@ func dbCreateCollection(ec *execContext) func(goja.FunctionCall) goja.Value {
 	}
 }
 
+// dbCreateView returns a function: db.createView(name, source, pipeline, options?) → { ok: 1 }
+// Equivalent to db.runCommand({ create: name, viewOn: source, pipeline: [...], ...options }).
+func dbCreateView(ec *execContext) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		requireClient(ec)
+		if len(call.Arguments) < 3 {
+			panic(ec.rt.NewGoError(fmt.Errorf("createView requires name, source, and pipeline arguments")))
+		}
+
+		name := call.Arguments[0].String()
+		source := call.Arguments[1].String()
+
+		pipelineRaw := exportValue(call.Arguments[2])
+		pipeline := convertToBson(pipelineRaw)
+
+		cmd := bson.D{
+			{Key: "create", Value: name},
+			{Key: "viewOn", Value: source},
+			{Key: "pipeline", Value: pipeline},
+		}
+
+		if len(call.Arguments) >= 4 && !goja.IsUndefined(call.Arguments[3]) {
+			optsRaw := exportValue(call.Arguments[3])
+			if optsDoc, ok := convertToBson(optsRaw).(bson.D); ok {
+				cmd = append(cmd, optsDoc...)
+			}
+		}
+
+		var result bson.M
+		err := ec.client.Database(ec.dbName).RunCommand(ec.ctx, cmd).Decode(&result)
+		if err != nil {
+			panic(ec.rt.NewGoError(fmt.Errorf("createView: %w", err)))
+		}
+
+		return ec.rt.ToValue(result)
+	}
+}
+
 // dbAggregate returns a function: db.aggregate(pipeline) → results array
 func dbAggregate(ec *execContext) func(goja.FunctionCall) goja.Value {
 	return func(call goja.FunctionCall) goja.Value {


### PR DESCRIPTION
## Summary
- Add `db.createView(name, source, pipeline, options?)` to the Goja engine, routed through `RunCommand({create, viewOn, pipeline, ...options})` to match mongosh behavior.
- Register `createView` in `dbMethodNames` so it is dispatched as a method rather than falling through to collection proxy access (which produced the opaque `TypeError: Not a function` in the original repro).

## Test plan
- [x] `go test ./internal/queryengine/...`
- [ ] `go test -tags integration ./internal/queryengine/...` (new `TestIntegration_CreateView` exercises the full path against a real MongoDB container)
- [ ] Manual: run the repro script from the issue against a sample dataset

Fixes #208