### PR TITLE
ci: use absolute paths for appcert WACK invocation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,10 +214,12 @@ jobs:
             Write-Host 'appcert.exe not found; skipping WACK'
             exit 0
           }
-          & $appcert test -appxpackagepath Vervet.msix -reportoutputpath wack-report.xml
+          $msixPath = (Resolve-Path Vervet.msix).Path
+          $reportPath = Join-Path $PWD 'wack-report.xml'
+          & $appcert test -appxpackagepath $msixPath -reportoutputpath $reportPath
           if ($LASTEXITCODE -ne 0) {
             Write-Host '::error::WACK failed'
-            Get-Content wack-report.xml
+            if (Test-Path $reportPath) { Get-Content $reportPath }
             exit 1
           }
 


### PR DESCRIPTION
## Summary
- WACK (`appcert.exe`) requires absolute paths for `-appxpackagepath` and `-reportoutputpath`; relative paths produced `The '/reportoutputpath' argument must be valid path to the report file.`
- Resolve MSIX + report paths via `Resolve-Path` / `Join-Path $PWD` before invoking appcert.

## Test plan
- [x] workflow_dispatch run on this branch: WACK step green, `wack-report.xml` artifact uploaded.
- [x] Local install smoke on Windows VM passed (no Updates tab, no badge, Mongo connect + persistence verified).