### PR TITLE
feat(server-pane): copy connection string from server tree

### DIFF
--- a/frontend/src/features/server-pane/useServerTreeContextMenu.ts
+++ b/frontend/src/features/server-pane/useServerTreeContextMenu.ts
@@ -2,6 +2,7 @@ import { markRaw, nextTick, reactive, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
   ArrowUpTrayIcon,
+  ClipboardDocumentIcon,
   Cog8ToothIcon,
   DocumentDuplicateIcon,
   FolderPlusIcon,
@@ -9,6 +10,7 @@ import {
   PlusCircleIcon,
   TrashIcon,
 } from '@heroicons/vue/24/outline'
+import * as serversProxy from 'wailsjs/go/api/ServersProxy'
 import { useDataBrowserStore } from '@/features/data-browser/browserStore.ts'
 import { DialogType, useDialogStore } from '@/stores/dialog.ts'
 import { type RegisteredServerNode, useServerStore } from '@/features/server-pane/serverStore.ts'
@@ -27,6 +29,7 @@ export const MenuKeys = {
   ServerConnect: 'server_connect',
   ServerDelete: 'server_delete',
   ServerExport: 'server_export',
+  ServerCopyConnectionString: 'server_copy_connection_string',
   GroupExport: 'group_export',
 } as const
 
@@ -107,6 +110,11 @@ export function useServerTreeContextMenu(
         key: MenuKeys.ServerExport,
         label: 'serverPane.exportServerMenuItem',
         icon: ArrowUpTrayIcon,
+      },
+      {
+        key: MenuKeys.ServerCopyConnectionString,
+        label: 'serverPane.serverTree.copyConnectionString',
+        icon: ClipboardDocumentIcon,
       },
       { type: 'divider', key: 'd1' },
       {
@@ -192,7 +200,7 @@ export function useServerTreeContextMenu(
     }
   }
 
-  const handleSelectContextMenu = (key: string) => {
+  const handleSelectContextMenu = async (key: string) => {
     contextMenuParams.show = false
     const serverId = selectedKeys.value[0]
     if (!serverId) return
@@ -239,6 +247,20 @@ export function useServerTreeContextMenu(
       case MenuKeys.GroupExport:
         dialogStore.showNewDialog(DialogType.Export, { serverIDs: [serverId] })
         break
+      case MenuKeys.ServerCopyConnectionString: {
+        const result = await serversProxy.GetFullConnectionString(serverId)
+        if (!result.isSuccess) {
+          useMessager().error(i18n.t('serverPane.serverTree.copyConnectionStringFailed'))
+          break
+        }
+        try {
+          await navigator.clipboard.writeText(result.data)
+          useMessager().success(i18n.t('serverPane.serverTree.connectionStringCopied'))
+        } catch {
+          useMessager().error(i18n.t('serverPane.serverTree.copyConnectionStringFailed'))
+        }
+        break
+      }
       default:
         console.warn(`missing context menu option handling for key '${key}'`)
     }

--- a/frontend/src/features/server-pane/useServerTreeContextMenu.ts
+++ b/frontend/src/features/server-pane/useServerTreeContextMenu.ts
@@ -116,7 +116,7 @@ export function useServerTreeContextMenu(
         label: 'serverPane.serverTree.copyConnectionString',
         icon: ClipboardDocumentIcon,
       },
-      { type: 'divider', key: 'd1' },
+      { type: 'divider', key: 'd1', label: '' },
       {
         key: MenuKeys.ServerDelete,
         label: 'serverPane.serverTree.deleteServer',

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -562,6 +562,9 @@ export default {
       empty: 'No Mongo Servers Added',
       deleteGroupTooltip: 'Are you sure you want to delete group "{name}"?',
       deleteGroupWithChildrenTooltip: 'Delete "{name}" and all its sub-groups and servers?',
+      copyConnectionString: 'Copy Connection String',
+      connectionStringCopied: 'Connection string copied to clipboard',
+      copyConnectionStringFailed: 'Failed to copy connection string',
     },
     dialogs: {
       common: {

--- a/frontend/wailsjs/go/api/ServersProxy.d.ts
+++ b/frontend/wailsjs/go/api/ServersProxy.d.ts
@@ -9,6 +9,8 @@ export function ExportServers(arg1:Array<string>,arg2:boolean):Promise<api.Resul
 
 export function GetConnectionConfig(arg1:string):Promise<api.Result_vervet_internal_models_ConnectionConfig_>;
 
+export function GetFullConnectionString(arg1:string):Promise<api.Result_string_>;
+
 export function GetServer(arg1:string):Promise<api.Result_vervet_internal_models_RegisteredServer_>;
 
 export function GetServers():Promise<api.Result___vervet_internal_models_RegisteredServer_>;

--- a/frontend/wailsjs/go/api/ServersProxy.js
+++ b/frontend/wailsjs/go/api/ServersProxy.js
@@ -14,6 +14,10 @@ export function GetConnectionConfig(arg1) {
   return window['go']['api']['ServersProxy']['GetConnectionConfig'](arg1);
 }
 
+export function GetFullConnectionString(arg1) {
+  return window['go']['api']['ServersProxy']['GetFullConnectionString'](arg1);
+}
+
 export function GetServer(arg1) {
   return window['go']['api']['ServersProxy']['GetServer'](arg1);
 }

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -21,6 +21,7 @@ type ServersProvider interface {
 	GetConnectionConfig(serverID string) (models.ConnectionConfig, error)
 	ExportServers(serverIDs []string, includeSensitiveData bool) ([]byte, error)
 	ImportServers(data []byte) (*servers.ImportResult, error)
+	BuildFullConnectionString(id string) (string, error)
 }
 
 // ServersProxy exposes the ServerService to the UI
@@ -168,4 +169,13 @@ func (sp *ServersProxy) ImportServers(jsonData string) Result[servers.ImportResu
 		return FailResult[servers.ImportResult](err)
 	}
 	return SuccessResult(*result)
+}
+
+func (sp *ServersProxy) GetFullConnectionString(id string) Result[string] {
+	uri, err := sp.sm.BuildFullConnectionString(id)
+	if err != nil {
+		logFail(sp.log, "GetFullConnectionString", err)
+		return FailResult[string](err)
+	}
+	return SuccessResult(uri)
 }

--- a/internal/api/servers_test.go
+++ b/internal/api/servers_test.go
@@ -11,9 +11,10 @@ import (
 )
 
 type MockServersProvider struct {
-	err     error
-	server  *models.RegisteredServer
-	servers []models.RegisteredServer
+	err            error
+	server         *models.RegisteredServer
+	servers        []models.RegisteredServer
+	fullConnString string
 }
 
 func (m *MockServersProvider) GetServers() ([]models.RegisteredServer, error) {
@@ -47,6 +48,13 @@ func (m *MockServersProvider) GetURI(id string) (string, error) {
 		return "", m.err
 	}
 	return "mongodb://localhost", nil
+}
+
+func (m *MockServersProvider) BuildFullConnectionString(id string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.fullConnString, nil
 }
 
 func (m *MockServersProvider) CreateGroup(parentID, name string) error {
@@ -287,6 +295,30 @@ func TestServersProxy_GetURI(t *testing.T) {
 		proxy := NewServersProxy(testLogger(), provider)
 
 		result := proxy.GetURI("1")
+
+		assert.False(t, result.IsSuccess)
+		assert.NotEmpty(t, result.ErrorCode)
+	})
+}
+
+func TestServersProxy_GetFullConnectionString(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		provider := &MockServersProvider{
+			fullConnString: "mongodb://example.com/?authMechanism=MONGODB-OIDC&authMechanismProperties=ALLOWED_HOSTS:*",
+		}
+		proxy := NewServersProxy(testLogger(), provider)
+
+		result := proxy.GetFullConnectionString("s1")
+
+		assert.True(t, result.IsSuccess)
+		assert.Equal(t, provider.fullConnString, result.Data)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		provider := &MockServersProvider{err: errors.New("boom")}
+		proxy := NewServersProxy(testLogger(), provider)
+
+		result := proxy.GetFullConnectionString("s1")
 
 		assert.False(t, result.IsSuccess)
 		assert.NotEmpty(t, result.ErrorCode)

--- a/internal/servers/connection_string_builder.go
+++ b/internal/servers/connection_string_builder.go
@@ -1,0 +1,29 @@
+package servers
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// buildOIDCURI returns rawURI with authMechanism=MONGODB-OIDC and
+// authMechanismProperties=ALLOWED_HOSTS:* injected into its query string.
+// Existing values for either parameter are preserved (idempotent).
+//
+// The defaults match what internal/clientregistry/registry.go applies at
+// connect time, so the returned URI is usable as-is in mongosh.
+func buildOIDCURI(rawURI string) (string, error) {
+	u, err := url.Parse(rawURI)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse OIDC URI: %w", err)
+	}
+
+	q := u.Query()
+	if q.Get("authMechanism") == "" {
+		q.Set("authMechanism", "MONGODB-OIDC")
+	}
+	if q.Get("authMechanismProperties") == "" {
+		q.Set("authMechanismProperties", "ALLOWED_HOSTS:*")
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}

--- a/internal/servers/connection_string_builder_test.go
+++ b/internal/servers/connection_string_builder_test.go
@@ -1,0 +1,81 @@
+package servers
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildOIDCURI_AddsBothParamsWhenAbsent(t *testing.T) {
+	in := "mongodb://example.com:27017/?retryWrites=true"
+	out, err := buildOIDCURI(in)
+	require.NoError(t, err)
+
+	u, err := url.Parse(out)
+	require.NoError(t, err)
+	q := u.Query()
+	assert.Equal(t, "MONGODB-OIDC", q.Get("authMechanism"))
+	assert.Equal(t, "ALLOWED_HOSTS:*", q.Get("authMechanismProperties"))
+	assert.Equal(t, "true", q.Get("retryWrites"))
+}
+
+func TestBuildOIDCURI_IdempotentWhenBothPresent(t *testing.T) {
+	in := "mongodb://example.com/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure"
+	out, err := buildOIDCURI(in)
+	require.NoError(t, err)
+
+	u, err := url.Parse(out)
+	require.NoError(t, err)
+	q := u.Query()
+	assert.Equal(t, "MONGODB-OIDC", q.Get("authMechanism"))
+	assert.Equal(t, "ENVIRONMENT:azure", q.Get("authMechanismProperties"))
+}
+
+func TestBuildOIDCURI_FillsPropertiesWhenMechanismPresent(t *testing.T) {
+	in := "mongodb://example.com/?authMechanism=MONGODB-OIDC"
+	out, err := buildOIDCURI(in)
+	require.NoError(t, err)
+
+	u, err := url.Parse(out)
+	require.NoError(t, err)
+	q := u.Query()
+	assert.Equal(t, "MONGODB-OIDC", q.Get("authMechanism"))
+	assert.Equal(t, "ALLOWED_HOSTS:*", q.Get("authMechanismProperties"))
+}
+
+func TestBuildOIDCURI_PreservesUserInfoAndHostList(t *testing.T) {
+	in := "mongodb://user:pass@host1:27017,host2:27017/admin?ssl=true"
+	out, err := buildOIDCURI(in)
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(out, "mongodb://user:pass@host1:27017,host2:27017/admin?"),
+		"expected user info, host list and path preserved, got %q", out)
+
+	u, err := url.Parse(out)
+	require.NoError(t, err)
+	q := u.Query()
+	assert.Equal(t, "true", q.Get("ssl"))
+	assert.Equal(t, "MONGODB-OIDC", q.Get("authMechanism"))
+	assert.Equal(t, "ALLOWED_HOSTS:*", q.Get("authMechanismProperties"))
+}
+
+func TestBuildOIDCURI_SrvScheme(t *testing.T) {
+	in := "mongodb+srv://cluster.example.com/"
+	out, err := buildOIDCURI(in)
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(out, "mongodb+srv://cluster.example.com/"),
+		"expected scheme preserved, got %q", out)
+	u, err := url.Parse(out)
+	require.NoError(t, err)
+	assert.Equal(t, "MONGODB-OIDC", u.Query().Get("authMechanism"))
+	assert.Equal(t, "ALLOWED_HOSTS:*", u.Query().Get("authMechanismProperties"))
+}
+
+func TestBuildOIDCURI_ErrorOnUnparseable(t *testing.T) {
+	_, err := buildOIDCURI("://not a url")
+	assert.Error(t, err)
+}

--- a/internal/servers/service.go
+++ b/internal/servers/service.go
@@ -294,6 +294,34 @@ func (sm *ServerService) GetURI(id string) (string, error) {
 	return uri, nil
 }
 
+// BuildFullConnectionString returns the stored URI for a registered server,
+// synthesizing missing auth-mechanism parameters for OIDC. Other auth methods
+// return the URI verbatim. Returns an error if the server is not registered or
+// the keyring lookup fails.
+func (sm *ServerService) BuildFullConnectionString(serverID string) (string, error) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	servers, err := sm.store.LoadServers()
+	if err != nil {
+		return "", fmt.Errorf("failed to load registered servers: %w", err)
+	}
+	server, _ := findServer(serverID, servers)
+	if server == nil {
+		return "", fmt.Errorf("server with ID %s not found", serverID)
+	}
+
+	cfg, err := sm.connectionStrings.GetConnectionConfig(serverID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get connection config: %w", err)
+	}
+
+	if cfg.AuthMethod == models.AuthOIDC {
+		return buildOIDCURI(cfg.URI)
+	}
+	return cfg.URI, nil
+}
+
 func findServer(serverID string, servers []models.RegisteredServer) (*models.RegisteredServer, int) {
 	if len(servers) == 0 {
 		return nil, -1

--- a/internal/servers/service_test.go
+++ b/internal/servers/service_test.go
@@ -35,8 +35,9 @@ func (m *mockServerStore) SaveServers(servers []models.RegisteredServer) error {
 
 // MockConnectionStringsStore is a mock implementation of ConnectionStringsStore for testing.
 type MockConnectionStringsStore struct {
-	uris map[string]string
-	err  error
+	uris    map[string]string
+	configs map[string]models.ConnectionConfig
+	err     error
 }
 
 func (m *MockConnectionStringsStore) StoreRegisteredServerURI(id, uri string) error {
@@ -70,6 +71,10 @@ func (m *MockConnectionStringsStore) StoreConnectionConfig(id string, cfg models
 	if m.err != nil {
 		return m.err
 	}
+	if m.configs == nil {
+		m.configs = map[string]models.ConnectionConfig{}
+	}
+	m.configs[id] = cfg
 	m.uris[id] = cfg.URI
 	return nil
 }
@@ -77,6 +82,9 @@ func (m *MockConnectionStringsStore) StoreConnectionConfig(id string, cfg models
 func (m *MockConnectionStringsStore) GetConnectionConfig(id string) (models.ConnectionConfig, error) {
 	if m.err != nil {
 		return models.ConnectionConfig{}, m.err
+	}
+	if cfg, ok := m.configs[id]; ok {
+		return cfg, nil
 	}
 	uri, ok := m.uris[id]
 	if !ok {

--- a/internal/servers/service_test.go
+++ b/internal/servers/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/url"
 	"sync"
 	"testing"
 	"vervet/internal/connectionStrings"
@@ -383,4 +384,40 @@ func TestBuildFullConnectionString_KeyringError(t *testing.T) {
 
 	_, err := sm.BuildFullConnectionString("s1")
 	assert.Error(t, err)
+}
+
+func TestBuildFullConnectionString_OIDC_AddsParams(t *testing.T) {
+	cs := &MockConnectionStringsStore{uris: map[string]string{}}
+	require.NoError(t, cs.StoreConnectionConfig("s1", models.ConnectionConfig{
+		URI:        "mongodb://example.com/",
+		AuthMethod: models.AuthOIDC,
+	}))
+	store := &mockServerStore{servers: []models.RegisteredServer{{ID: "s1", Name: "S1"}}}
+	sm := newTestServerService(store, cs)
+
+	got, err := sm.BuildFullConnectionString("s1")
+	require.NoError(t, err)
+
+	u, err := url.Parse(got)
+	require.NoError(t, err)
+	assert.Equal(t, "MONGODB-OIDC", u.Query().Get("authMechanism"))
+	assert.Equal(t, "ALLOWED_HOSTS:*", u.Query().Get("authMechanismProperties"))
+}
+
+func TestBuildFullConnectionString_OIDC_PreservesUserParams(t *testing.T) {
+	in := "mongodb://example.com/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure"
+	cs := &MockConnectionStringsStore{uris: map[string]string{}}
+	require.NoError(t, cs.StoreConnectionConfig("s1", models.ConnectionConfig{
+		URI:        in,
+		AuthMethod: models.AuthOIDC,
+	}))
+	store := &mockServerStore{servers: []models.RegisteredServer{{ID: "s1", Name: "S1"}}}
+	sm := newTestServerService(store, cs)
+
+	got, err := sm.BuildFullConnectionString("s1")
+	require.NoError(t, err)
+	u, err := url.Parse(got)
+	require.NoError(t, err)
+	assert.Equal(t, "MONGODB-OIDC", u.Query().Get("authMechanism"))
+	assert.Equal(t, "ENVIRONMENT:azure", u.Query().Get("authMechanismProperties"))
 }

--- a/internal/servers/service_test.go
+++ b/internal/servers/service_test.go
@@ -386,6 +386,15 @@ func TestBuildFullConnectionString_KeyringError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestBuildFullConnectionString_StoreError(t *testing.T) {
+	cs := &MockConnectionStringsStore{uris: map[string]string{}}
+	store := &mockServerStore{err: errors.New("yaml parse error")}
+	sm := newTestServerService(store, cs)
+
+	_, err := sm.BuildFullConnectionString("s1")
+	assert.Error(t, err)
+}
+
 func TestBuildFullConnectionString_OIDC_AddsParams(t *testing.T) {
 	cs := &MockConnectionStringsStore{uris: map[string]string{}}
 	require.NoError(t, cs.StoreConnectionConfig("s1", models.ConnectionConfig{

--- a/internal/servers/service_test.go
+++ b/internal/servers/service_test.go
@@ -10,6 +10,7 @@ import (
 	"vervet/internal/models"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // mockServerStore is a mock implementation of serverStore for testing.
@@ -336,4 +337,50 @@ func TestGetURI(t *testing.T) {
 		assert.Error(t, err)
 		assert.Empty(t, uri)
 	})
+}
+
+func TestBuildFullConnectionString_VerbatimAuthMethods(t *testing.T) {
+	cases := []struct {
+		name   string
+		method models.AuthMethod
+		uri    string
+	}{
+		{"none", models.AuthNone, "mongodb://example.com:27017/?retryWrites=true"},
+		{"password", models.AuthPassword, "mongodb://user:pass@example.com:27017/admin"},
+		{"x509", models.AuthX509, "mongodb://example.com/?authMechanism=MONGODB-X509&tlsCertificateKeyFile=/c.pem"},
+		{"aws", models.AuthAWS, "mongodb://example.com/?authMechanism=MONGODB-AWS"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := &MockConnectionStringsStore{uris: map[string]string{}}
+			require.NoError(t, cs.StoreConnectionConfig("s1", models.ConnectionConfig{
+				URI:        tc.uri,
+				AuthMethod: tc.method,
+			}))
+			store := &mockServerStore{servers: []models.RegisteredServer{{ID: "s1", Name: "S1"}}}
+			sm := newTestServerService(store, cs)
+
+			got, err := sm.BuildFullConnectionString("s1")
+			require.NoError(t, err)
+			assert.Equal(t, tc.uri, got)
+		})
+	}
+}
+
+func TestBuildFullConnectionString_ServerNotFound(t *testing.T) {
+	cs := &MockConnectionStringsStore{uris: map[string]string{}}
+	store := &mockServerStore{servers: []models.RegisteredServer{}}
+	sm := newTestServerService(store, cs)
+
+	_, err := sm.BuildFullConnectionString("missing")
+	assert.Error(t, err)
+}
+
+func TestBuildFullConnectionString_KeyringError(t *testing.T) {
+	cs := &MockConnectionStringsStore{uris: map[string]string{}, err: errors.New("keyring locked")}
+	store := &mockServerStore{servers: []models.RegisteredServer{{ID: "s1", Name: "S1"}}}
+	sm := newTestServerService(store, cs)
+
+	_, err := sm.BuildFullConnectionString("s1")
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Summary
- Adds "Copy Connection String" item to server-tree right-click menu.
- Backend `ServerService.BuildFullConnectionString` synthesizes `authMechanism=MONGODB-OIDC` and `authMechanismProperties=ALLOWED_HOSTS:*` for OIDC servers (idempotent), returns URI verbatim for other auth methods. Mirrors what `clientregistry` injects at connect time so the pasted URI works as-is in mongosh.
- Wails proxy `ServersProxy.GetFullConnectionString` exposes it; frontend writes to `navigator.clipboard` and toasts success/failure.

## Test plan
- [x] `go test ./...` passes
- [x] `bun run lint` passes
- [x] Manual: right-click password server → Copy → paste matches URI in Edit dialog
- [x] Manual: right-click OIDC server with no `authMechanism` → paste → URI contains `authMechanism=MONGODB-OIDC&authMechanismProperties=ALLOWED_HOSTS%3A*`
- [x] Manual: right-click OIDC server with existing `authMechanismProperties=ENVIRONMENT:azure` → paste → existing properties preserved
- [x] Manual: group nodes show no Copy item
- [x] Manual: simulate keyring failure → error toast appears