### PR TITLE
fix(ci): add librsvg2-dev and libgtk-3-bin for AppImage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev pkg-config libfuse-dev libfuse2 imagemagick
+          sudo apt-get install -y build-essential libgtk-3-dev libgtk-3-bin libwebkit2gtk-4.1-dev libsoup-3.0-dev librsvg2-dev pkg-config libfuse-dev libfuse2 imagemagick
 
       # ── macOS dependencies ──
       - name: Install macOS dependencies


### PR DESCRIPTION
v2026.05.1 release retry: linux build succeeds but AppImage packaging fails because the linuxdeploy gtk plugin needs librsvg-2.0.pc (`librsvg2-dev`) and gtk-query-immodules-3.0 (`libgtk-3-bin`). Add both to apt install.