### PR TITLE
fix(shell): enable Run button when built-in engine selected

### DIFF
--- a/frontend/src/features/queries/QueryTab.vue
+++ b/frontend/src/features/queries/QueryTab.vue
@@ -84,11 +84,16 @@ const resizeOffset = computed(() => {
 
 const modKey = isMacOS() ? 'Cmd' : 'Ctrl'
 
+const mongoshUnavailable = computed(
+  () =>
+    settingsStore.query.queryEngine === 'mongosh' && queryStore.mongoshAvailable === false,
+)
+
 const runButtonTooltip = computed(() => {
   if (!queryState.value.selectedDatabase) {
     return t('errors.no_database_selected')
   }
-  if (queryStore.mongoshAvailable === false) {
+  if (mongoshUnavailable.value) {
     return t('errors.shell_not_found')
   }
   return `${t('query.run')} (F5 / ${modKey}+Enter)`
@@ -363,7 +368,7 @@ watch(
             <n-button
               type="primary"
               size="small"
-              :disabled="!queryState.selectedDatabase || queryStore.mongoshAvailable === false"
+              :disabled="!queryState.selectedDatabase || mongoshUnavailable"
               @click="runQuery">
               <template #icon>
                 <n-icon :component="PlayIcon" />
@@ -413,7 +418,7 @@ watch(
         </n-tooltip>
       </n-space>
     </div>
-    <div v-if="queryStore.mongoshAvailable === false" class="mongosh-warning">
+    <div v-if="mongoshUnavailable" class="mongosh-warning">
       {{ t('errors.shell_not_found') }}
     </div>
     <div


### PR DESCRIPTION
## Summary
- Run button and mongosh-not-found warning were disabled whenever `mongosh` was missing from the host, even when the configured query engine was the built-in engine.
- Gate both checks on `settingsStore.query.queryEngine === 'mongosh'` so the built-in engine is unaffected by mongosh availability.

Fixes #247

## Test plan
- [x] `vue-tsc --noEmit --strict` clean
- [x] `vitest run` — 382 tests pass
- [x] Manual: with `mongosh` absent, settings → Built-in → Run button enabled, query executes; switch to Mongosh → Run disabled and warning shown.