### PR TITLE
feat(queryengine): require() support for built-in modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.8
 require (
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dop251/goja v0.0.0-20260311135729-065cd970411c
+	github.com/dop251/goja_nodejs v0.0.0-20260212111938-1f56ff5bcf14
 	github.com/flopp/go-findfont v0.1.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
@@ -35,7 +36,7 @@ require (
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dop251/goja_nodejs v0.0.0-20260212111938-1f56ff5bcf14 // indirect
+	github.com/dop251/base64dec v0.0.0-20231022112746-c6c9f9a96217 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/dop251/goja_nodejs v0.0.0-20260212111938-1f56ff5bcf14 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dop251/goja v0.0.0-20260311135729-065cd970411c h1:OcLmPfx1T1RmZVHHFwWMPaZDdRf0DBMZOFMVWJa7Pdk=
 github.com/dop251/goja v0.0.0-20260311135729-065cd970411c/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
+github.com/dop251/goja_nodejs v0.0.0-20260212111938-1f56ff5bcf14 h1:3U8dTgyNBhEQ/GVw0jZW5q+93Zw2gAZPRWhJ9TwV3rM=
+github.com/dop251/goja_nodejs v0.0.0-20260212111938-1f56ff5bcf14/go.mod h1:Tb7Xxye4LX7cT3i8YLvmPMGCV92IOi4CDZvm/V8ylc0=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pM
 github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dop251/base64dec v0.0.0-20231022112746-c6c9f9a96217 h1:16iT9CBDOniJwFGPI41MbUDfEk74hFaKTqudrX8kenY=
+github.com/dop251/base64dec v0.0.0-20231022112746-c6c9f9a96217/go.mod h1:eIb+f24U+eWQCIsj9D/ah+MD9UP+wdxuqzsdLD+mhGM=
 github.com/dop251/goja v0.0.0-20260311135729-065cd970411c h1:OcLmPfx1T1RmZVHHFwWMPaZDdRf0DBMZOFMVWJa7Pdk=
 github.com/dop251/goja v0.0.0-20260311135729-065cd970411c/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
 github.com/dop251/goja_nodejs v0.0.0-20260212111938-1f56ff5bcf14 h1:3U8dTgyNBhEQ/GVw0jZW5q+93Zw2gAZPRWhJ9TwV3rM=

--- a/internal/queryengine/goja_engine.go
+++ b/internal/queryengine/goja_engine.go
@@ -6,8 +6,13 @@ import (
 	"reflect"
 	"strings"
 	"vervet/internal/models"
+	"vervet/internal/queryengine/jsmodules"
 
 	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/buffer"
+	"github.com/dop251/goja_nodejs/console"
+	"github.com/dop251/goja_nodejs/process"
+	"github.com/dop251/goja_nodejs/require"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -17,14 +22,21 @@ import (
 type GojaEngine struct {
 	client   *mongo.Client
 	pageSize int64
+	registry *require.Registry
 }
 
 func NewGojaEngine(client *mongo.Client, pageSize int64) *GojaEngine {
-	return &GojaEngine{client: client, pageSize: pageSize}
+	registry := require.NewRegistry()
+	jsmodules.RegisterAll(registry)
+	return &GojaEngine{client: client, pageSize: pageSize, registry: registry}
 }
 
 func (e *GojaEngine) ExecuteQuery(ctx context.Context, uri, dbName, query string) (models.QueryResult, error) {
 	rt := goja.New()
+	e.registry.Enable(rt)
+	buffer.Enable(rt)
+	process.Enable(rt)
+	console.Enable(rt)
 	ec := &execContext{ctx: ctx, client: e.client, dbName: dbName, rt: rt, pageSize: e.pageSize}
 
 	if err := registerBSONTypes(rt); err != nil {

--- a/internal/queryengine/goja_engine_test.go
+++ b/internal/queryengine/goja_engine_test.go
@@ -2,6 +2,9 @@ package queryengine
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/dop251/goja"
@@ -318,4 +321,48 @@ func TestMultiStatement_VariableThenCursor(t *testing.T) {
 	cursor := extractLazyCursor(val)
 	require.NotNil(t, cursor)
 	assert.Equal(t, "users", cursor.collection)
+}
+
+func TestGojaEngine_RequireFS_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "doc.json")
+	require.NoError(t, os.WriteFile(p, []byte(`{"hello":"world","n":42}`), 0o644))
+
+	eng := NewGojaEngine(nil, 100)
+	script := fmt.Sprintf(`
+		const fs = require('fs');
+		JSON.parse(fs.readFileSync(%q, 'utf8'))
+	`, p)
+	res, err := eng.ExecuteQuery(context.Background(), "", "testdb", script)
+	require.NoError(t, err)
+	require.Len(t, res.Documents, 1)
+	doc := res.Documents[0].(map[string]any)
+	assert.Equal(t, "world", doc["hello"])
+}
+
+func TestGojaEngine_RequirePath_Join(t *testing.T) {
+	eng := NewGojaEngine(nil, 100)
+	res, err := eng.ExecuteQuery(context.Background(), "", "testdb",
+		`require('path').join('a', 'b', 'c.txt')`)
+	require.NoError(t, err)
+	assert.Equal(t, "a/b/c.txt", res.RawOutput)
+}
+
+func TestGojaEngine_RequireCrypto_Sha256(t *testing.T) {
+	eng := NewGojaEngine(nil, 100)
+	res, err := eng.ExecuteQuery(context.Background(), "", "testdb",
+		`require('crypto').createHash('sha256').update('abc').digest('hex')`)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		res.RawOutput,
+	)
+}
+
+func TestGojaEngine_RequireFS_MissingFileSurfacesENOENT(t *testing.T) {
+	eng := NewGojaEngine(nil, 100)
+	_, err := eng.ExecuteQuery(context.Background(), "", "testdb",
+		`require('fs').readFileSync('/definitely/not/here.txt', 'utf8')`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ENOENT")
 }

--- a/internal/queryengine/jsmodules/crypto.go
+++ b/internal/queryengine/jsmodules/crypto.go
@@ -1,0 +1,72 @@
+package jsmodules
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"hash"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+	"github.com/google/uuid"
+)
+
+func registerCrypto(r *require.Registry) {
+	r.RegisterNativeModule("crypto", func(rt *goja.Runtime, m *goja.Object) {
+		exports := m.Get("exports").(*goja.Object)
+
+		_ = exports.Set("createHash", func(call goja.FunctionCall) goja.Value {
+			alg := call.Argument(0).String()
+			var h hash.Hash
+			switch alg {
+			case "md5":
+				h = md5.New()
+			case "sha1":
+				h = sha1.New()
+			case "sha256":
+				h = sha256.New()
+			case "sha512":
+				h = sha512.New()
+			default:
+				panic(nodeError(rt, "ERR_OSSL_EVP_UNSUPPORTED", "unsupported hash algorithm: "+alg))
+			}
+			obj := rt.NewObject()
+			_ = obj.Set("update", func(call goja.FunctionCall) goja.Value {
+				h.Write([]byte(call.Argument(0).String()))
+				return obj
+			})
+			_ = obj.Set("digest", func(call goja.FunctionCall) goja.Value {
+				sum := h.Sum(nil)
+				if len(call.Arguments) == 0 {
+					return rt.ToValue(rt.NewArrayBuffer(sum))
+				}
+				switch call.Argument(0).String() {
+				case "hex":
+					return rt.ToValue(hex.EncodeToString(sum))
+				case "base64":
+					return rt.ToValue(base64.StdEncoding.EncodeToString(sum))
+				default:
+					panic(nodeError(rt, "ERR_INVALID_ARG_VALUE", "unsupported digest encoding"))
+				}
+			})
+			return obj
+		})
+
+		_ = exports.Set("randomBytes", func(call goja.FunctionCall) goja.Value {
+			n := int(call.Argument(0).ToInteger())
+			buf := make([]byte, n)
+			if _, err := rand.Read(buf); err != nil {
+				panic(nodeError(rt, "EUNKNOWN", err.Error()))
+			}
+			return rt.ToValue(rt.NewArrayBuffer(buf))
+		})
+
+		_ = exports.Set("randomUUID", func(call goja.FunctionCall) goja.Value {
+			return rt.ToValue(uuid.NewString())
+		})
+	})
+}

--- a/internal/queryengine/jsmodules/crypto_test.go
+++ b/internal/queryengine/jsmodules/crypto_test.go
@@ -1,0 +1,68 @@
+package jsmodules
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCrypto_Sha256Hex(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('crypto').createHash('sha256').update('abc').digest('hex')`)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		val.Export(),
+	)
+}
+
+func TestCrypto_Md5Hex(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('crypto').createHash('md5').update('abc').digest('hex')`)
+	require.NoError(t, err)
+	assert.Equal(t, "900150983cd24fb0d6963f7d28e17f72", val.Export())
+}
+
+func TestCrypto_Sha1Base64(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('crypto').createHash('sha1').update('abc').digest('base64')`)
+	require.NoError(t, err)
+	assert.Equal(t, "qZk+NkcGgWq6PiVxeFDCbJzQ2J0=", val.Export())
+}
+
+func TestCrypto_HashChainedUpdates(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`
+		const h = require('crypto').createHash('sha256');
+		h.update('a'); h.update('b'); h.update('c');
+		h.digest('hex')
+	`)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		val.Export(),
+	)
+}
+
+func TestCrypto_UnknownAlgPanics(t *testing.T) {
+	rt := newTestRuntime(t)
+	_, err := rt.RunString(`require('crypto').createHash('nope')`)
+	require.Error(t, err)
+}
+
+func TestCrypto_RandomUUID(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('crypto').randomUUID()`)
+	require.NoError(t, err)
+	re := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	assert.Regexp(t, re, val.Export())
+}
+
+func TestCrypto_RandomBytesLength(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('crypto').randomBytes(16).byteLength`)
+	require.NoError(t, err)
+	assert.EqualValues(t, 16, val.Export())
+}

--- a/internal/queryengine/jsmodules/fs.go
+++ b/internal/queryengine/jsmodules/fs.go
@@ -1,0 +1,98 @@
+package jsmodules
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"syscall"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+)
+
+// fsErrCode maps a Go error to a Node-style errno string.
+func fsErrCode(err error) string {
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return "ENOENT"
+	case errors.Is(err, fs.ErrPermission):
+		return "EACCES"
+	case errors.Is(err, fs.ErrExist):
+		return "EEXIST"
+	case errors.Is(err, syscall.EISDIR):
+		return "EISDIR"
+	case errors.Is(err, syscall.ENOTDIR):
+		return "ENOTDIR"
+	default:
+		return ""
+	}
+}
+
+func panicFSErr(rt *goja.Runtime, err error) {
+	panic(nodeError(rt, fsErrCode(err), err.Error()))
+}
+
+func registerFS(r *require.Registry) {
+	r.RegisterNativeModule("fs", func(rt *goja.Runtime, m *goja.Object) {
+		exports := m.Get("exports").(*goja.Object)
+
+		_ = exports.Set("readFileSync", func(call goja.FunctionCall) goja.Value {
+			path := call.Argument(0).String()
+			encoding := ""
+			if len(call.Arguments) > 1 {
+				arg := call.Argument(1)
+				if s, ok := arg.Export().(string); ok {
+					encoding = s
+				} else if obj, ok := arg.Export().(map[string]any); ok {
+					if e, ok := obj["encoding"].(string); ok {
+						encoding = e
+					}
+				}
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				panicFSErr(rt, err)
+			}
+			if encoding == "" {
+				return rt.ToValue(rt.NewArrayBuffer(data))
+			}
+			return rt.ToValue(string(data))
+		})
+
+		_ = exports.Set("existsSync", func(call goja.FunctionCall) goja.Value {
+			_, err := os.Stat(call.Argument(0).String())
+			return rt.ToValue(err == nil)
+		})
+
+		_ = exports.Set("statSync", func(call goja.FunctionCall) goja.Value {
+			info, err := os.Stat(call.Argument(0).String())
+			if err != nil {
+				panicFSErr(rt, err)
+			}
+			obj := rt.NewObject()
+			_ = obj.Set("size", info.Size())
+			_ = obj.Set("mtime", info.ModTime())
+			_ = obj.Set("mtimeMs", info.ModTime().UnixMilli())
+			_ = obj.Set("mode", uint32(info.Mode().Perm()))
+			isFile := info.Mode().IsRegular()
+			isDir := info.IsDir()
+			isSymlink := info.Mode()&os.ModeSymlink != 0
+			_ = obj.Set("isFile", func(goja.FunctionCall) goja.Value { return rt.ToValue(isFile) })
+			_ = obj.Set("isDirectory", func(goja.FunctionCall) goja.Value { return rt.ToValue(isDir) })
+			_ = obj.Set("isSymbolicLink", func(goja.FunctionCall) goja.Value { return rt.ToValue(isSymlink) })
+			return obj
+		})
+
+		_ = exports.Set("readdirSync", func(call goja.FunctionCall) goja.Value {
+			entries, err := os.ReadDir(call.Argument(0).String())
+			if err != nil {
+				panicFSErr(rt, err)
+			}
+			names := make([]string, len(entries))
+			for i, e := range entries {
+				names[i] = e.Name()
+			}
+			return rt.ToValue(names)
+		})
+	})
+}

--- a/internal/queryengine/jsmodules/fs.go
+++ b/internal/queryengine/jsmodules/fs.go
@@ -94,5 +94,107 @@ func registerFS(r *require.Registry) {
 			}
 			return rt.ToValue(names)
 		})
+
+		_ = exports.Set("writeFileSync", func(call goja.FunctionCall) goja.Value {
+			path := call.Argument(0).String()
+			data := []byte(call.Argument(1).String())
+			if err := os.WriteFile(path, data, 0o644); err != nil {
+				panicFSErr(rt, err)
+			}
+			return goja.Undefined()
+		})
+
+		_ = exports.Set("appendFileSync", func(call goja.FunctionCall) goja.Value {
+			path := call.Argument(0).String()
+			data := []byte(call.Argument(1).String())
+			f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+			if err != nil {
+				panicFSErr(rt, err)
+			}
+			defer f.Close()
+			if _, err := f.Write(data); err != nil {
+				panicFSErr(rt, err)
+			}
+			return goja.Undefined()
+		})
+
+		_ = exports.Set("mkdirSync", func(call goja.FunctionCall) goja.Value {
+			path := call.Argument(0).String()
+			recursive := false
+			mode := os.FileMode(0o755)
+			if len(call.Arguments) > 1 {
+				if obj, ok := call.Argument(1).Export().(map[string]any); ok {
+					if r, ok := obj["recursive"].(bool); ok {
+						recursive = r
+					}
+					if m, ok := obj["mode"].(int64); ok {
+						mode = os.FileMode(m)
+					}
+				}
+			}
+			var err error
+			if recursive {
+				err = os.MkdirAll(path, mode)
+			} else {
+				err = os.Mkdir(path, mode)
+			}
+			if err != nil {
+				panicFSErr(rt, err)
+			}
+			return goja.Undefined()
+		})
+
+		_ = exports.Set("rmSync", func(call goja.FunctionCall) goja.Value {
+			path := call.Argument(0).String()
+			recursive := false
+			force := false
+			if len(call.Arguments) > 1 {
+				if obj, ok := call.Argument(1).Export().(map[string]any); ok {
+					if r, ok := obj["recursive"].(bool); ok {
+						recursive = r
+					}
+					if f, ok := obj["force"].(bool); ok {
+						force = f
+					}
+				}
+			}
+			var err error
+			if recursive {
+				err = os.RemoveAll(path)
+			} else {
+				err = os.Remove(path)
+			}
+			if err != nil && !(force && errors.Is(err, fs.ErrNotExist)) {
+				panicFSErr(rt, err)
+			}
+			return goja.Undefined()
+		})
+
+		_ = exports.Set("unlinkSync", func(call goja.FunctionCall) goja.Value {
+			if err := os.Remove(call.Argument(0).String()); err != nil {
+				panicFSErr(rt, err)
+			}
+			return goja.Undefined()
+		})
+
+		_ = exports.Set("renameSync", func(call goja.FunctionCall) goja.Value {
+			if err := os.Rename(call.Argument(0).String(), call.Argument(1).String()); err != nil {
+				panicFSErr(rt, err)
+			}
+			return goja.Undefined()
+		})
+
+		_ = exports.Set("copyFileSync", func(call goja.FunctionCall) goja.Value {
+			src := call.Argument(0).String()
+			dst := call.Argument(1).String()
+			data, err := os.ReadFile(src)
+			if err != nil {
+				panicFSErr(rt, err)
+			}
+			if err := os.WriteFile(dst, data, 0o644); err != nil {
+				panicFSErr(rt, err)
+			}
+			return goja.Undefined()
+		})
 	})
 }

--- a/internal/queryengine/jsmodules/fs_test.go
+++ b/internal/queryengine/jsmodules/fs_test.go
@@ -86,6 +86,114 @@ func TestFS_StatSyncDirectory(t *testing.T) {
 	assert.Equal(t, []any{false, true}, val.Export())
 }
 
+func TestFS_WriteFileSyncRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "out.txt")
+
+	rt := newTestRuntime(t)
+	require.NoError(t, rt.Set("P", p))
+	_, err := rt.RunString(`require('fs').writeFileSync(P, 'hello')`)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(got))
+}
+
+func TestFS_AppendFileSync(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "log.txt")
+	require.NoError(t, os.WriteFile(p, []byte("a"), 0o644))
+
+	rt := newTestRuntime(t)
+	require.NoError(t, rt.Set("P", p))
+	_, err := rt.RunString(`require('fs').appendFileSync(P, 'b')`)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	assert.Equal(t, "ab", string(got))
+}
+
+func TestFS_MkdirSyncRecursive(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "a", "b", "c")
+
+	rt := newTestRuntime(t)
+	require.NoError(t, rt.Set("P", target))
+	_, err := rt.RunString(`require('fs').mkdirSync(P, {recursive: true})`)
+	require.NoError(t, err)
+
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestFS_RmSyncRecursive(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "f"), []byte(""), 0o644))
+
+	rt := newTestRuntime(t)
+	require.NoError(t, rt.Set("P", sub))
+	_, err := rt.RunString(`require('fs').rmSync(P, {recursive: true, force: true})`)
+	require.NoError(t, err)
+
+	_, err = os.Stat(sub)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestFS_UnlinkSync(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "x")
+	require.NoError(t, os.WriteFile(p, []byte(""), 0o644))
+
+	rt := newTestRuntime(t)
+	require.NoError(t, rt.Set("P", p))
+	_, err := rt.RunString(`require('fs').unlinkSync(P)`)
+	require.NoError(t, err)
+
+	_, err = os.Stat(p)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestFS_RenameSync(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	require.NoError(t, os.WriteFile(a, []byte("x"), 0o644))
+
+	rt := newTestRuntime(t)
+	require.NoError(t, rt.Set("A", a))
+	require.NoError(t, rt.Set("B", b))
+	_, err := rt.RunString(`require('fs').renameSync(A, B)`)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(b)
+	require.NoError(t, err)
+	assert.Equal(t, "x", string(got))
+}
+
+func TestFS_CopyFileSync(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	require.NoError(t, os.WriteFile(a, []byte("x"), 0o644))
+
+	rt := newTestRuntime(t)
+	require.NoError(t, rt.Set("A", a))
+	require.NoError(t, rt.Set("B", b))
+	_, err := rt.RunString(`require('fs').copyFileSync(A, B)`)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(b)
+	require.NoError(t, err)
+	assert.Equal(t, "x", string(got))
+	_, err = os.Stat(a)
+	require.NoError(t, err)
+}
+
 func TestFS_ReaddirSync(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "a"), []byte(""), 0o644))

--- a/internal/queryengine/jsmodules/fs_test.go
+++ b/internal/queryengine/jsmodules/fs_test.go
@@ -1,0 +1,99 @@
+package jsmodules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFS_ReadFileSyncUtf8(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "x.txt")
+	require.NoError(t, os.WriteFile(p, []byte("hello"), 0o644))
+
+	rt := newTestRuntime(t)
+	require.NoError(t, rt.Set("P", p))
+	val, err := rt.RunString(`require('fs').readFileSync(P, 'utf8')`)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", val.Export())
+}
+
+func TestFS_ReadFileSyncOptionsObject(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "x.txt")
+	require.NoError(t, os.WriteFile(p, []byte("hi"), 0o644))
+
+	rt := newTestRuntime(t)
+	require.NoError(t, rt.Set("P", p))
+	val, err := rt.RunString(`require('fs').readFileSync(P, {encoding: 'utf8'})`)
+	require.NoError(t, err)
+	assert.Equal(t, "hi", val.Export())
+}
+
+func TestFS_ReadFileSyncMissingErrors(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`
+		try {
+			require('fs').readFileSync('/definitely/not/here.txt', 'utf8');
+			'no-error';
+		} catch (e) {
+			e.code;
+		}
+	`)
+	require.NoError(t, err)
+	assert.Equal(t, "ENOENT", val.Export())
+}
+
+func TestFS_ExistsSync(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "x.txt")
+	require.NoError(t, os.WriteFile(p, []byte("hi"), 0o644))
+
+	rt := newTestRuntime(t)
+	require.NoError(t, rt.Set("P", p))
+	val, err := rt.RunString(`[require('fs').existsSync(P), require('fs').existsSync('/nope/nope')]`)
+	require.NoError(t, err)
+	assert.Equal(t, []any{true, false}, val.Export())
+}
+
+func TestFS_StatSyncFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "x.txt")
+	require.NoError(t, os.WriteFile(p, []byte("12345"), 0o644))
+
+	rt := newTestRuntime(t)
+	require.NoError(t, rt.Set("P", p))
+	val, err := rt.RunString(`
+		const s = require('fs').statSync(P);
+		[s.size, s.isFile(), s.isDirectory()]
+	`)
+	require.NoError(t, err)
+	assert.Equal(t, []any{int64(5), true, false}, val.Export())
+}
+
+func TestFS_StatSyncDirectory(t *testing.T) {
+	dir := t.TempDir()
+	rt := newTestRuntime(t)
+	require.NoError(t, rt.Set("P", dir))
+	val, err := rt.RunString(`
+		const s = require('fs').statSync(P);
+		[s.isFile(), s.isDirectory()]
+	`)
+	require.NoError(t, err)
+	assert.Equal(t, []any{false, true}, val.Export())
+}
+
+func TestFS_ReaddirSync(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b"), []byte(""), 0o644))
+
+	rt := newTestRuntime(t)
+	require.NoError(t, rt.Set("P", dir))
+	val, err := rt.RunString(`require('fs').readdirSync(P).sort()`)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, val.Export())
+}

--- a/internal/queryengine/jsmodules/jsmodules.go
+++ b/internal/queryengine/jsmodules/jsmodules.go
@@ -19,8 +19,13 @@ func RegisterAll(r *require.Registry) {
 
 // nodeError builds a JS Error with a Node-style `code` property.
 // Pass to panic() to surface as a script error from the runtime.
+// The code is prefixed onto the message so it surfaces in Go errors too.
 func nodeError(rt *goja.Runtime, code, msg string) *goja.Object {
-	obj := rt.NewGoError(errors.New(msg))
+	full := msg
+	if code != "" {
+		full = code + ": " + msg
+	}
+	obj := rt.NewGoError(errors.New(full))
 	_ = obj.Set("code", code)
 	return obj
 }

--- a/internal/queryengine/jsmodules/jsmodules.go
+++ b/internal/queryengine/jsmodules/jsmodules.go
@@ -26,6 +26,5 @@ func nodeError(rt *goja.Runtime, code, msg string) *goja.Object {
 }
 
 // Stubs replaced by per-module files in subsequent tasks.
-func registerOS(r *require.Registry)     {}
 func registerCrypto(r *require.Registry) {}
 func registerFS(r *require.Registry)     {}

--- a/internal/queryengine/jsmodules/jsmodules.go
+++ b/internal/queryengine/jsmodules/jsmodules.go
@@ -1,0 +1,32 @@
+// Package jsmodules registers Node-compatible built-in modules
+// (fs, path, os, crypto) onto a goja_nodejs require.Registry.
+package jsmodules
+
+import (
+	"errors"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+)
+
+// RegisterAll registers fs, path, os, and crypto on the given registry.
+func RegisterAll(r *require.Registry) {
+	registerPath(r)
+	registerOS(r)
+	registerCrypto(r)
+	registerFS(r)
+}
+
+// nodeError builds a JS Error with a Node-style `code` property.
+// Pass to panic() to surface as a script error from the runtime.
+func nodeError(rt *goja.Runtime, code, msg string) *goja.Object {
+	obj := rt.NewGoError(errors.New(msg))
+	_ = obj.Set("code", code)
+	return obj
+}
+
+// Stubs replaced by per-module files in subsequent tasks.
+func registerPath(r *require.Registry)   {}
+func registerOS(r *require.Registry)     {}
+func registerCrypto(r *require.Registry) {}
+func registerFS(r *require.Registry)     {}

--- a/internal/queryengine/jsmodules/jsmodules.go
+++ b/internal/queryengine/jsmodules/jsmodules.go
@@ -26,7 +26,6 @@ func nodeError(rt *goja.Runtime, code, msg string) *goja.Object {
 }
 
 // Stubs replaced by per-module files in subsequent tasks.
-func registerPath(r *require.Registry)   {}
 func registerOS(r *require.Registry)     {}
 func registerCrypto(r *require.Registry) {}
 func registerFS(r *require.Registry)     {}

--- a/internal/queryengine/jsmodules/jsmodules.go
+++ b/internal/queryengine/jsmodules/jsmodules.go
@@ -25,5 +25,3 @@ func nodeError(rt *goja.Runtime, code, msg string) *goja.Object {
 	return obj
 }
 
-// Stub replaced by per-module file in subsequent task.
-func registerFS(r *require.Registry) {}

--- a/internal/queryengine/jsmodules/jsmodules.go
+++ b/internal/queryengine/jsmodules/jsmodules.go
@@ -25,6 +25,5 @@ func nodeError(rt *goja.Runtime, code, msg string) *goja.Object {
 	return obj
 }
 
-// Stubs replaced by per-module files in subsequent tasks.
-func registerCrypto(r *require.Registry) {}
-func registerFS(r *require.Registry)     {}
+// Stub replaced by per-module file in subsequent task.
+func registerFS(r *require.Registry) {}

--- a/internal/queryengine/jsmodules/jsmodules_test.go
+++ b/internal/queryengine/jsmodules/jsmodules_test.go
@@ -1,0 +1,28 @@
+package jsmodules
+
+import (
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/buffer"
+	gojarequire "github.com/dop251/goja_nodejs/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRuntime(t *testing.T) *goja.Runtime {
+	t.Helper()
+	registry := gojarequire.NewRegistry()
+	RegisterAll(registry)
+	rt := goja.New()
+	registry.Enable(rt)
+	buffer.Enable(rt)
+	return rt
+}
+
+func TestRegisterAll_EnablesRequire(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`typeof require`)
+	require.NoError(t, err)
+	assert.Equal(t, "function", val.Export())
+}

--- a/internal/queryengine/jsmodules/os.go
+++ b/internal/queryengine/jsmodules/os.go
@@ -1,0 +1,72 @@
+package jsmodules
+
+import (
+	"os"
+	"os/user"
+	"runtime"
+	"strconv"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+)
+
+func registerOS(r *require.Registry) {
+	r.RegisterNativeModule("os", func(rt *goja.Runtime, m *goja.Object) {
+		exports := m.Get("exports").(*goja.Object)
+		eol := "\n"
+		if runtime.GOOS == "windows" {
+			eol = "\r\n"
+		}
+		_ = exports.Set("EOL", eol)
+		_ = exports.Set("homedir", func(call goja.FunctionCall) goja.Value {
+			h, err := os.UserHomeDir()
+			if err != nil {
+				return rt.ToValue("")
+			}
+			return rt.ToValue(h)
+		})
+		_ = exports.Set("tmpdir", func(call goja.FunctionCall) goja.Value {
+			return rt.ToValue(os.TempDir())
+		})
+		_ = exports.Set("platform", func(call goja.FunctionCall) goja.Value {
+			p := runtime.GOOS
+			if p == "windows" {
+				p = "win32"
+			}
+			return rt.ToValue(p)
+		})
+		_ = exports.Set("arch", func(call goja.FunctionCall) goja.Value {
+			a := runtime.GOARCH
+			switch a {
+			case "amd64":
+				a = "x64"
+			case "386":
+				a = "ia32"
+			}
+			return rt.ToValue(a)
+		})
+		_ = exports.Set("hostname", func(call goja.FunctionCall) goja.Value {
+			h, err := os.Hostname()
+			if err != nil {
+				return rt.ToValue("")
+			}
+			return rt.ToValue(h)
+		})
+		_ = exports.Set("userInfo", func(call goja.FunctionCall) goja.Value {
+			u, err := user.Current()
+			if err != nil {
+				panic(nodeError(rt, "EUNKNOWN", err.Error()))
+			}
+			uid, _ := strconv.Atoi(u.Uid)
+			gid, _ := strconv.Atoi(u.Gid)
+			shell := os.Getenv("SHELL")
+			return rt.ToValue(map[string]any{
+				"username": u.Username,
+				"homedir":  u.HomeDir,
+				"shell":    shell,
+				"uid":      uid,
+				"gid":      gid,
+			})
+		})
+	})
+}

--- a/internal/queryengine/jsmodules/os_test.go
+++ b/internal/queryengine/jsmodules/os_test.go
@@ -1,0 +1,74 @@
+package jsmodules
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOS_Homedir(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('os').homedir()`)
+	require.NoError(t, err)
+	assert.NotEmpty(t, val.Export())
+}
+
+func TestOS_Tmpdir(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('os').tmpdir()`)
+	require.NoError(t, err)
+	assert.NotEmpty(t, val.Export())
+}
+
+func TestOS_Platform(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('os').platform()`)
+	require.NoError(t, err)
+	want := map[string]string{"linux": "linux", "darwin": "darwin", "windows": "win32"}[runtime.GOOS]
+	if want == "" {
+		want = runtime.GOOS
+	}
+	assert.Equal(t, want, val.Export())
+}
+
+func TestOS_Arch(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('os').arch()`)
+	require.NoError(t, err)
+	want := map[string]string{"amd64": "x64", "arm64": "arm64", "386": "ia32"}[runtime.GOARCH]
+	if want == "" {
+		want = runtime.GOARCH
+	}
+	assert.Equal(t, want, val.Export())
+}
+
+func TestOS_Hostname(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('os').hostname()`)
+	require.NoError(t, err)
+	assert.NotEmpty(t, val.Export())
+}
+
+func TestOS_EOL(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('os').EOL`)
+	require.NoError(t, err)
+	want := "\n"
+	if runtime.GOOS == "windows" {
+		want = "\r\n"
+	}
+	assert.Equal(t, want, val.Export())
+}
+
+func TestOS_UserInfo(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('os').userInfo()`)
+	require.NoError(t, err)
+	m := val.Export().(map[string]any)
+	assert.NotEmpty(t, m["username"])
+	assert.NotEmpty(t, m["homedir"])
+	assert.Contains(t, m, "uid")
+	assert.Contains(t, m, "gid")
+}

