### PR TITLE
feat(tabs): drag-reorder server and inner tabs

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -14,6 +14,7 @@
         "monaco-editor": "^0.55.1",
         "pinia": "^3.0.4",
         "sass": "^1.99.0",
+        "sortablejs": "^1.15.7",
         "vue": "^3.5.32",
         "vue-i18n": "^11.3.2",
         "wcwidth": "^1.0.1",
@@ -22,6 +23,7 @@
         "@babel/types": "^7.29.0",
         "@tsconfig/node24": "^24.0.4",
         "@types/node": "^24.12.2",
+        "@types/sortablejs": "^1.15.9",
         "@vicons/tabler": "^0.13.0",
         "@vitejs/plugin-vue": "^6.0.5",
         "@vue/eslint-config-prettier": "^10.2.0",
@@ -344,6 +346,8 @@
     "@types/lodash-es": ["@types/lodash-es@4.17.12", "", { "dependencies": { "@types/lodash": "*" } }, "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ=="],
 
     "@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "@types/sortablejs": ["@types/sortablejs@1.15.9", "", {}, "sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
@@ -828,6 +832,8 @@
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
+    "sortablejs": ["sortablejs@1.15.7", "", {}, "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "monaco-editor": "^0.55.1",
     "pinia": "^3.0.4",
     "sass": "^1.99.0",
+    "sortablejs": "^1.15.7",
     "vue": "^3.5.32",
     "vue-i18n": "^11.3.2",
     "wcwidth": "^1.0.1"
@@ -32,6 +33,7 @@
     "@babel/types": "^7.29.0",
     "@tsconfig/node24": "^24.0.4",
     "@types/node": "^24.12.2",
+    "@types/sortablejs": "^1.15.9",
     "@vicons/tabler": "^0.13.0",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vue/eslint-config-prettier": "^10.2.0",

--- a/frontend/src/features/tabs/ConnectedServerTabs.vue
+++ b/frontend/src/features/tabs/ConnectedServerTabs.vue
@@ -47,7 +47,7 @@ onBeforeUnmount(() => {
 
 watch(() => tabStore.tabs.length, () => nextTick(checkOverflow))
 
-useTabSortable(tabsRef, '.n-tabs-nav-scroll-content', (from, to) => {
+useTabSortable(tabsRef, '.n-tabs-wrapper', (from, to) => {
   tabStore.reorderTabs(from, to)
 })
 

--- a/frontend/src/features/tabs/ConnectedServerTabs.vue
+++ b/frontend/src/features/tabs/ConnectedServerTabs.vue
@@ -141,7 +141,7 @@ const exThemeVars = computed(() => {
     </template>
     <n-tab
       v-for="(t, index) in tabStore.tabs"
-      :key="index"
+      :key="t.serverId"
       :class="tabClass(index)"
       :closable="true"
       :name="index"

--- a/frontend/src/features/tabs/ConnectedServerTabs.vue
+++ b/frontend/src/features/tabs/ConnectedServerTabs.vue
@@ -189,4 +189,11 @@ const exThemeVars = computed(() => {
     right: -2px;
   }
 }
+
+:deep(.tab-sortable-fallback) {
+  opacity: 0 !important;
+}
+:deep(.tab-sortable-ghost) {
+  opacity: 0.4;
+}
 </style>

--- a/frontend/src/features/tabs/ConnectedServerTabs.vue
+++ b/frontend/src/features/tabs/ConnectedServerTabs.vue
@@ -10,6 +10,7 @@ import { useSettingsStore } from '@/features/settings/settingsStore.ts'
 import { ChevronDownIcon, ServerIcon } from '@heroicons/vue/24/outline'
 import type { ServerTabItem } from '@/types/ServerTabItem.ts'
 import Color from 'color'
+import { useTabSortable } from '@/features/tabs/useTabSortable'
 
 const tabStore = useTabStore()
 const serverStore = useServerStore()
@@ -45,6 +46,10 @@ onBeforeUnmount(() => {
 })
 
 watch(() => tabStore.tabs.length, () => nextTick(checkOverflow))
+
+useTabSortable(tabsRef, '.n-tabs-nav-scroll-content', (from, to) => {
+  tabStore.reorderTabs(from, to)
+})
 
 const serverDropdownOptions = computed<DropdownOption[]>(() => {
   return tabStore.tabs.map((tab, index) => ({

--- a/frontend/src/features/tabs/UnifiedContentPane.vue
+++ b/frontend/src/features/tabs/UnifiedContentPane.vue
@@ -350,4 +350,11 @@ async function promptSaveBeforeClose(queryId: string, state: QueryState): Promis
   justify-content: center;
   height: 100%;
 }
+
+:deep(.tab-sortable-fallback) {
+  opacity: 0 !important;
+}
+:deep(.tab-sortable-ghost) {
+  opacity: 0.4;
+}
 </style>

--- a/frontend/src/features/tabs/UnifiedContentPane.vue
+++ b/frontend/src/features/tabs/UnifiedContentPane.vue
@@ -12,6 +12,7 @@ import CollectionStatisticsTab from '@/features/statistics/CollectionStatisticsT
 import DatabaseStatisticsTab from '@/features/statistics/DatabaseStatisticsTab.vue'
 import ServerStatisticsTab from '@/features/statistics/ServerStatisticsTab.vue'
 import SchemaBrowserPane from '@/features/schema-browser/SchemaBrowserPane.vue'
+import { useTabSortable } from '@/features/tabs/useTabSortable'
 
 type UnifiedTab = {
   id: string
@@ -34,42 +35,35 @@ const unifiedTabs = computed<UnifiedTab[]>(() => {
   if (!tab) {
     return []
   }
+  const queryById = new Map(tab.queries.map((q) => [q.id, q] as const))
+  const indexById = new Map((tab.indexTabs ?? []).map((i) => [i.id, i] as const))
+  const statsById = new Map((tab.statisticsTabs ?? []).map((s) => [s.id, s] as const))
+  const schemaById = new Map((tab.schemaTabs ?? []).map((s) => [s.id, s] as const))
 
-  const tabs: UnifiedTab[] = []
-
-  for (const query of tab.queries) {
-    tabs.push({
-      id: query.id,
-      label: tabStore.queryTabLabel(tab, query),
-      type: 'query',
-    })
+  const result: UnifiedTab[] = []
+  for (const id of tab.innerTabOrder) {
+    const q = queryById.get(id)
+    if (q) {
+      result.push({ id, label: tabStore.queryTabLabel(tab, q), type: 'query' })
+      continue
+    }
+    const i = indexById.get(id)
+    if (i) {
+      result.push({ id, label: tabStore.indexTabLabel(tab, i), type: 'index' })
+      continue
+    }
+    const s = statsById.get(id)
+    if (s) {
+      result.push({ id, label: tabStore.statisticsTabLabel(tab, s), type: 'statistics' })
+      continue
+    }
+    const sc = schemaById.get(id)
+    if (sc) {
+      result.push({ id, label: tabStore.schemaTabLabel(tab, sc), type: 'schema' })
+      continue
+    }
   }
-
-  for (const indexTab of tab.indexTabs ?? []) {
-    tabs.push({
-      id: indexTab.id,
-      label: tabStore.indexTabLabel(tab, indexTab),
-      type: 'index',
-    })
-  }
-
-  for (const statsTab of tab.statisticsTabs ?? []) {
-    tabs.push({
-      id: statsTab.id,
-      label: tabStore.statisticsTabLabel(tab, statsTab),
-      type: 'statistics',
-    })
-  }
-
-  for (const schemaTab of tab.schemaTabs ?? []) {
-    tabs.push({
-      id: schemaTab.id,
-      label: tabStore.schemaTabLabel(tab, schemaTab),
-      type: 'schema',
-    })
-  }
-
-  return tabs
+  return result
 })
 
 const hasInnerTabs = computed(() => unifiedTabs.value.length > 0)
@@ -103,6 +97,14 @@ onBeforeUnmount(() => {
 })
 
 watch(() => unifiedTabs.value.length, () => nextTick(checkOverflow))
+
+useTabSortable(innerTabsRef, '.n-tabs-nav-scroll-content', (from, to) => {
+  const serverId = tabStore.currentTab?.serverId
+  if (!serverId) {
+    return
+  }
+  tabStore.reorderInnerTabs(serverId, from, to)
+})
 
 const tabDropdownOptions = computed<DropdownOption[]>(() => {
   return unifiedTabs.value.map((tab) => ({

--- a/frontend/src/features/tabs/UnifiedContentPane.vue
+++ b/frontend/src/features/tabs/UnifiedContentPane.vue
@@ -98,7 +98,7 @@ onBeforeUnmount(() => {
 
 watch(() => unifiedTabs.value.length, () => nextTick(checkOverflow))
 
-useTabSortable(innerTabsRef, '.n-tabs-nav-scroll-content', (from, to) => {
+useTabSortable(innerTabsRef, '.n-tabs-wrapper', (from, to) => {
   const serverId = tabStore.currentTab?.serverId
   if (!serverId) {
     return

--- a/frontend/src/features/tabs/tabs.test.ts
+++ b/frontend/src/features/tabs/tabs.test.ts
@@ -306,3 +306,54 @@ describe('tabs.reorderTabs', () => {
     expect(store.activeTabIndex).toBe(0)
   })
 })
+
+describe('tabs.reorderInnerTabs', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('reorders ids across types and leaves activeInnerTabId untouched', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    store.activeTabIndex = 0
+    const q = store.openQuery('s1', 'mydb')!
+    store.openIndexTab('s1', 'mydb', 'col')
+    const i = store.tabItems[0]!.innerTabOrder[1]!
+    store.tabItems[0]!.activeInnerTabId = q
+    store.reorderInnerTabs('s1', 0, 1)
+    expect(store.tabItems[0]!.innerTabOrder).toEqual([i, q])
+    expect(store.tabItems[0]!.activeInnerTabId).toBe(q)
+  })
+
+  it('is a no-op when from === to', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    store.activeTabIndex = 0
+    const q = store.openQuery('s1', 'mydb')!
+    store.openIndexTab('s1', 'mydb', 'col')
+    const before = [...store.tabItems[0]!.innerTabOrder]
+    store.reorderInnerTabs('s1', 0, 0)
+    expect(store.tabItems[0]!.innerTabOrder).toEqual(before)
+    expect(q).toBeDefined()
+  })
+
+  it('is a no-op for unknown serverId', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    store.activeTabIndex = 0
+    store.openQuery('s1', 'mydb')
+    const before = [...store.tabItems[0]!.innerTabOrder]
+    store.reorderInnerTabs('missing', 0, 1)
+    expect(store.tabItems[0]!.innerTabOrder).toEqual(before)
+  })
+
+  it('is a no-op for out-of-range indices', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    store.activeTabIndex = 0
+    store.openQuery('s1', 'mydb')
+    const before = [...store.tabItems[0]!.innerTabOrder]
+    store.reorderInnerTabs('s1', -1, 5)
+    expect(store.tabItems[0]!.innerTabOrder).toEqual(before)
+  })
+})

--- a/frontend/src/features/tabs/tabs.test.ts
+++ b/frontend/src/features/tabs/tabs.test.ts
@@ -177,3 +177,45 @@ describe('tabs.innerTabOrder maintenance on add', () => {
     expect(store.tabItems[0]!.innerTabOrder.length).toBe(1)
   })
 })
+
+describe('tabs.innerTabOrder maintenance on close', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('removes id on closeQuery', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    const a = store.openQuery('s1', 'mydb')!
+    const b = store.openQuery('s1', 'mydb')!
+    store.closeQuery('s1', a)
+    expect(store.tabItems[0]!.innerTabOrder).toEqual([b])
+  })
+
+  it('removes id on closeIndexTab', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    store.openIndexTab('s1', 'mydb', 'col')
+    const id = store.tabItems[0]!.innerTabOrder[0]!
+    store.closeIndexTab('s1', id)
+    expect(store.tabItems[0]!.innerTabOrder).toEqual([])
+  })
+
+  it('removes id on closeStatisticsTab', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    store.openStatisticsTab('s1', 'mydb', 'col', 'collection')
+    const id = store.tabItems[0]!.innerTabOrder[0]!
+    store.closeStatisticsTab('s1', id)
+    expect(store.tabItems[0]!.innerTabOrder).toEqual([])
+  })
+
+  it('removes id on closeSchemaTab', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    store.openSchemaTab('s1', 'mydb', 'col')
+    const id = store.tabItems[0]!.innerTabOrder[0]!
+    store.closeSchemaTab('s1', id)
+    expect(store.tabItems[0]!.innerTabOrder).toEqual([])
+  })
+})

--- a/frontend/src/features/tabs/tabs.test.ts
+++ b/frontend/src/features/tabs/tabs.test.ts
@@ -120,3 +120,60 @@ describe('tabs.duplicateQuery', () => {
     expect(tabs.duplicateQuery('s1', 'query-999999')).toBeUndefined()
   })
 })
+
+describe('tabs.innerTabOrder maintenance on add', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('appends id when openQuery is called', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    const id = store.openQuery('s1', 'mydb')
+    expect(store.tabItems[0]!.innerTabOrder).toEqual([id])
+  })
+
+  it('appends id when openIndexTab is called', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    store.openIndexTab('s1', 'mydb', 'col')
+    const ids = store.tabItems[0]!.innerTabOrder
+    expect(ids.length).toBe(1)
+    expect(ids[0]!.startsWith('index-')).toBe(true)
+  })
+
+  it('appends id when openStatisticsTab is called', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    store.openStatisticsTab('s1', 'mydb', 'col', 'collection')
+    const ids = store.tabItems[0]!.innerTabOrder
+    expect(ids.length).toBe(1)
+    expect(ids[0]!.startsWith('stats-')).toBe(true)
+  })
+
+  it('appends id when openSchemaTab is called', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    store.openSchemaTab('s1', 'mydb', 'col')
+    const ids = store.tabItems[0]!.innerTabOrder
+    expect(ids.length).toBe(1)
+    expect(ids[0]!.startsWith('schema-')).toBe(true)
+  })
+
+  it('inserts duplicated query id immediately after source', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    const a = store.openQuery('s1', 'mydb')!
+    const b = store.openQuery('s1', 'mydb')!
+    const dup = store.duplicateQuery('s1', a)!
+    expect(store.tabItems[0]!.innerTabOrder).toEqual([a, dup, b])
+  })
+
+  it('reuses existing entry when openIndexTab matches existing target', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    store.openIndexTab('s1', 'mydb', 'col')
+    store.openIndexTab('s1', 'mydb', 'col')
+    expect(store.tabItems[0]!.innerTabOrder.length).toBe(1)
+  })
+})

--- a/frontend/src/features/tabs/tabs.test.ts
+++ b/frontend/src/features/tabs/tabs.test.ts
@@ -236,3 +236,25 @@ describe('tabs.findFallbackInnerTabId via innerTabOrder', () => {
     expect(store.tabItems[0]!.activeInnerTabId).toBe(q1)
   })
 })
