### PR TITLE
ci: pin AppRun to AppImageKit 12 (13 lacks AppRun-x86_64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,11 +273,12 @@ jobs:
           popd
 
           # Download AppRun binary
-          # Pinned to the immutable AppImageKit 13 release asset rather than
+          # Pinned to the immutable AppImageKit 12 release asset rather than
           # the mutable 'continuous' tag, so the binary baked into the shipped
-          # AppImage can't be swapped upstream. TODO: add sha256 verification
-          # once a vetted checksum is recorded.
-          wget -q https://github.com/AppImage/AppImageKit/releases/download/13/AppRun-x86_64 -O AppDir/AppRun
+          # AppImage can't be swapped upstream. (Tag 13 renamed the asset to
+          # obsolete-AppRun-x86_64; 12 is the newest tag with AppRun-x86_64.)
+          # TODO: add sha256 verification once a vetted checksum is recorded.
+          wget -q https://github.com/AppImage/AppImageKit/releases/download/12/AppRun-x86_64 -O AppDir/AppRun
           chmod +x AppDir/AppRun
 
           # Resize icon to 512x512 (linuxdeploy rejects >512)


### PR DESCRIPTION
## Summary
PR #249 pinned `AppRun-x86_64` to AppImageKit release `13`, but tag `13` renamed that asset to `obsolete-AppRun-x86_64`. The download 404'd, `wget` exited 8, and the Linux AppImage build failed (run 26001642294).

Tag `12` is the newest immutable release that still ships `AppRun-x86_64`. Keeps the supply-chain hardening (immutable pin, no `continuous`) while restoring the build.

## Test plan
- [x] YAML valid
- [ ] Linux AppImage build green on next tag.

Refs #250 (sha256 verification still outstanding).