--- a/internal/queryengine/jsmodules/path.go
+++ b/internal/queryengine/jsmodules/path.go
@@ -1,0 +1,79 @@
+package jsmodules
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+)
+
+func registerPath(r *require.Registry) {
+	r.RegisterNativeModule("path", func(rt *goja.Runtime, m *goja.Object) {
+		exports := m.Get("exports").(*goja.Object)
+		_ = exports.Set("sep", string(filepath.Separator))
+		_ = exports.Set("join", func(call goja.FunctionCall) goja.Value {
+			parts := make([]string, len(call.Arguments))
+			for i, a := range call.Arguments {
+				parts[i] = a.String()
+			}
+			return rt.ToValue(filepath.Join(parts...))
+		})
+		_ = exports.Set("resolve", func(call goja.FunctionCall) goja.Value {
+			parts := make([]string, len(call.Arguments))
+			for i, a := range call.Arguments {
+				parts[i] = a.String()
+			}
+			abs, err := filepath.Abs(filepath.Join(parts...))
+			if err != nil {
+				panic(rt.ToValue(err.Error()))
+			}
+			return rt.ToValue(abs)
+		})
+		_ = exports.Set("dirname", func(call goja.FunctionCall) goja.Value {
+			return rt.ToValue(filepath.Dir(call.Argument(0).String()))
+		})
+		_ = exports.Set("basename", func(call goja.FunctionCall) goja.Value {
+			base := filepath.Base(call.Argument(0).String())
+			if len(call.Arguments) > 1 {
+				ext := call.Argument(1).String()
+				base = strings.TrimSuffix(base, ext)
+			}
+			return rt.ToValue(base)
+		})
+		_ = exports.Set("extname", func(call goja.FunctionCall) goja.Value {
+			return rt.ToValue(filepath.Ext(call.Argument(0).String()))
+		})
+		_ = exports.Set("isAbsolute", func(call goja.FunctionCall) goja.Value {
+			return rt.ToValue(filepath.IsAbs(call.Argument(0).String()))
+		})
+		_ = exports.Set("normalize", func(call goja.FunctionCall) goja.Value {
+			return rt.ToValue(filepath.Clean(call.Argument(0).String()))
+		})
+		_ = exports.Set("relative", func(call goja.FunctionCall) goja.Value {
+			rel, err := filepath.Rel(call.Argument(0).String(), call.Argument(1).String())
+			if err != nil {
+				panic(rt.ToValue(err.Error()))
+			}
+			return rt.ToValue(rel)
+		})
+		_ = exports.Set("parse", func(call goja.FunctionCall) goja.Value {
+			p := call.Argument(0).String()
+			dir := filepath.Dir(p)
+			base := filepath.Base(p)
+			ext := filepath.Ext(p)
+			name := strings.TrimSuffix(base, ext)
+			root := ""
+			if filepath.IsAbs(p) {
+				root = string(filepath.Separator)
+			}
+			return rt.ToValue(map[string]any{
+				"root": root,
+				"dir":  dir,
+				"base": base,
+				"ext":  ext,
+				"name": name,
+			})
+		})
+	})
+}

