### PR TITLE
fix(settings): surface save errors and trim oversized save payload

### DIFF
--- a/frontend/src/features/settings/settingsStore.ts
+++ b/frontend/src/features/settings/settingsStore.ts
@@ -210,7 +210,24 @@ export const useSettingsStore = defineStore('settings', {
       this.fontList = result.data
     },
     async saveConfiguration(): Promise<boolean> {
-      const result = await settingsProxy.SetSettings(this)
+      const payload: models.Settings = {
+        window: this.window,
+        general: this.general,
+        editor: this.editor,
+        query: this.query,
+        terminal: this.terminal,
+        workspaces: this.workspaces,
+        updates: this.updates,
+        logging: this.logging,
+      } as models.Settings
+      const result = await settingsProxy.SetSettings(payload)
+      if (!result.isSuccess) {
+        const notifier = useNotifier()
+        notifier.error(i18nGlobal.t(`errors.${result.errorCode || 'unknown_error'}`), {
+          title: i18nGlobal.t('errorTitles.saveSettings'),
+          detail: result.errorDetail,
+        })
+      }
       return result.isSuccess
     },
     async restoreConfiguration(): Promise<boolean> {


### PR DESCRIPTION
## Summary

- Stop sending the full Pinia store (`fontList`, `previousVersion`) to `SetSettings`; send only the `models.Settings` shape.
- Notify the user when save fails so silent IPC failures surface.

## Why

User reported on Windows that switching query engine in Settings → Query → Save did nothing, no error shown. Likely cause: oversized payload over Wails/WebView2 IPC (Windows machines often have many installed fonts, blowing up `fontList`). Save returned failure but UI swallowed it.

Fixes #233

## Test plan

- [ ] `bun run lint` clean
- [ ] `bun run test` passes (313/313 locally)
- [ ] Manual on Windows: Settings → Query → switch engine → Save → dialog closes, engine persisted across restart
- [ ] Manual: simulate save failure (e.g. read-only config) → notifier error appears