+
+describe('tabs.currentInnerTabIds', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('returns innerTabOrder of the active server tab', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    store.activeTabIndex = 0
+    const q = store.openQuery('s1', 'mydb')!
+    store.openIndexTab('s1', 'mydb', 'col')
+    expect(store.currentInnerTabIds).toEqual(store.tabItems[0]!.innerTabOrder)
+    expect(store.currentInnerTabIds[0]).toBe(q)
+  })
+
+  it('returns empty array when no tab is active', () => {
+    const store = useTabStore()
+    store.activeTabIndex = -1
+    expect(store.currentInnerTabIds).toEqual([])
+  })
+})

--- a/frontend/src/features/tabs/tabs.test.ts
+++ b/frontend/src/features/tabs/tabs.test.ts
@@ -219,3 +219,20 @@ describe('tabs.innerTabOrder maintenance on close', () => {
     expect(store.tabItems[0]!.innerTabOrder).toEqual([])
   })
 })
+
+describe('tabs.findFallbackInnerTabId via innerTabOrder', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('falls back to last id in innerTabOrder when active type empties', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('s1')]
+    const q1 = store.openQuery('s1', 'mydb')!
+    store.openIndexTab('s1', 'mydb', 'col')
+    const indexId = store.tabItems[0]!.innerTabOrder[1]!
+    store.tabItems[0]!.activeInnerTabId = indexId
+    store.closeIndexTab('s1', indexId)
+    expect(store.tabItems[0]!.activeInnerTabId).toBe(q1)
+  })
+})

