### PR TITLE
fix(ci): install imagemagick on ubuntu-24.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev pkg-config libfuse-dev libfuse2
+          sudo apt-get install -y build-essential libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev pkg-config libfuse-dev libfuse2 imagemagick
 
       # ── macOS dependencies ──
       - name: Install macOS dependencies


### PR DESCRIPTION
v2026.05.1 release retry failed because ubuntu-24.04 doesn't ship ImageMagick. Add it explicitly so the AppImage icon resize step works.

Fixes the linux build of v2026.05.1 release.