--- a/internal/queryengine/jsmodules/path_test.go
+++ b/internal/queryengine/jsmodules/path_test.go
@@ -1,0 +1,51 @@
+package jsmodules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPath_Join(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('path').join('a', 'b', 'c.txt')`)
+	require.NoError(t, err)
+	assert.Equal(t, "a/b/c.txt", val.Export())
+}
+
+func TestPath_BasenameAndExtname(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`
+		const p = require('path');
+		[p.basename('/foo/bar.txt'), p.extname('/foo/bar.txt'), p.dirname('/foo/bar.txt')]
+	`)
+	require.NoError(t, err)
+	assert.Equal(t, []any{"bar.txt", ".txt", "/foo"}, val.Export())
+}
+
+func TestPath_IsAbsolute(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`[require('path').isAbsolute('/x'), require('path').isAbsolute('x')]`)
+	require.NoError(t, err)
+	assert.Equal(t, []any{true, false}, val.Export())
+}
+
+func TestPath_Parse(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('path').parse('/foo/bar.txt')`)
+	require.NoError(t, err)
+	m := val.Export().(map[string]any)
+	assert.Equal(t, "/", m["root"])
+	assert.Equal(t, "/foo", m["dir"])
+	assert.Equal(t, "bar.txt", m["base"])
+	assert.Equal(t, ".txt", m["ext"])
+	assert.Equal(t, "bar", m["name"])
+}
+
+func TestPath_Sep(t *testing.T) {
+	rt := newTestRuntime(t)
+	val, err := rt.RunString(`require('path').sep`)
+	require.NoError(t, err)
+	assert.Equal(t, "/", val.Export())
+}


### PR DESCRIPTION
## Summary
- Adds `require()` to GojaEngine for `fs`, `path`, `os`, `crypto` so mongosh-style scripts run unchanged
- New `internal/queryengine/jsmodules` package — one file per module, hand-rolled on top of `goja_nodejs/require`
- Registry built once per `GojaEngine`; reused across queries. `buffer`, `process`, `console` enabled per runtime
- Sync-only `fs` (readFileSync, writeFileSync, statSync, mkdirSync, rmSync, unlinkSync, etc) with Node-style error codes (ENOENT, EACCES, EISDIR, ...)

## Test plan
- [x] Unit tests per module under `jsmodules/` (no Mongo required)
- [x] Integration tests in `goja_engine_test.go` exercising require() through `ExecuteQuery`
- [x] `go vet ./...` clean
- [x] `go test ./...` passes

Fixes #231