--- a/frontend/src/features/tabs/tabs.test.ts
+++ b/frontend/src/features/tabs/tabs.test.ts
@@ -258,3 +258,51 @@ describe('tabs.currentInnerTabIds', () => {
     expect(store.currentInnerTabIds).toEqual([])
   })
 })
+
+describe('tabs.reorderTabs', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('moves an item from one position to another', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('a'), seedServerTab('b'), seedServerTab('c')]
+    store.activeTabIndex = 0
+    store.reorderTabs(0, 2)
+    expect(store.tabItems.map((t) => t.serverId)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('keeps the same tab active after the move', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('a'), seedServerTab('b'), seedServerTab('c')]
+    store.activeTabIndex = 1 // active = b
+    store.reorderTabs(0, 2) // a -> end; b shifts left
+    expect(store.tabItems[store.activeTabIndex]!.serverId).toBe('b')
+  })
+
+  it('keeps active tab when active itself is moved', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('a'), seedServerTab('b'), seedServerTab('c')]
+    store.activeTabIndex = 0 // active = a
+    store.reorderTabs(0, 2)
+    expect(store.tabItems[store.activeTabIndex]!.serverId).toBe('a')
+  })
+
+  it('is a no-op when from === to', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('a'), seedServerTab('b')]
+    store.activeTabIndex = 1
+    store.reorderTabs(1, 1)
+    expect(store.tabItems.map((t) => t.serverId)).toEqual(['a', 'b'])
+    expect(store.activeTabIndex).toBe(1)
+  })
+
+  it('is a no-op when indices out of range', () => {
+    const store = useTabStore()
+    store.tabItems = [seedServerTab('a'), seedServerTab('b')]
+    store.activeTabIndex = 0
+    store.reorderTabs(-1, 5)
+    expect(store.tabItems.map((t) => t.serverId)).toEqual(['a', 'b'])
+    expect(store.activeTabIndex).toBe(0)
+  })
+})

