### PR TITLE
feat: expose query defaults and confirm-destructive as settings

### DIFF
--- a/frontend/src/features/data-browser/DataBrowserTree.vue
+++ b/frontend/src/features/data-browser/DataBrowserTree.vue
@@ -7,6 +7,7 @@ import { CircleStackIcon, EyeIcon, FolderIcon, FolderOpenIcon } from '@heroicons
 import { DataNodeType, type DataTreeNode } from '@/features/data-browser/types.ts'
 import { useDataTreeContextMenu } from '@/features/data-browser/useDataTreeContextMenu.ts'
 import { useDataBrowserStore } from '@/features/data-browser/browserStore.ts'
+import { useSettingsStore } from '@/features/settings/settingsStore.ts'
 import { useTabStore } from '@/features/tabs/tabs.ts'
 import DataTreeContextMenu from '@/features/data-browser/DataTreeContextMenu.vue'
 import { useDialogStore } from '@/stores/dialog.ts'
@@ -25,6 +26,7 @@ const props = defineProps<{
 
 const tabStore = useTabStore()
 const browserStore = useDataBrowserStore()
+const settingsStore = useSettingsStore()
 const contextMenu = useDataTreeContextMenu()
 const dialogStore = useDialogStore()
 const dialog = useDialog()
@@ -50,7 +52,7 @@ const openQueryForNode = (node: DataTreeNode) => {
     const dbName = parts[1]
     const name = parts[3]
     if (serverId && dbName && name) {
-      const queryText = `db.getCollection('${name}').find({}).limit(42)`
+      const queryText = `db.getCollection('${name}').find({}).limit(${settingsStore.query.defaultLimit})`
       tabStore.openQuery(serverId, dbName, queryText, name)
     }
   }

--- a/frontend/src/features/data-browser/DataBrowserTree.vue
+++ b/frontend/src/features/data-browser/DataBrowserTree.vue
@@ -181,6 +181,21 @@ async function handleContextMenuSelect(key: string) {
       const serverId = parts[0]
       const dbName = parts[1]
       if (serverId && dbName) {
+        const doDropDb = async () => {
+          const result = await databasesProxy.DropDatabase(serverId, dbName)
+          if (!result.isSuccess) {
+            notifier.error(t(`errors.${result.errorCode}`), {
+              title: t('errorTitles.dropDatabase'),
+              detail: result.errorDetail,
+            })
+            return
+          }
+          await browserStore.refreshServerDatabases(serverId)
+        }
+        if (!settingsStore.general.confirmDestructive) {
+          await doDropDb()
+          return
+        }
         const statsResult = await databasesProxy.GetDatabaseStatistics(serverId, dbName)
         const impact =
           statsResult.isSuccess && statsResult.data
@@ -190,17 +205,7 @@ async function handleContextMenuSelect(key: string) {
           kind: 'database',
           name: dbName,
           impact,
-          onConfirm: async () => {
-            const result = await databasesProxy.DropDatabase(serverId, dbName)
-            if (!result.isSuccess) {
-              notifier.error(t(`errors.${result.errorCode}`), {
-                title: t('errorTitles.dropDatabase'),
-                detail: result.errorDetail,
-              })
-              return
-            }
-            await browserStore.refreshServerDatabases(serverId)
-          },
+          onConfirm: doDropDb,
         })
       }
     }
