### PR TITLE
fix(ci): build linux on ubuntu-24.04 with webkit2gtk-4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           - os: windows-latest
             platform: windows/arm64
             arch: arm64
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             platform: linux/amd64
             arch: amd64
           - os: macos-latest
@@ -98,7 +98,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libgtk-3-dev libwebkit2gtk-4.0-dev pkg-config libfuse-dev libfuse2
+          sudo apt-get install -y build-essential libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev pkg-config libfuse-dev libfuse2
 
       # ── macOS dependencies ──
       - name: Install macOS dependencies


### PR DESCRIPTION
## Summary
- v2026.05.1 release build failed because `wails.json` pins the `webkit2_41` build tag but CI installed `libwebkit2gtk-4.0-dev` on ubuntu-22.04.
- Bump linux runner to ubuntu-24.04 and install `libwebkit2gtk-4.1-dev` + `libsoup-3.0-dev`.

## Test plan
- [ ] Re-tag once merged; release workflow's linux build step succeeds and uploads AppImage/deb/rpm.