--- a/frontend/src/features/tabs/tabs.test.ts
+++ b/frontend/src/features/tabs/tabs.test.ts
@@ -42,6 +42,7 @@ function seedServerTab(serverId: string): ServerTabItem {
     blank: false,
     serverId,
     queries: [],
+    innerTabOrder: [],
   }
 }
 

--- a/frontend/src/features/tabs/tabs.ts
+++ b/frontend/src/features/tabs/tabs.ts
@@ -26,6 +26,7 @@ type TabStoreGetters = {
   currentStatisticsTab: () => StatisticsTabItem | undefined
   currentSchemaTabs: () => SchemaTabItem[]
   currentSchemaTab: () => SchemaTabItem | undefined
+  currentInnerTabIds: () => string[]
 }
 
 type TabUpsertOptions = ServerTabItem & {
@@ -116,6 +117,9 @@ export const useTabStore = defineStore('tabs', {
         return undefined
       }
       return tab.schemaTabs.find((t) => t.id === tab.activeInnerTabId)
+    },
+    currentInnerTabIds(state: TabStoreState) {
+      return state.tabItems[state.activeTabIndex]?.innerTabOrder ?? []
     },
   } as TabStoreGetters,
   actions: {

--- a/frontend/src/features/tabs/tabs.ts
+++ b/frontend/src/features/tabs/tabs.ts
@@ -611,5 +611,24 @@ export const useTabStore = defineStore('tabs', {
     schemaTabLabel(_tab: ServerTabItem, schemaTab: SchemaTabItem): string {
       return i18nGlobal.t('schemaBrowser.tabLabel', { collection: schemaTab.collectionName })
     },
+
+    reorderTabs(from: number, to: number) {
+      const len = this.tabItems.length
+      if (from === to) {
+        return
+      }
+      if (from < 0 || from >= len || to < 0 || to >= len) {
+        return
+      }
+      const activeTab = this.tabItems[this.activeTabIndex]
+      const [moved] = this.tabItems.splice(from, 1)
+      if (!moved) {
+        return
+      }
+      this.tabItems.splice(to, 0, moved)
+      if (activeTab) {
+        this.activeTabIndex = this.tabItems.indexOf(activeTab)
+      }
+    },
   },
 })

