### PR TITLE
Run selected text in the editor

### DIFF
--- a/frontend/src/features/queries/QueryTab.vue
+++ b/frontend/src/features/queries/QueryTab.vue
@@ -132,7 +132,9 @@ const runQuery = async () => {
   if (!editor.value) {
     return
   }
-  const query = editor.value.getValue()
+  const selection = editor.value.getSelection()
+  const selectedText = selection ? (editor.value.getModel()?.getValueInRange(selection) ?? '') : ''
+  const query = selectedText.trim() !== '' ? selectedText : editor.value.getValue()
   await queryStore.executeQuery(props.queryId, query)
 }
 


### PR DESCRIPTION
## Summary
- When a non-empty selection exists in the query editor, Run / F5 / Ctrl-Cmd+Enter executes only the selection; otherwise it executes the full buffer as before.

Fixes #185

## Test plan
- [x] Type a multi-statement query, select one statement, press Ctrl/Cmd+Enter — only the selection runs.
- [x] Clear the selection, press Ctrl/Cmd+Enter — entire buffer runs.
- [x] Whitespace-only selection falls back to the full buffer.
- [x] F5 and the Run button behave identically.