### PR TITLE
fix(updates): trigger due-check from frontend after subscribe

### DIFF
--- a/frontend/src/features/updates/updateStore.ts
+++ b/frontend/src/features/updates/updateStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { CheckNow, DismissUpdate, OpenReleasePage } from 'wailsjs/go/api/UpdatesProxy'
+import { CheckIfDue, CheckNow, DismissUpdate, OpenReleasePage } from 'wailsjs/go/api/UpdatesProxy'
 import { EventsOn, EventsOff } from 'wailsjs/runtime/runtime'
 import { useSettingsStore } from '@/features/settings/settingsStore'
 
@@ -30,6 +30,7 @@ export const useUpdateStore = defineStore('updates', () => {
     EventsOn('update-available', (info: UpdateInfo) => {
       applyEvent(info)
     })
+    void CheckIfDue()
   }
 
   function unsubscribe() {

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -9,6 +9,7 @@ import (
 
 type UpdatesService interface {
 	CheckNow(ctx context.Context) (updates.UpdateInfo, error)
+	CheckIfDue(ctx context.Context) error
 	DismissVersion(version string) error
 }
 
@@ -38,6 +39,14 @@ func (p *UpdatesProxy) CheckNow() Result[updates.UpdateInfo] {
 		return FailResult[updates.UpdateInfo](err)
 	}
 	return SuccessResult(info)
+}
+
+func (p *UpdatesProxy) CheckIfDue() EmptyResult {
+	if err := p.svc.CheckIfDue(p.ctx); err != nil {
+		logFail(p.log, "CheckIfDue", err)
+		return Fail(err)
+	}
+	return Success()
 }
 
 func (p *UpdatesProxy) DismissUpdate(version string) EmptyResult {

--- a/internal/api/updates_test.go
+++ b/internal/api/updates_test.go
@@ -17,6 +17,9 @@ type fakeUpdatesService struct {
 func (f *fakeUpdatesService) CheckNow(ctx context.Context) (updates.UpdateInfo, error) {
 	return f.info, f.err
 }
+func (f *fakeUpdatesService) CheckIfDue(ctx context.Context) error {
+	return f.err
+}
 func (f *fakeUpdatesService) DismissVersion(v string) error {
 	f.dismissed = v
 	return nil

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -183,12 +183,6 @@ func (a *App) Startup(ctx context.Context) {
 	a.updatesEmitter.SetContext(ctx)
 	a.updatesOpener.SetContext(ctx)
 	a.UpdatesProxy.Init(ctx)
-
-	go func() {
-		if err := a.updatesService.CheckIfDue(ctx); err != nil {
-			a.log.Warn("update check failed", slog.Any("error", err))
-		}
-	}()
 }
 
 // DomReady is called after front-end resources have been loaded


### PR DESCRIPTION
## Summary
- Automatic update checks (`startup`/`daily`/`weekly` frequency) never surfaced. Only the manual **Check Now** button worked.
- Root cause: `Startup` launched `updatesService.CheckIfDue` in a goroutine that emitted `update-available` before the frontend's `EventsOn` handler was registered in `AppContent.onMounted`. Wails events are fire-and-forget — payload lost.
- Fix: expose `CheckIfDue` on `UpdatesProxy`; the frontend store invokes it inside `subscribe()` after `EventsOn` registers. Removed the racing goroutine in `Startup`.

## Test plan
- [x] `go test ./...` passes
- [ ] Set frequency to `startup`, restart app — update notification appears when newer release exists
- [ ] Set frequency to `daily`, force `lastCheckedAt` > 24h old, restart — check fires and emits
- [ ] Manual **Check Now** still works
- [ ] Frequency `never` does not check