--- a/frontend/src/features/tabs/tabs.ts
+++ b/frontend/src/features/tabs/tabs.ts
@@ -630,5 +630,28 @@ export const useTabStore = defineStore('tabs', {
         this.activeTabIndex = this.tabItems.indexOf(activeTab)
       }
     },
+
+    reorderInnerTabs(serverId: string, from: number, to: number) {
+      const tabIndex = findIndex(this.tabItems, { serverId })
+      if (tabIndex === -1) {
+        return
+      }
+      const tab = this.tabItems[tabIndex]
+      if (!tab) {
+        return
+      }
+      const len = tab.innerTabOrder.length
+      if (from === to) {
+        return
+      }
+      if (from < 0 || from >= len || to < 0 || to >= len) {
+        return
+      }
+      const [moved] = tab.innerTabOrder.splice(from, 1)
+      if (moved == null) {
+        return
+      }
+      tab.innerTabOrder.splice(to, 0, moved)
+    },
   },
 })

--- a/frontend/src/features/tabs/tabs.ts
+++ b/frontend/src/features/tabs/tabs.ts
@@ -60,19 +60,10 @@ function innerTabType(id: string): BrowserSubTabType {
 }
 
 function findFallbackInnerTabId(tab: ServerTabItem): string | undefined {
-  if (tab.queries.length > 0) {
-    return tab.queries[tab.queries.length - 1]!.id
+  if (tab.innerTabOrder.length === 0) {
+    return undefined
   }
-  if (tab.indexTabs && tab.indexTabs.length > 0) {
-    return tab.indexTabs[tab.indexTabs.length - 1]!.id
-  }
-  if (tab.statisticsTabs && tab.statisticsTabs.length > 0) {
-    return tab.statisticsTabs[tab.statisticsTabs.length - 1]!.id
-  }
-  if (tab.schemaTabs && tab.schemaTabs.length > 0) {
-    return tab.schemaTabs[tab.schemaTabs.length - 1]!.id
-  }
-  return undefined
+  return tab.innerTabOrder[tab.innerTabOrder.length - 1]
 }
 
 export const useTabStore = defineStore('tabs', {

--- a/frontend/src/features/tabs/tabs.ts
+++ b/frontend/src/features/tabs/tabs.ts
@@ -301,6 +301,11 @@ export const useTabStore = defineStore('tabs', {
 
       tab.queries.splice(queryIndex, 1)
 
+      const orderIdx = tab.innerTabOrder.indexOf(queryId)
+      if (orderIdx !== -1) {
+        tab.innerTabOrder.splice(orderIdx, 1)
+      }
+
       if (tab.activeInnerTabId === queryId) {
         if (tab.queries.length > 0) {
           const newIndex = Math.min(queryIndex, tab.queries.length - 1)
@@ -414,6 +419,11 @@ export const useTabStore = defineStore('tabs', {
 
       tab.indexTabs.splice(idx, 1)
 
+      const orderIdx = tab.innerTabOrder.indexOf(indexTabId)
+      if (orderIdx !== -1) {
+        tab.innerTabOrder.splice(orderIdx, 1)
+      }
+
       if (tab.activeInnerTabId === indexTabId) {
         if (tab.indexTabs.length > 0) {
           const newIdx = Math.min(idx, tab.indexTabs.length - 1)
@@ -491,6 +501,11 @@ export const useTabStore = defineStore('tabs', {
       }
 
       tab.statisticsTabs.splice(idx, 1)
+
+      const orderIdx = tab.innerTabOrder.indexOf(statisticsTabId)
+      if (orderIdx !== -1) {
+        tab.innerTabOrder.splice(orderIdx, 1)
+      }
 
       if (tab.activeInnerTabId === statisticsTabId) {
         if (tab.statisticsTabs.length > 0) {
@@ -574,6 +589,11 @@ export const useTabStore = defineStore('tabs', {
       }
 
       tab.schemaTabs.splice(idx, 1)
+
+      const orderIdx = tab.innerTabOrder.indexOf(schemaTabId)
+      if (orderIdx !== -1) {
+        tab.innerTabOrder.splice(orderIdx, 1)
+      }
 
       if (tab.activeInnerTabId === schemaTabId) {
         if (tab.schemaTabs.length > 0) {

--- a/frontend/src/features/tabs/tabs.ts
+++ b/frontend/src/features/tabs/tabs.ts
@@ -276,6 +276,7 @@ export const useTabStore = defineStore('tabs', {
       }
 
       tab.queries.push(queryItem)
+      tab.innerTabOrder.push(queryItem.id)
       tab.activeInnerTabId = queryItem.id
       this._setActivatedIndex(tabIndex, true)
       this.pendingFocusQueryId = queryItem.id
@@ -337,6 +338,9 @@ export const useTabStore = defineStore('tabs', {
       }
 
       tab.queries.splice(queryIndex + 1, 0, newItem)
+      const orderIdx = tab.innerTabOrder.indexOf(queryId)
+      const insertAt = orderIdx === -1 ? tab.innerTabOrder.length : orderIdx + 1
+      tab.innerTabOrder.splice(insertAt, 0, newItem.id)
       tab.activeInnerTabId = newItem.id
       this.pendingFocusQueryId = newItem.id
       this._setActivatedIndex(tabIndex, true)
@@ -387,6 +391,7 @@ export const useTabStore = defineStore('tabs', {
       }
 
       tab.indexTabs.push(indexTab)
+      tab.innerTabOrder.push(indexTab.id)
       tab.activeInnerTabId = indexTab.id
       this._setActivatedIndex(tabIndex, true)
     },
@@ -464,6 +469,7 @@ export const useTabStore = defineStore('tabs', {
       }
 
       tab.statisticsTabs.push(statsTab)
+      tab.innerTabOrder.push(statsTab.id)
       tab.activeInnerTabId = statsTab.id
       this._setActivatedIndex(tabIndex, true)
     },
@@ -546,6 +552,7 @@ export const useTabStore = defineStore('tabs', {
       }
 
       tab.schemaTabs.push(schemaTab)
+      tab.innerTabOrder.push(schemaTab.id)
       tab.activeInnerTabId = schemaTab.id
       this._setActivatedIndex(tabIndex, true)
     },

--- a/frontend/src/features/tabs/tabs.ts
+++ b/frontend/src/features/tabs/tabs.ts
@@ -191,6 +191,7 @@ export const useTabStore = defineStore('tabs', {
           queries: [],
           indexTabs: [],
           statisticsTabs: [],
+          innerTabOrder: [],
         }
         this.tabItems.push(tabItem)
         tabIndex = this.tabItems.length - 1

--- a/frontend/src/features/tabs/useTabSortable.ts
+++ b/frontend/src/features/tabs/useTabSortable.ts
@@ -1,0 +1,43 @@
+import { onBeforeUnmount, onMounted, type Ref, type ComponentPublicInstance } from 'vue'
+import Sortable from 'sortablejs'
+
+type TabRoot = HTMLElement | ComponentPublicInstance | null
+
+export function useTabSortable(
+  rootRef: Ref<TabRoot>,
+  navSelector: string,
+  onReorder: (from: number, to: number) => void,
+): void {
+  let sortable: Sortable | null = null
+
+  onMounted(() => {
+    const root = (rootRef.value as ComponentPublicInstance | null)?.$el
+      ?? (rootRef.value as HTMLElement | null)
+    if (!root) {
+      return
+    }
+    const navEl = root.querySelector(navSelector) as HTMLElement | null
+    if (!navEl) {
+      return
+    }
+    sortable = new Sortable(navEl, {
+      animation: 150,
+      scroll: true,
+      draggable: '.n-tabs-tab-wrapper',
+      filter: '.n-tabs-tab__close, .n-tabs-tab-pad',
+      preventOnFilter: false,
+      onEnd(evt) {
+        const from = evt.oldIndex
+        const to = evt.newIndex
+        if (typeof from === 'number' && typeof to === 'number' && from !== to) {
+          onReorder(from, to)
+        }
+      },
+    })
+  })
+
+  onBeforeUnmount(() => {
+    sortable?.destroy()
+    sortable = null
+  })
+}

--- a/frontend/src/features/tabs/useTabSortable.ts
+++ b/frontend/src/features/tabs/useTabSortable.ts
@@ -23,6 +23,9 @@ export function useTabSortable(
     sortable = new Sortable(navEl, {
       animation: 150,
       scroll: true,
+      forceFallback: true,
+      fallbackOnBody: false,
+      revertOnSpill: true,
       draggable: '.n-tabs-tab-wrapper',
       filter: '.n-tabs-tab__close, .n-tabs-tab-pad',
       preventOnFilter: false,

--- a/frontend/src/features/tabs/useTabSortable.ts
+++ b/frontend/src/features/tabs/useTabSortable.ts
@@ -44,7 +44,6 @@ export function useTabSortable(
       fallbackTolerance: 5,
       fallbackClass: 'tab-sortable-fallback',
       ghostClass: 'tab-sortable-ghost',
-      revertOnSpill: true,
       draggable: '.n-tabs-tab-wrapper',
       filter: '.n-tabs-tab__close, .n-tabs-tab-pad',
       preventOnFilter: false,

--- a/frontend/src/features/tabs/useTabSortable.ts
+++ b/frontend/src/features/tabs/useTabSortable.ts
@@ -1,4 +1,4 @@
-import { onBeforeUnmount, onMounted, type Ref, type ComponentPublicInstance } from 'vue'
+import { nextTick, onBeforeUnmount, watch, type Ref, type ComponentPublicInstance } from 'vue'
 import Sortable from 'sortablejs'
 
 type TabRoot = HTMLElement | ComponentPublicInstance | null
@@ -9,17 +9,32 @@ export function useTabSortable(
   onReorder: (from: number, to: number) => void,
 ): void {
   let sortable: Sortable | null = null
+  let boundEl: HTMLElement | null = null
 
-  onMounted(() => {
-    const root = (rootRef.value as ComponentPublicInstance | null)?.$el
-      ?? (rootRef.value as HTMLElement | null)
+  function teardown() {
+    sortable?.destroy()
+    sortable = null
+    boundEl = null
+  }
+
+  function setup() {
+    const value = rootRef.value
+    const root = (value as ComponentPublicInstance | null)?.$el
+      ?? (value as HTMLElement | null)
     if (!root) {
+      teardown()
       return
     }
     const navEl = root.querySelector(navSelector) as HTMLElement | null
     if (!navEl) {
+      teardown()
       return
     }
+    if (sortable && boundEl === navEl) {
+      return
+    }
+    teardown()
+    boundEl = navEl
     sortable = new Sortable(navEl, {
       animation: 150,
       scroll: true,
@@ -40,10 +55,11 @@ export function useTabSortable(
         }
       },
     })
-  })
+  }
 
-  onBeforeUnmount(() => {
-    sortable?.destroy()
-    sortable = null
-  })
+  watch(rootRef, () => {
+    void nextTick(setup)
+  }, { immediate: true, flush: 'post' })
+
+  onBeforeUnmount(teardown)
 }

--- a/frontend/src/features/tabs/useTabSortable.ts
+++ b/frontend/src/features/tabs/useTabSortable.ts
@@ -23,8 +23,11 @@ export function useTabSortable(
     sortable = new Sortable(navEl, {
       animation: 150,
       scroll: true,
+      direction: 'horizontal',
       forceFallback: true,
       fallbackOnBody: false,
+      fallbackClass: 'tab-sortable-fallback',
+      ghostClass: 'tab-sortable-ghost',
       revertOnSpill: true,
       draggable: '.n-tabs-tab-wrapper',
       filter: '.n-tabs-tab__close, .n-tabs-tab-pad',

--- a/frontend/src/features/tabs/useTabSortable.ts
+++ b/frontend/src/features/tabs/useTabSortable.ts
@@ -41,6 +41,7 @@ export function useTabSortable(
       direction: 'horizontal',
       forceFallback: true,
       fallbackOnBody: false,
+      fallbackTolerance: 5,
       fallbackClass: 'tab-sortable-fallback',
       ghostClass: 'tab-sortable-ghost',
       revertOnSpill: true,

--- a/frontend/src/features/tabs/useTabSortable.ts
+++ b/frontend/src/features/tabs/useTabSortable.ts
@@ -27,8 +27,8 @@ export function useTabSortable(
       filter: '.n-tabs-tab__close, .n-tabs-tab-pad',
       preventOnFilter: false,
       onEnd(evt) {
-        const from = evt.oldIndex
-        const to = evt.newIndex
+        const from = evt.oldDraggableIndex
+        const to = evt.newDraggableIndex
         if (typeof from === 'number' && typeof to === 'number' && from !== to) {
           onReorder(from, to)
         }

--- a/frontend/src/types/ServerTabItem.ts
+++ b/frontend/src/types/ServerTabItem.ts
@@ -37,5 +37,6 @@ export type ServerTabItem = {
   indexTabs?: IndexTabItem[]
   statisticsTabs?: StatisticsTabItem[]
   schemaTabs?: SchemaTabItem[]
+  innerTabOrder: string[]
   activeInnerTabId?: string
 }


### PR DESCRIPTION
## Summary
- Add SortableJS-driven drag-to-reorder for server tabs (title bar) and inner tabs (query / index / statistics / schema strip in browser pane).
- Introduce `innerTabOrder: string[]` on `ServerTabItem` so the mixed-type inner strip has one canonical ordering; type-specific arrays remain for lookup.
- New composable `useTabSortable` mounts SortableJS imperatively on the existing `n-tabs` nav, leaving Naive UI markup, theming, and overflow handling untouched.

## Test plan
- [x] `bun run lint` (frontend)
- [x] `bun run test` (379 tests pass)
- [x] `go test ./...`
- [x] Manual: drag-reorder server tabs in title bar
- [x] Manual: drag-reorder mixed inner tabs across types (query past index, etc.)
- [x] Manual: overflow auto-scroll while dragging
- [x] Manual: close button still works on tabs
- [x] Manual: right-click duplicate on query tab still works

Fixes #180