### PR TITLE
feat(tabs): duplicate query tab via right-click context menu

### DIFF
--- a/frontend/src/features/queries/QueryTab.vue
+++ b/frontend/src/features/queries/QueryTab.vue
@@ -328,6 +328,7 @@ onMounted(async () => {
         queryStore.setDirty(props.queryId, currentContent !== saved)
       }
     })
+    queryStore.setCurrentContent(props.queryId, editor.value.getValue())
   }
 })
 

--- a/frontend/src/features/tabs/UnifiedContentPane.vue
+++ b/frontend/src/features/tabs/UnifiedContentPane.vue
@@ -115,6 +115,56 @@ function handleTabSelect(key: string) {
   activeInnerTabId.value = key
 }
 
+const contextMenuShown = ref(false)
+const contextMenuX = ref(0)
+const contextMenuY = ref(0)
+const contextMenuTargetId = ref<string | null>(null)
+const contextMenuTargetType = ref<UnifiedTab['type'] | null>(null)
+
+const contextMenuOptions = computed<DropdownOption[]>(() => {
+  if (contextMenuTargetType.value !== 'query') {
+    return []
+  }
+  return [
+    { label: t('query.tabContextMenu.duplicate'), key: 'duplicate' },
+  ]
+})
+
+function onTabContextMenu(e: MouseEvent, uTab: UnifiedTab) {
+  e.preventDefault()
+  if (uTab.type !== 'query') {
+    contextMenuShown.value = false
+    return
+  }
+  contextMenuTargetId.value = uTab.id
+  contextMenuTargetType.value = uTab.type
+  contextMenuX.value = e.clientX
+  contextMenuY.value = e.clientY
+  contextMenuShown.value = false
+  nextTick(() => {
+    contextMenuShown.value = true
+  })
+}
+
+function onContextMenuSelect(key: string) {
+  const targetId = contextMenuTargetId.value
+  contextMenuShown.value = false
+  if (!targetId) {
+    return
+  }
+  const serverId = tabStore.currentTab?.serverId
+  if (!serverId) {
+    return
+  }
+  if (key === 'duplicate') {
+    tabStore.duplicateQuery(serverId, targetId)
+  }
+}
+
+function onContextMenuClickOutside() {
+  contextMenuShown.value = false
+}
+
 function findIndexTabById(id: string) {
   return (tabStore.currentTab?.indexTabs ?? []).find((t) => t.id === id)
 }
@@ -208,6 +258,9 @@ async function promptSaveBeforeClose(queryId: string, state: QueryState): Promis
         :name="uTab.id"
         :tab="uTab.label"
         display-directive="show:lazy">
+        <template #tab>
+          <span @contextmenu="onTabContextMenu($event, uTab)">{{ uTab.label }}</span>
+        </template>
         <!-- Query content -->
         <QueryTab v-if="uTab.type === 'query'" :query-id="uTab.id" />
 
@@ -250,6 +303,15 @@ async function promptSaveBeforeClose(queryId: string, state: QueryState): Promis
     <div v-else class="empty-state">
       <n-empty :description="t('query.emptyState')" />
     </div>
+    <n-dropdown
+      trigger="manual"
+      placement="bottom-start"
+      :show="contextMenuShown"
+      :x="contextMenuX"
+      :y="contextMenuY"
+      :options="contextMenuOptions"
+      @select="onContextMenuSelect"
+      @clickoutside="onContextMenuClickOutside" />
   </div>
 </template>
 

--- a/frontend/src/features/tabs/tabs.test.ts
+++ b/frontend/src/features/tabs/tabs.test.ts
@@ -99,6 +99,17 @@ describe('tabs.duplicateQuery', () => {
     expect(tabs.pendingFocusQueryId).toBe(dupId)
   })
 