@@ -233,6 +238,23 @@ async function handleContextMenuSelect(key: string) {
       const dbName = parts[1]
       const collectionName = parts[3]
       if (serverId && dbName && collectionName) {
+        const doDrop = async () => {
+          const result = await collectionsProxy.DropCollection(serverId, dbName, collectionName)
+          if (!result.isSuccess) {
+            notifier.error(t(`errors.${result.errorCode}`), {
+              title: t('errorTitles.dropCollection'),
+              detail: result.errorDetail,
+            })
+            return
+          }
+          await browserStore.refreshDatabaseCollections(serverId, dbName)
+        }
+
+        if (!settingsStore.general.confirmDestructive) {
+          await doDrop()
+          return
+        }
+
         const isView = node.type === DataNodeType.View
         let impact: { documentCount?: number } = {}
         let statsFetchFailed = false
@@ -246,18 +268,6 @@ async function handleContextMenuSelect(key: string) {
         }
         const documentCount = statsFetchFailed ? undefined : impact.documentCount
         const escalate = shouldEscalateCollectionDrop({ isView, documentCount })
-
-        const doDrop = async () => {
-          const result = await collectionsProxy.DropCollection(serverId, dbName, collectionName)
-          if (!result.isSuccess) {
-            notifier.error(t(`errors.${result.errorCode}`), {
-              title: t('errorTitles.dropCollection'),
-              detail: result.errorDetail,
-            })
-            return
-          }
-          await browserStore.refreshDatabaseCollections(serverId, dbName)
-        }
 
         if (escalate) {
           dialogStore.openDestructiveConfirmDialog({

--- a/frontend/src/features/queries/queryStore.ts
+++ b/frontend/src/features/queries/queryStore.ts
@@ -246,7 +246,7 @@ export const useQueryStore = defineStore('query', {
       }
 
       const settingsStore = useSettingsStore()
-      if (settingsStore.editor.queryEngine === 'mongosh' && this.mongoshAvailable === false) {
+      if (settingsStore.query.queryEngine === 'mongosh' && this.mongoshAvailable === false) {
         const msg = i18nGlobal.t('errors.shell_not_found')
         state.error = msg
         this.appendMessage(queryId, { level: 'error', text: msg, query: queryPayload })

--- a/frontend/src/features/results-document-tree/DocumentTreeTable.vue
+++ b/frontend/src/features/results-document-tree/DocumentTreeTable.vue
@@ -98,7 +98,7 @@ watch(
 
 const pagination = reactive({
   page: 1,
-  pageSize: 25,
+  pageSize: settingsStore.query.defaultPageSize,
   pageSizes: PAGE_SIZES,
   showSizePicker: true,
   size: 'small' as const,

--- a/frontend/src/features/settings/EditorSettings.vue
+++ b/frontend/src/features/settings/EditorSettings.vue
@@ -44,27 +44,6 @@ const fontOptions = computed(() => [
       <n-form-item-gi :label="$t('settings.common.fontSize')" :span="24">
         <n-input-number v-model:value="settingsStore.editor.font.size" :max="65535" :min="1" />
       </n-form-item-gi>
-      <n-form-item-gi :span="24">
-        <template #label>
-          {{ $t('settings.editor.queryEngine') }}
-          <n-tooltip trigger="hover">
-            <template #trigger>
-              <n-icon :component="QuestionMarkCircleIcon" />
-            </template>
-            <div class="text-block">
-              {{ $t('settings.editor.queryEngineHelp') }}
-            </div>
-          </n-tooltip>
-        </template>
-        <n-radio-group v-model:value="settingsStore.editor.queryEngine" name="queryEngine" size="medium">
-          <n-radio-button value="builtin">
-            {{ $t('settings.editor.queryEngineBuiltin') }}
-          </n-radio-button>
-          <n-radio-button value="mongosh">
-            {{ $t('settings.editor.queryEngineMongosh') }}
-          </n-radio-button>
-        </n-radio-group>
-      </n-form-item-gi>
       <n-form-item-gi :show-feedback="false" :show-label="false" :span="24">
         <n-checkbox v-model:checked="settingsStore.editor.lineNumbers">
           {{ $t('settings.editor.showLineNumbers') }}

--- a/frontend/src/features/settings/GeneralSettings.vue
+++ b/frontend/src/features/settings/GeneralSettings.vue
@@ -64,6 +64,19 @@ const fontOptions = computed(() => [
       <n-form-item-gi :label="$t('settings.common.fontSize')" :span="24">
         <n-input-number v-model:value="settingsStore.general.font.size" :max="65535" :min="1" />
       </n-form-item-gi>
+      <n-form-item-gi :show-feedback="false" :show-label="false" :span="24">
+        <n-checkbox v-model:checked="settingsStore.general.confirmDestructive">
+          {{ $t('settings.general.confirmDestructive') }}
+          <n-tooltip trigger="hover">
+            <template #trigger>
+              <n-icon :component="QuestionMarkCircleIcon" />
+            </template>
+            <div class="text-block">
+              {{ $t('settings.general.confirmDestructiveHelp') }}
+            </div>
+          </n-tooltip>
+        </n-checkbox>
+      </n-form-item-gi>
     </n-grid>
   </n-form>
 </template>

--- a/frontend/src/features/settings/QuerySettings.vue
+++ b/frontend/src/features/settings/QuerySettings.vue
@@ -1,0 +1,83 @@
+<script lang="ts" setup>
+import { useSettingsStore } from '@/features/settings/settingsStore.ts'
+import { QuestionMarkCircleIcon } from '@heroicons/vue/24/outline'
+
+const props = defineProps<{ loading: boolean }>()
+
+const settingsStore = useSettingsStore()
+
+const pageSizeOptions = [
+  { label: '25', value: 25 },
+  { label: '50', value: 50 },
+  { label: '100', value: 100 },
+  { label: '200', value: 200 },
+  { label: '500', value: 500 },
+]
+</script>
+
+<template>
+  <n-form
+    :disabled="props.loading"
+    :model="settingsStore.query"
+    :show-require-mark="false"
+    label-placement="top">
+    <n-grid :x-gap="10">
+      <n-form-item-gi :span="24">
+        <template #label>
+          {{ $t('settings.query.defaultLimit') }}
+          <n-tooltip trigger="hover">
+            <template #trigger>
+              <n-icon :component="QuestionMarkCircleIcon" />
+            </template>
+            <div class="text-block">
+              {{ $t('settings.query.defaultLimitHelp') }}
+            </div>
+          </n-tooltip>
+        </template>
+        <n-input-number
+          v-model:value="settingsStore.query.defaultLimit"
+          :max="10000"
+          :min="1" />
+      </n-form-item-gi>
+      <n-form-item-gi :span="24">
+        <template #label>
+          {{ $t('settings.query.defaultPageSize') }}
+          <n-tooltip trigger="hover">
+            <template #trigger>
+              <n-icon :component="QuestionMarkCircleIcon" />
+            </template>
+            <div class="text-block">
+              {{ $t('settings.query.defaultPageSizeHelp') }}
+            </div>
+          </n-tooltip>
+        </template>
+        <n-select
+          v-model:value="settingsStore.query.defaultPageSize"
+          :options="pageSizeOptions" />
+      </n-form-item-gi>
+      <n-form-item-gi :span="24">
+        <template #label>
+          {{ $t('settings.query.queryEngine') }}
+          <n-tooltip trigger="hover">
+            <template #trigger>
+              <n-icon :component="QuestionMarkCircleIcon" />
+            </template>
+            <div class="text-block">
+              {{ $t('settings.query.queryEngineHelp') }}
+            </div>
+          </n-tooltip>
+        </template>
+        <n-radio-group v-model:value="settingsStore.query.queryEngine" name="queryEngine" size="medium">
+          <n-radio-button value="builtin">
+            {{ $t('settings.query.queryEngineBuiltin') }}
+          </n-radio-button>
+          <n-radio-button value="mongosh">
+            {{ $t('settings.query.queryEngineMongosh') }}
+          </n-radio-button>
+        </n-radio-group>
+      </n-form-item-gi>
+    </n-grid>
+  </n-form>
+</template>
+
+<style lang="scss" scoped></style>

--- a/frontend/src/features/settings/SettingsDialog.vue
+++ b/frontend/src/features/settings/SettingsDialog.vue
@@ -4,6 +4,7 @@ import { ref, watchEffect } from 'vue'
 import { DialogType, useDialogStore } from '@/stores/dialog.ts'
 import GeneralSettings from '@/features/settings/GeneralSettings.vue'
 import EditorSettings from '@/features/settings/EditorSettings.vue'
+import QuerySettings from '@/features/settings/QuerySettings.vue'
 import MessagesSettings from '@/features/settings/MessagesSettings.vue'
 import WorkspacesSettings from '@/features/settings/WorkspacesSettings.vue'
 import LoggingSettings from '@/features/settings/LoggingSettings.vue'
@@ -76,6 +77,9 @@ const onClose = async () => {
         </n-tab-pane>
         <n-tab-pane :tab="$t('settings.editor.name')" display-directive="show:lazy" name="editor">
           <editor-settings :loading="loading" />
+        </n-tab-pane>
+        <n-tab-pane :tab="$t('settings.query.name')" display-directive="show:lazy" name="query">
+          <query-settings :loading="loading" />
         </n-tab-pane>
         <n-tab-pane
           :tab="$t('settings.terminal.name')"

--- a/frontend/src/features/settings/settingsStore.test.ts
+++ b/frontend/src/features/settings/settingsStore.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('wailsjs/go/api/SettingsProxy', () => ({
+  GetSettings: vi.fn(),
+  SetSettings: vi.fn(),
+  ResetSettings: vi.fn(),
+  GetAvailableFonts: vi.fn(),
+}))
+
+vi.mock('naive-ui', () => ({
+  useOsTheme: () => ({ value: 'light' }),
+}))
+
+import { useSettingsStore } from './settingsStore'
+import * as settingsProxy from 'wailsjs/go/api/SettingsProxy'
+
+describe('settingsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('seeds default query and confirmDestructive values', () => {
+    const store = useSettingsStore()
+    expect(store.query.defaultLimit).toBe(42)
+    expect(store.query.defaultPageSize).toBe(25)
+    expect(store.query.queryEngine).toBe('builtin')
+    expect(store.general.confirmDestructive).toBe(true)
+  })
+
+  it('migrates legacy editor.queryEngine when payload lacks query block', async () => {
+    ;(settingsProxy.GetSettings as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      isSuccess: true,
+      data: {
+        general: { theme: 'auto', language: 'auto', font: { size: 14 } },
+        editor: { font: { size: 14 }, queryEngine: 'mongosh' },
+        terminal: { font: { size: 14 }, cursorStyle: 'block' },
+        workspaces: { fileExtensions: ['.js'] },
+        logging: { level: 'info', consoleEnabled: false, fileEnabled: true, maxSizeMB: 10, maxBackups: 5 },
+      },
+    })
+    const store = useSettingsStore()
+    await store.loadSettings()
+    expect(store.query.queryEngine).toBe('mongosh')
+    expect(store.query.defaultLimit).toBe(42)
+    expect(store.query.defaultPageSize).toBe(25)
+  })
+
+  it('defaults confirmDestructive to true when missing from payload', async () => {
+    ;(settingsProxy.GetSettings as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      isSuccess: true,
+      data: {
+        general: { theme: 'auto', language: 'auto', font: { size: 14 } },
+        editor: { font: { size: 14 } },
+        query: { defaultLimit: 100, defaultPageSize: 50, queryEngine: 'builtin' },
+        terminal: { font: { size: 14 }, cursorStyle: 'block' },
+        workspaces: { fileExtensions: ['.js'] },
+        logging: { level: 'info', consoleEnabled: false, fileEnabled: true, maxSizeMB: 10, maxBackups: 5 },
+      },
+    })
+    const store = useSettingsStore()
+    await store.loadSettings()
+    expect(store.general.confirmDestructive).toBe(true)
+    expect(store.query.defaultLimit).toBe(100)
+    expect(store.query.defaultPageSize).toBe(50)
+  })
+})

--- a/frontend/src/features/settings/settingsStore.ts
+++ b/frontend/src/features/settings/settingsStore.ts
@@ -26,12 +26,17 @@ export const useSettingsStore = defineStore('settings', {
         font: {
           size: 14,
         },
+        confirmDestructive: true,
       },
       editor: {
         font: {
           size: 14,
         },
         showLineNumbers: true,
+      },
+      query: {
+        defaultLimit: 42,
+        defaultPageSize: 25,
         queryEngine: 'builtin',
       },
       terminal: {
@@ -163,6 +168,19 @@ export const useSettingsStore = defineStore('settings', {
       const links = get(result.data, 'editor.links')
       if (links === undefined) {
         set(result.data, 'editor.links', true)
+      }
+      const query = get(result.data, 'query')
+      if (query === undefined) {
+        const legacyEngine = get(result.data, 'editor.queryEngine') as string | undefined
+        set(this, 'query', {
+          defaultLimit: 42,
+          defaultPageSize: 25,
+          queryEngine: legacyEngine ?? 'builtin',
+        })
+      }
+      const confirmDestructive = get(result.data, 'general.confirmDestructive')
+      if (confirmDestructive === undefined) {
+        set(this, 'general.confirmDestructive', true)
       }
       const fileExtensions = get(result.data, 'workspaces.fileExtensions')
       if (fileExtensions == null) {

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -65,6 +65,9 @@ export default {
       themeAuto: 'Auto',
       language: 'Language',
       systemLanguage: 'Use System Language',
+      confirmDestructive: 'Confirm destructive operations',
+      confirmDestructiveHelp:
+        'When enabled, dropping a database or collection requires confirmation. Disable to skip the confirmation prompts.',
     },
     editor: {
       name: 'Editor',
@@ -72,6 +75,15 @@ export default {
       showFolding: 'Enable Code Folding',
       dropText: 'Allow Dragging & Dropping of Text',
       links: 'Support Links',
+    },
+    query: {
+      name: 'Query',
+      defaultLimit: 'Default result limit',
+      defaultLimitHelp:
+        'The number of documents requested when opening a query from the data browser. Inserted as the .limit(N) clause in the generated query.',
+      defaultPageSize: 'Default page size',
+      defaultPageSizeHelp:
+        'Initial page size of the results table. You can still change page size per-table from the pagination control.',
       queryEngine: 'Query Engine',
       queryEngineBuiltin: 'Built-in (recommended)',
       queryEngineMongosh: 'mongosh',

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -224,7 +224,6 @@ export namespace models {
 	    showFolding: boolean;
 	    dropText: boolean;
 	    links: boolean;
-	    queryEngine: string;
 	}
 	
 	export interface Font {
@@ -236,6 +235,7 @@ export namespace models {
 	    theme: string;
 	    language: string;
 	    font: FontSettings;
+	    confirmDestructive: boolean;
 	}
 	export interface Index {
 	    name: string;
@@ -260,6 +260,11 @@ export namespace models {
 	    rawOutput: string;
 	    operationType?: string;
 	    affectedCount?: number;
+	}
+	export interface QuerySettings {
+	    defaultLimit: number;
+	    defaultPageSize: number;
+	    queryEngine: string;
 	}
 	export interface RegisteredServer {
 	    id: string;
@@ -294,6 +299,7 @@ export namespace models {
 	    window: WindowSettings;
 	    general: GeneralSettings;
 	    editor: EditorSettings;
+	    query: QuerySettings;
 	    terminal: TerminalSettings;
 	    workspaces: WorkspacesSettings;
 	    updates: UpdatesSettings;

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -10,6 +10,7 @@ type Settings struct {
 	Window     WindowSettings     `json:"window" yaml:"window"`
 	General    GeneralSettings    `json:"general" yaml:"general"`
 	Editor     EditorSettings     `json:"editor" yaml:"editor"`
+	Query      QuerySettings      `json:"query" yaml:"query"`
 	Terminal   TerminalSettings   `json:"terminal" yaml:"terminal"`
 	Workspaces WorkspacesSettings `json:"workspaces" yaml:"workspaces"`
 	Updates    UpdatesSettings    `json:"updates" yaml:"updates"`
@@ -36,9 +37,16 @@ type WindowSettings struct {
 }
 
 type GeneralSettings struct {
-	Theme    string       `json:"theme" yaml:"theme"`
-	Language string       `json:"language" yaml:"language"`
-	Font     FontSettings `json:"font" yaml:"font,omitempty"`
+	Theme              string       `json:"theme" yaml:"theme"`
+	Language           string       `json:"language" yaml:"language"`
+	Font               FontSettings `json:"font" yaml:"font,omitempty"`
+	ConfirmDestructive bool         `json:"confirmDestructive" yaml:"confirmDestructive"`
+}
+
+type QuerySettings struct {
+	DefaultLimit    int    `json:"defaultLimit" yaml:"defaultLimit"`
+	DefaultPageSize int    `json:"defaultPageSize" yaml:"defaultPageSize"`
+	QueryEngine     string `json:"queryEngine" yaml:"queryEngine"`
 }
 
 type FontSettings struct {
@@ -53,7 +61,6 @@ type EditorSettings struct {
 	ShowFolding bool         `json:"showFolding" yaml:"showFolding"`
 	DropText    bool         `json:"dropText" yaml:"dropText"`
 	Links       bool         `json:"links" yaml:"links"`
-	QueryEngine string       `json:"queryEngine" yaml:"queryEngine"`
 }
 
 type TerminalSettings struct {
@@ -85,6 +92,24 @@ func (s *LoggingSettings) Normalize() {
 	}
 	if s.MaxBackups < 0 {
 		s.MaxBackups = 0
+	}
+}
+
+// Normalize clamps loaded query settings into safe ranges and falls back to
+// defaults when values are missing or out of bounds.
+func (q *QuerySettings) Normalize() {
+	if q.DefaultLimit < 1 || q.DefaultLimit > 10000 {
+		q.DefaultLimit = 42
+	}
+	switch q.DefaultPageSize {
+	case 25, 50, 100, 200, 500:
+	default:
+		q.DefaultPageSize = 25
+	}
+	switch q.QueryEngine {
+	case "builtin", "mongosh":
+	default:
+		q.QueryEngine = "builtin"
 	}
 }
 

--- a/internal/queryexecutor/executor.go
+++ b/internal/queryexecutor/executor.go
@@ -73,7 +73,7 @@ func (qe *QueryExecutor) ExecuteQuery(serverID, dbName, query string) (models.Qu
 	}()
 
 	cfg, _ := qe.settings.GetSettings()
-	if cfg.Editor.QueryEngine == "builtin" {
+	if cfg.Query.QueryEngine == "builtin" {
 		return qe.executeWithGoja(queryCtx, serverID, dbName, query)
 	}
 	return qe.executeWithMongosh(queryCtx, serverID, dbName, query)

--- a/internal/settings/service.go
+++ b/internal/settings/service.go
@@ -214,20 +214,22 @@ func (s *settingsService) getSettings() (models.Settings, error) {
 
 // migrateLegacyFields lifts deprecated YAML keys to their new locations so
 // older configuration files do not lose user choices on upgrade. Returns true
-// when the caller should persist the migrated settings. Must be called on the
-// freshly-unmarshalled settings, before normalization, so that "field absent"
-// can be distinguished from "field defaulted".
+// when the caller should persist the migrated settings. Detection is based on
+// the raw YAML rather than the unmarshalled struct, because defaults pre-fill
+// the new fields so "absent in YAML" cannot be distinguished from "defaulted".
 func (s *settingsService) migrateLegacyFields(settings *models.Settings, raw []byte) bool {
-	if settings.Query.QueryEngine != "" {
-		return false
-	}
-
 	var legacy struct {
 		Editor struct {
 			QueryEngine string `yaml:"queryEngine"`
 		} `yaml:"editor"`
+		Query struct {
+			QueryEngine string `yaml:"queryEngine"`
+		} `yaml:"query"`
 	}
 	if err := yaml.Unmarshal(raw, &legacy); err != nil {
+		return false
+	}
+	if legacy.Query.QueryEngine != "" {
 		return false
 	}
 	if legacy.Editor.QueryEngine == "" {

--- a/internal/settings/service.go
+++ b/internal/settings/service.go
@@ -30,6 +30,8 @@ const DefaultFontSize = 14
 const DefaultWindowWidth = 1024
 const DefaultWindowHeight = 768
 const DefaultAsideWidth = 300
+const DefaultResultLimit = 42
+const DefaultResultPageSize = 25
 
 type settingsService struct {
 	store         infrastructure.Store
@@ -196,8 +198,44 @@ func (s *settingsService) getSettings() (models.Settings, error) {
 		return s.defaultSettings(), fmt.Errorf("error parsing configuration: %w", err)
 	}
 
+	migrated := s.migrateLegacyFields(&settings, b)
+
 	settings.Logging.Normalize()
+	settings.Query.Normalize()
+
+	if migrated {
+		if saveErr := s.saveSettings(&settings); saveErr != nil {
+			s.log.Warn("failed to persist settings migration", slog.Any("error", saveErr))
+		}
+	}
+
 	return settings, nil
+}
+
+// migrateLegacyFields lifts deprecated YAML keys to their new locations so
+// older configuration files do not lose user choices on upgrade. Returns true
+// when the caller should persist the migrated settings. Must be called on the
+// freshly-unmarshalled settings, before normalization, so that "field absent"
+// can be distinguished from "field defaulted".
+func (s *settingsService) migrateLegacyFields(settings *models.Settings, raw []byte) bool {
+	if settings.Query.QueryEngine != "" {
+		return false
+	}
+
+	var legacy struct {
+		Editor struct {
+			QueryEngine string `yaml:"queryEngine"`
+		} `yaml:"editor"`
+	}
+	if err := yaml.Unmarshal(raw, &legacy); err != nil {
+		return false
+	}
+	if legacy.Editor.QueryEngine == "" {
+		return false
+	}
+
+	settings.Query.QueryEngine = legacy.Editor.QueryEngine
+	return true
 }
 
 func (s *settingsService) setSettings(settings *models.Settings, key string, value any) error {
@@ -273,13 +311,18 @@ func defaultSettingsForBuild(isDev bool) models.Settings {
 			Font: models.FontSettings{
 				Size: DefaultFontSize,
 			},
+			ConfirmDestructive: true,
 		},
 		Editor: models.EditorSettings{
 			Font: models.FontSettings{
 				Size: DefaultFontSize,
 			},
 			LineNumbers: true,
-			QueryEngine: "builtin",
+		},
+		Query: models.QuerySettings{
+			DefaultLimit:    DefaultResultLimit,
+			DefaultPageSize: DefaultResultPageSize,
+			QueryEngine:     "builtin",
 		},
 		Terminal: models.TerminalSettings{
 			Font: models.FontSettings{

--- a/internal/settings/service_test.go
+++ b/internal/settings/service_test.go
@@ -130,6 +130,85 @@ func Test_SettingsService_DefaultQueryEngine(t *testing.T) {
 	})
 }
 
+func Test_SettingsService_QueryDefaults(t *testing.T) {
+	t.Run("first run sets query defaults", func(t *testing.T) {
+		m := newTestService(nil, nil)
+		c, err := m.GetSettings()
+		assert.NoError(t, err)
+		assert.Equal(t, settings.DefaultResultLimit, c.Query.DefaultLimit)
+		assert.Equal(t, settings.DefaultResultPageSize, c.Query.DefaultPageSize)
+		assert.Equal(t, "builtin", c.Query.QueryEngine)
+	})
+
+	t.Run("first run sets confirmDestructive to true", func(t *testing.T) {
+		m := newTestService(nil, nil)
+		c, err := m.GetSettings()
+		assert.NoError(t, err)
+		assert.True(t, c.General.ConfirmDestructive)
+	})
+
+	t.Run("clamps out-of-range default limit", func(t *testing.T) {
+		m := newTestService(&storeStub{
+			content: []byte("query:\n  defaultLimit: 999999\n  defaultPageSize: 50\n  queryEngine: builtin"),
+		}, nil)
+		c, err := m.GetSettings()
+		assert.NoError(t, err)
+		assert.Equal(t, settings.DefaultResultLimit, c.Query.DefaultLimit)
+		assert.Equal(t, 50, c.Query.DefaultPageSize)
+	})
+
+	t.Run("clamps invalid page size to default", func(t *testing.T) {
+		m := newTestService(&storeStub{
+			content: []byte("query:\n  defaultLimit: 100\n  defaultPageSize: 7\n  queryEngine: builtin"),
+		}, nil)
+		c, err := m.GetSettings()
+		assert.NoError(t, err)
+		assert.Equal(t, 100, c.Query.DefaultLimit)
+		assert.Equal(t, settings.DefaultResultPageSize, c.Query.DefaultPageSize)
+	})
+
+	t.Run("clamps unknown query engine to builtin", func(t *testing.T) {
+		m := newTestService(&storeStub{
+			content: []byte("query:\n  defaultLimit: 42\n  defaultPageSize: 25\n  queryEngine: bogus"),
+		}, nil)
+		c, err := m.GetSettings()
+		assert.NoError(t, err)
+		assert.Equal(t, "builtin", c.Query.QueryEngine)
+	})
+}
+
+func Test_SettingsService_LegacyQueryEngineMigration(t *testing.T) {
+	t.Run("migrates editor.queryEngine to query.queryEngine and persists", func(t *testing.T) {
+		store := &storeStub{
+			content: []byte("editor:\n  queryEngine: mongosh\n"),
+		}
+		m := newTestService(store, nil)
+		c, err := m.GetSettings()
+		assert.NoError(t, err)
+		assert.Equal(t, "mongosh", c.Query.QueryEngine)
+
+		// Persisted YAML carries the migrated location.
+		assert.Contains(t, string(store.content), "query:")
+		assert.Contains(t, string(store.content), "queryEngine: mongosh")
+
+		// Subsequent read does not re-migrate (would otherwise overwrite an
+		// explicit user choice).
+		c2, err := m.GetSettings()
+		assert.NoError(t, err)
+		assert.Equal(t, "mongosh", c2.Query.QueryEngine)
+	})
+
+	t.Run("no migration when query.queryEngine already set", func(t *testing.T) {
+		store := &storeStub{
+			content: []byte("editor:\n  queryEngine: mongosh\nquery:\n  defaultLimit: 42\n  defaultPageSize: 25\n  queryEngine: builtin\n"),
+		}
+		m := newTestService(store, nil)
+		c, err := m.GetSettings()
+		assert.NoError(t, err)
+		assert.Equal(t, "builtin", c.Query.QueryEngine)
+	})
+}
+
 func Test_DefaultSettings_UpdatesFrequency_IsDaily(t *testing.T) {
 	m := newTestService(nil, nil)
 	c, err := m.GetSettings()
@@ -158,6 +237,16 @@ func Test_SettingsService_RestoreSettings(t *testing.T) {
 		if c.Window.Width != settings.DefaultWindowWidth {
 			t.Errorf("expected default window width, got %d", c.Window.Width)
 		}
+	})
+
+	t.Run("restore resets query and confirmDestructive", func(t *testing.T) {
+		m := newTestService(nil, nil)
+		c, err := m.RestoreSettings()
+		assert.NoError(t, err)
+		assert.Equal(t, settings.DefaultResultLimit, c.Query.DefaultLimit)
+		assert.Equal(t, settings.DefaultResultPageSize, c.Query.DefaultPageSize)
+		assert.Equal(t, "builtin", c.Query.QueryEngine)
+		assert.True(t, c.General.ConfirmDestructive)
 	})
 }
 

--- a/internal/settings/service_test.go
+++ b/internal/settings/service_test.go
@@ -124,8 +124,8 @@ func Test_SettingsService_DefaultQueryEngine(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if c.Editor.QueryEngine != "builtin" {
-			t.Errorf("expected default query engine 'builtin', got '%s'", c.Editor.QueryEngine)
+		if c.Query.QueryEngine != "builtin" {
+			t.Errorf("expected default query engine 'builtin', got '%s'", c.Query.QueryEngine)
 		}
 	})
 }
@@ -202,13 +202,18 @@ func expectedSettings() models.Settings {
 			Font: models.FontSettings{
 				Size: settings.DefaultFontSize,
 			},
+			ConfirmDestructive: true,
 		},
 		Editor: models.EditorSettings{
 			Font: models.FontSettings{
 				Size: settings.DefaultFontSize,
 			},
 			LineNumbers: true,
-			QueryEngine: "builtin",
+		},
+		Query: models.QuerySettings{
+			DefaultLimit:    settings.DefaultResultLimit,
+			DefaultPageSize: settings.DefaultResultPageSize,
+			QueryEngine:     "builtin",
 		},
 		Terminal: models.TerminalSettings{
 			Font: models.FontSettings{

--- a/internal/settings/testdata/expected_save_configuration.yaml
+++ b/internal/settings/testdata/expected_save_configuration.yaml
@@ -10,14 +10,18 @@ general:
       language: "auto"
       font:
            size: 14
+      confirmDestructive: true
 editor:
       lineNumbers: true
       showFolding: false
       dropText: false
       links: false
-      queryEngine: "builtin"
       font:
            size: 14
+query:
+      defaultLimit: 42
+      defaultPageSize: 25
+      queryEngine: "builtin"
 terminal:
       font:
            size: 14

--- a/internal/settings/testdata/expected_save_window_state.yaml
+++ b/internal/settings/testdata/expected_save_window_state.yaml
@@ -10,6 +10,7 @@ general:
   language: auto
   font:
     size: 14
+  confirmDestructive: true
 editor:
   font:
     size: 14
@@ -17,6 +18,9 @@ editor:
   showFolding: false
   dropText: false
   links: false
+query:
+  defaultLimit: 42
+  defaultPageSize: 25
   queryEngine: builtin
 terminal:
   font:


### PR DESCRIPTION
## Summary

- Adds a new **Query** settings tab with default result limit, default results-table page size, and query engine
- Adds a **Confirm destructive operations** toggle to the General settings tab (defaults ON)
- Replaces the hard-coded `limit(42)` and page-size `25` literals with values from settings, and gates the drop-collection / drop-database confirmation dialogs on the new toggle
- One-shot YAML migration moves `editor.queryEngine` to `query.queryEngine` on first load

Fixes #177

## Test plan

- [x] `go test ./...` passes (covers settings defaults, clamping, legacy queryEngine migration, restore)
- [x] `bun run lint` passes
- [x] `bun run test` passes (15 files / 303 tests, including new `settingsStore.test.ts`)
- [x] Manual: open Settings → Query, change defaults, confirm they persist
- [x] Manual: change defaultLimit and verify "Open query" inserts `.limit(N)` with the new value
- [x] Manual: change defaultPageSize and verify the results table picker reflects the new default
- [x] Manual: toggle confirm-destructive off and verify drop-collection / drop-database skip the confirmation dialog
- [x] Manual: load a config file with the legacy `editor.queryEngine` field and verify it migrates to `query.queryEngine` and is persisted