### PR TITLE
Fix keyring cooldown triggered by slow interactive unlock

### DIFF
--- a/internal/connectionStrings/store.go
+++ b/internal/connectionStrings/store.go
@@ -13,7 +13,13 @@ import (
 )
 
 const serviceName = "Vervet"
-const keyringTimeout = 5 * time.Second
+
+// keyringTimeout is intentionally generous: on Linux the OS secret service may
+// prompt the user for a password to unlock the login keyring, and that interaction
+// dominates wall-clock latency. A truly-missing D-Bus daemon fails fast from
+// go-keyring with an error, so the timeout only needs to guard against a wedged
+// daemon, not normal interactive unlock.
+const keyringTimeout = 60 * time.Second
 const keyringCooldown = 1 * time.Minute
 
 type Store interface {
@@ -102,11 +108,19 @@ func (s *store) markKeyringUnavailable() {
 	s.lastCheck = time.Now()
 }
 
+func (s *store) markKeyringAvailable() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.keyringAvailable = true
+}
+
 // withTimeout runs fn in a goroutine and returns its error, or a timeout error
 // if it doesn't complete within the given duration. This prevents keyring operations
-// from hanging indefinitely when the OS secret service (D-Bus) is unavailable,
-// which is common in environments like WSL2 without a running keyring daemon.
+// from hanging indefinitely when the OS secret service (D-Bus) is wedged.
 // If the keyring has previously timed out, it fails fast during the cooldown period.
+// If a goroutine started by a previous timed-out call eventually returns, the
+// unavailable flag is cleared — any return (success or error) proves the keyring
+// is responsive and the cooldown should not block the next attempt.
 func (s *store) withTimeout(timeout time.Duration, fn func() error) error {
 	if err := s.checkKeyringAvailable(); err != nil {
 		return err
@@ -114,7 +128,9 @@ func (s *store) withTimeout(timeout time.Duration, fn func() error) error {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- fn()
+		err := fn()
+		done <- err
+		s.markKeyringAvailable()
 	}()
 	select {
 	case err := <-done:

--- a/internal/connectionStrings/store_test.go
+++ b/internal/connectionStrings/store_test.go
@@ -1,10 +1,70 @@
 package connectionStrings
 
 import (
+	"io"
+	"log/slog"
 	"testing"
+	"time"
 
 	"vervet/internal/models"
 )
+
+func newTestStore() *store {
+	return NewStore(slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func TestWithTimeoutLateReturnClearsUnavailable(t *testing.T) {
+	s := newTestStore()
+
+	// fn takes longer than the timeout: cooldown should be set.
+	start := make(chan struct{})
+	err := s.withTimeout(20*time.Millisecond, func() error {
+		<-start
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+
+	s.mu.Lock()
+	if s.keyringAvailable {
+		s.mu.Unlock()
+		t.Fatal("expected keyring marked unavailable after timeout")
+	}
+	s.mu.Unlock()
+
+	// Allow the goroutine to finish; it should clear the unavailable flag.
+	close(start)
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		s.mu.Lock()
+		available := s.keyringAvailable
+		s.mu.Unlock()
+		if available {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("late goroutine return did not clear keyringAvailable")
+}
+
+func TestWithTimeoutCooldownFailsFast(t *testing.T) {
+	s := newTestStore()
+	s.markKeyringUnavailable()
+
+	called := false
+	err := s.withTimeout(time.Second, func() error {
+		called = true
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected error during cooldown")
+	}
+	if called {
+		t.Fatal("fn should not run during cooldown")
+	}
+}
 
 func TestSerialiseConnectionConfig(t *testing.T) {
 	cfg := models.ConnectionConfig{


### PR DESCRIPTION
## Summary
- Raise the keyring operation timeout from 5s to 60s so a user-slow OS-keyring password unlock does not trip the cooldown path. On Linux, interactive unlock dominates latency; a truly-missing D-Bus daemon still errors fast from `go-keyring`, so the timeout only needs to guard against a wedged daemon.
- If a previous timed-out keyring call eventually returns (success or error), clear the unavailable flag so the next operation proceeds immediately instead of waiting out the 60s cooldown. Any return proves the daemon is responsive.

## Test plan
- [x] `go test ./internal/connectionStrings/...`
- [x] New unit test: late goroutine return clears `keyringAvailable`
- [x] New unit test: operations fail fast during cooldown
- [ ] Manual: on a fresh Linux session with a locked login keyring, click Connect, wait >5s at the keyring prompt, unlock — subsequent Connect attempts should succeed immediately

Fixes #203
Fixes #204