+  it('switches nav to Browser via _setActivatedIndex', () => {
+    const tabs = useTabStore()
+    tabs.tabItems = [seedServerTab('s1')]
+    const srcId = tabs.openQuery('s1', 'mydb')!
+    // NavType is a const enum (inlined by tsc, not accessible at vitest runtime)
+    tabs.nav = 'servers' as never
+
+    tabs.duplicateQuery('s1', srcId)
+    expect(tabs.nav).toBe('browser')
+  })
+
   it('returns undefined for unknown serverId or queryId', () => {
     const tabs = useTabStore()
     tabs.tabItems = [seedServerTab('s1')]

--- a/frontend/src/features/tabs/tabs.test.ts
+++ b/frontend/src/features/tabs/tabs.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('wailsjs/go/api/SettingsProxy', () => ({
+  GetSettings: vi.fn(),
+  SetSettings: vi.fn(),
+  ResetSettings: vi.fn(),
+  GetAvailableFonts: vi.fn(),
+}))
+
+vi.mock('wailsjs/go/api/ShellProxy', () => ({
+  CheckMongosh: vi.fn(),
+  ExecuteQuery: vi.fn(),
+  FetchPage: vi.fn(),
+  CountForPage: vi.fn(),
+  CancelQuery: vi.fn(),
+}))
+
+vi.mock('wailsjs/go/api/FilesProxy', () => ({
+  SelectFile: vi.fn(),
+  ReadFile: vi.fn(),
+  SaveFile: vi.fn(),
+  WriteFile: vi.fn(),
+}))
+
+vi.mock('naive-ui', () => ({
+  useOsTheme: () => ({ value: 'light' }),
+}))
+
+vi.mock('@/utils/dialog.ts', () => ({
+  useDialoger: () => ({ confirm: vi.fn(), warning: vi.fn() }),
+  useNotifier: () => ({ error: vi.fn(), success: vi.fn(), info: vi.fn() }),
+}))
+
+import { useTabStore } from './tabs'
+import { useQueryStore } from '@/features/queries/queryStore'
+import type { ServerTabItem } from '@/types/ServerTabItem.ts'
+
+function seedServerTab(serverId: string): ServerTabItem {
+  return {
+    title: serverId,
+    blank: false,
+    serverId,
+    queries: [],
+  }
+}
+
+describe('tabs.duplicateQuery', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('inserts a new query tab immediately after the source', () => {
+    const tabs = useTabStore()
+    tabs.tabItems = [seedServerTab('s1')]
+    const firstId = tabs.openQuery('s1', 'mydb', 'first')!
+    const secondId = tabs.openQuery('s1', 'otherdb', 'second')!
+
+    const dupId = tabs.duplicateQuery('s1', firstId)
+    expect(dupId).toBeTruthy()
+
+    const ids = tabs.tabItems[0]!.queries.map((q) => q.id)
+    expect(ids).toEqual([firstId, dupId, secondId])
+  })
+
+  it('copies database and collectionName, leaves filePath unset', () => {
+    const tabs = useTabStore()
+    tabs.tabItems = [seedServerTab('s1')]
+    const srcId = tabs.openQuery('s1', 'mydb', 'first', 'mycoll')!
+    tabs.tabItems[0]!.queries[0]!.filePath = '/tmp/q.js'
+
+    const dupId = tabs.duplicateQuery('s1', srcId)!
+    const dup = tabs.tabItems[0]!.queries.find((q) => q.id === dupId)!
+    expect(dup.database).toBe('mydb')
+    expect(dup.collectionName).toBe('mycoll')
+    expect(dup.filePath).toBeUndefined()
+  })
+
+  it('seeds initialText with the source query store live content', () => {
+    const tabs = useTabStore()
+    tabs.tabItems = [seedServerTab('s1')]
+    const srcId = tabs.openQuery('s1', 'mydb')!
+    const queries = useQueryStore()
+    queries.initQueryState(srcId, 'mydb')
+    queries.setCurrentContent(srcId, 'db.foo.find({live: true})')
+
+    const dupId = tabs.duplicateQuery('s1', srcId)!
+    const dup = tabs.tabItems[0]!.queries.find((q) => q.id === dupId)!
+    expect(dup.initialText).toBe('db.foo.find({live: true})')
+  })
+
+  it('activates the new tab and marks pendingFocusQueryId', () => {
+    const tabs = useTabStore()
+    tabs.tabItems = [seedServerTab('s1')]
+    const srcId = tabs.openQuery('s1', 'mydb')!
+
+    const dupId = tabs.duplicateQuery('s1', srcId)!
+    expect(tabs.tabItems[0]!.activeInnerTabId).toBe(dupId)
+    expect(tabs.pendingFocusQueryId).toBe(dupId)
+  })
+
+  it('returns undefined for unknown serverId or queryId', () => {
+    const tabs = useTabStore()
+    tabs.tabItems = [seedServerTab('s1')]
+    const srcId = tabs.openQuery('s1', 'mydb')!
+
+    expect(tabs.duplicateQuery('missing', srcId)).toBeUndefined()
+    expect(tabs.duplicateQuery('s1', 'query-999999')).toBeUndefined()
+  })
+})

--- a/frontend/src/features/tabs/tabs.ts
+++ b/frontend/src/features/tabs/tabs.ts
@@ -312,17 +312,17 @@ export const useTabStore = defineStore('tabs', {
     duplicateQuery(serverId: string, queryId: string): string | undefined {
       const tabIndex = findIndex(this.tabItems, { serverId })
       if (tabIndex === -1) {
-        return undefined
+        return
       }
 
       const tab = this.tabItems[tabIndex]
       if (!tab) {
-        return undefined
+        return
       }
 
       const queryIndex = tab.queries.findIndex((q) => q.id === queryId)
       if (queryIndex === -1) {
-        return undefined
+        return
       }
 
       const source = tab.queries[queryIndex]!
@@ -338,6 +338,7 @@ export const useTabStore = defineStore('tabs', {
       tab.queries.splice(queryIndex + 1, 0, newItem)
       tab.activeInnerTabId = newItem.id
       this.pendingFocusQueryId = newItem.id
+      this._setActivatedIndex(tabIndex, true)
       return newItem.id
     },
 

--- a/frontend/src/features/tabs/tabs.ts
+++ b/frontend/src/features/tabs/tabs.ts
@@ -309,6 +309,38 @@ export const useTabStore = defineStore('tabs', {
       }
     },
 
+    duplicateQuery(serverId: string, queryId: string): string | undefined {
+      const tabIndex = findIndex(this.tabItems, { serverId })
+      if (tabIndex === -1) {
+        return undefined
+      }
+
+      const tab = this.tabItems[tabIndex]
+      if (!tab) {
+        return undefined
+      }
+
+      const queryIndex = tab.queries.findIndex((q) => q.id === queryId)
+      if (queryIndex === -1) {
+        return undefined
+      }
+
+      const source = tab.queries[queryIndex]!
+      const liveContent = useQueryStore().getQueryState(queryId).currentContent
+
+      const newItem: QueryTabItem = {
+        id: `query-${++queryIdCounter}`,
+        database: source.database,
+        initialText: liveContent,
+        collectionName: source.collectionName,
+      }
+
+      tab.queries.splice(queryIndex + 1, 0, newItem)
+      tab.activeInnerTabId = newItem.id
+      this.pendingFocusQueryId = newItem.id
+      return newItem.id
+    },
+
     queryTabLabel(tab: ServerTabItem, query: QueryTabItem): string {
       if (query.filePath) {
         return query.filePath.split('/').pop() ?? query.database

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -461,6 +461,9 @@ export default {
     objectFields: "{'{'} {count} fields {'}'}",
     binaryValue: 'Binary ({subType})',
     timestampValue: 'Timestamp({t}, {i})',
+    tabContextMenu: {
+      duplicate: 'Duplicate',
+    },
     contextMenu: {
       viewDocument: 'View Document',
       editDocument: 'Edit Document',


### PR DESCRIPTION
## Summary
- Adds right-click context menu on query tab headers with a single "Duplicate" action.
- New tab is inserted immediately after the source, copies database/collection, seeds the editor with the source's live content, and is independent (no `filePath`, no result/paging state).
- Non-query inner tabs (index/stats/schema) show no menu (browser context menu suppressed).
- Side-fix: `QueryTab.vue` now seeds `queryStore.currentContent` on mount so duplicate captures content even when the user has not typed yet.

Fixes #123

## Test plan
- [x] Vitest `tabs.test.ts`: ordering, copied fields, live content, activation + `pendingFocusQueryId`, nav switch, unknown ids.
- [x] `bun run lint` clean.
- [x] `bun run test` 332/332 passing.
- [x] Manual: right-click query tab → Duplicate → independent copy appears after source; right-click non-query tab → no menu.