### PR TITLE
fix(server-pane): allow cloning a connected server

### DIFF
--- a/frontend/src/features/server-pane/ServerDialog.vue
+++ b/frontend/src/features/server-pane/ServerDialog.vue
@@ -89,6 +89,9 @@ const generalFormRules = () => {
 const isEditMode = computed(() => dialogStore.serverDialogData?.mode === 'edit')
 
 const closingConnection = computed(() => {
+  if (!isEditMode.value) {
+    return false
+  }
   if (isEmpty(editServerID.value)) {
     return false
   }


### PR DESCRIPTION
## Summary
- Clone dialog reused the edit-mode "is connected" guard, which disables the form and leaves the spinner spinning forever when the source server has an active connection.
- Restrict the guard to edit mode so clone always proceeds.

Fixes #241

## Test plan
- [x] Connect to a server, right-click → Clone, confirm dialog is interactive (no spinner) and save creates the cloned server
- [x] Right-click → Edit on a connected server still shows the spinner / disabled form (existing behaviour preserved)
- [x] Clone of a disconnected server still works