### PR TITLE
chore: bump version to 2026.04.6

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vervet",
-  "version": "2026.04.5",
+  "version": "2026.04.6",
   "description": "A desktop Mongo DB tool",
   "productName": "Vervet",
   "author": "Sean Garrett <sean@blacktau.com>",

--- a/wails.json
+++ b/wails.json
@@ -11,7 +11,7 @@
     "email": "sean@blacktau.com"
   },
   "info": {
-    "productVersion": "2026.04.5",
+    "productVersion": "2026.04.6",
     "productName": "Vervet",
     "companyName": "Blacktau",
     "copyright": "Copyright 2026 Sean Garrett",


### PR DESCRIPTION
Bump productVersion in wails.json and version in frontend/package.json to 2026.04.6 ahead of release tag v2026.04.6.