### PR TITLE
feat(query): live elapsed timer and backgrounded query toast

### DIFF
--- a/frontend/src/features/queries/QueryTab.vue
+++ b/frontend/src/features/queries/QueryTab.vue
@@ -24,7 +24,8 @@ import { useDialogStore } from '@/stores/dialog'
 import ListTreeIcon from '@/features/icon/ListTreeIcon.vue'
 import { useSettingsStore } from '@/features/settings/settingsStore'
 import { isMacOS } from '@/init/environment'
-import { ref, onMounted, computed, watch, nextTick } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed, watch, nextTick } from 'vue'
+import { formatElapsed } from '@/features/queries/timeFormat'
 import { useI18n } from 'vue-i18n'
 import type { CollectionContext } from '@/features/results-document-tree/useDocumentContextMenu'
 import * as monaco from 'monaco-editor'
@@ -186,6 +187,47 @@ function jumpToQuery(q: LogMessageQuery) {
 const cancelQuery = () => {
   queryStore.cancelQuery(props.queryId)
 }
+
+const elapsedLabel = ref('0:00')
+let elapsedTimer: ReturnType<typeof setInterval> | null = null
+
+function stopElapsedTimer() {
+  if (elapsedTimer !== null) {
+    clearInterval(elapsedTimer)
+    elapsedTimer = null
+  }
+}
+
+function startElapsedTimer() {
+  stopElapsedTimer()
+  const tick = () => {
+    const started = queryState.value.runStartedAt
+    if (started === null) {
+      elapsedLabel.value = '0:00'
+      return
+    }
+    elapsedLabel.value = formatElapsed(Date.now() - started)
+  }
+  tick()
+  elapsedTimer = setInterval(tick, 250)
+}
+
+watch(
+  () => queryState.value.loading,
+  (isLoading) => {
+    if (isLoading) {
+      startElapsedTimer()
+    } else {
+      stopElapsedTimer()
+      elapsedLabel.value = '0:00'
+    }
+  },
+  { immediate: true },
+)
+
+onBeforeUnmount(() => {
+  stopElapsedTimer()
+})
 
 const fileName = computed(() => {
   const fp = queryState.value.filePath
@@ -382,7 +424,7 @@ watch(
           <template #icon>
             <n-icon :component="StopIcon" />
           </template>
-          {{ t('query.cancel') }}
+          {{ t('query.cancel') }} · {{ elapsedLabel }}
         </n-button>
       </n-space>
       <n-space align="center" :size="4">
@@ -572,7 +614,7 @@ watch(
             <div v-if="queryState.loading" class="loading-state">
               <n-spin size="medium">
                 <template #description>
-                  {{ t('query.messages.executing') }}
+                  {{ t('query.messages.executing') }} {{ elapsedLabel }}
                 </template>
                 <div class="loading-state-spacer" />
               </n-spin>

--- a/frontend/src/features/queries/queryStore.ts
+++ b/frontend/src/features/queries/queryStore.ts
@@ -84,6 +84,8 @@ export interface QueryState {
   isDirty: boolean
   savedContent: string | null
   currentContent: string
+  /** Timestamp (ms since epoch) when the current execution started; null when idle */
+  runStartedAt: number | null
   /** The limit() from the last executed query, when the result may be truncated */
   activeLimit: number | null
   /** Lazily computed JSON — only populated when the JSON view is first accessed */
@@ -123,6 +125,7 @@ function createQueryState(database: string): QueryState {
     isDirty: false,
     savedContent: null,
     currentContent: '',
+    runStartedAt: null,
     activeLimit: null,
     _rawJsonCache: null,
     pageContext: null,
@@ -294,9 +297,8 @@ export const useQueryStore = defineStore('query', {
         query: queryPayload,
       })
 
-      const startTime = Date.now()
-
       try {
+        state.runStartedAt = Date.now()
         const result = await shellProxy.ExecuteQuery(
           serverId,
           queryId,
@@ -324,7 +326,7 @@ export const useQueryStore = defineStore('query', {
             void this.fetchCount(queryId)
           }
 
-          const elapsed = formatDuration(Date.now() - startTime)
+          const elapsed = formatDuration(Date.now() - (state.runStartedAt ?? Date.now()))
           const docCount = data.documents?.length ?? 0
           const opType = data.operationType || 'find'
           const msg = resultMessage(opType, data.affectedCount || docCount, elapsed)
@@ -357,6 +359,7 @@ export const useQueryStore = defineStore('query', {
         state.activeResultTab = 'messages'
       } finally {
         state.loading = false
+        state.runStartedAt = null
       }
     },
 

--- a/frontend/src/features/queries/queryStore.ts
+++ b/frontend/src/features/queries/queryStore.ts
@@ -226,6 +226,17 @@ export const useQueryStore = defineStore('query', {
         return
       }
 
+      const isBackgrounded = (): boolean => {
+        const tab = tabStore.currentTab
+        if (!tab) {
+          return true
+        }
+        if (tabStore.currentTabId !== serverId) {
+          return true
+        }
+        return tab.activeInnerTabId !== queryId
+      }
+
       const state = this.getQueryState(queryId)
       let query = payload.text
       const queryPayload: LogMessageQuery = { text: payload.text, range: payload.range }
@@ -331,6 +342,15 @@ export const useQueryStore = defineStore('query', {
           const opType = data.operationType || 'find'
           const msg = resultMessage(opType, data.affectedCount || docCount, elapsed)
           this.appendMessage(queryId, { level: 'info', text: msg, query: queryPayload })
+
+          if (isBackgrounded() && state.executionId === thisExecution && !state.cancelled) {
+            useNotifier().info(
+              i18nGlobal.t('query.messages.bgFinished', {
+                db: state.selectedDatabase,
+                elapsed,
+              }),
+            )
+          }
         } else {
           const translated = translateError(result.errorCode, result.errorDetail)
           state.error = translated
@@ -347,6 +367,12 @@ export const useQueryStore = defineStore('query', {
             })
           }
           state.activeResultTab = 'messages'
+
+          if (isBackgrounded() && state.executionId === thisExecution && !state.cancelled) {
+            useNotifier().error(
+              i18nGlobal.t('query.messages.bgFailed', { db: state.selectedDatabase }),
+            )
+          }
         }
       } catch (e) {
         if (state.cancelled || state.executionId !== thisExecution) {
@@ -357,6 +383,12 @@ export const useQueryStore = defineStore('query', {
         state.error = String(e)
         this.appendMessage(queryId, { level: 'error', text: String(e), query: queryPayload })
         state.activeResultTab = 'messages'
+
+        if (isBackgrounded()) {
+          useNotifier().error(
+            i18nGlobal.t('query.messages.bgFailed', { db: state.selectedDatabase }),
+          )
+        }
       } finally {
         state.loading = false
         state.runStartedAt = null

--- a/frontend/src/features/queries/queryStore.ts
+++ b/frontend/src/features/queries/queryStore.ts
@@ -379,16 +379,15 @@ export const useQueryStore = defineStore('query', {
           return
         }
         const notifier = useNotifier()
-        notifier.error(String(e))
+        const backgrounded = isBackgrounded()
+        if (backgrounded) {
+          notifier.error(i18nGlobal.t('query.messages.bgFailed', { db: state.selectedDatabase }))
+        } else {
+          notifier.error(String(e))
+        }
         state.error = String(e)
         this.appendMessage(queryId, { level: 'error', text: String(e), query: queryPayload })
         state.activeResultTab = 'messages'
-
-        if (isBackgrounded()) {
-          useNotifier().error(
-            i18nGlobal.t('query.messages.bgFailed', { db: state.selectedDatabase }),
-          )
-        }
       } finally {
         state.loading = false
         state.runStartedAt = null

--- a/frontend/src/features/queries/tests/queryStoreBgToast.test.ts
+++ b/frontend/src/features/queries/tests/queryStoreBgToast.test.ts
@@ -1,0 +1,143 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('wailsjs/go/api/ShellProxy', () => ({
+  ExecuteQuery: vi.fn(),
+  CancelQuery: vi.fn(async () => undefined),
+  FetchPage: vi.fn(),
+  CountForPage: vi.fn(),
+  CheckMongosh: vi.fn(async () => ({ isSuccess: true, data: true })),
+}))
+
+vi.mock('wailsjs/go/api/FilesProxy', () => ({
+  SelectFile: vi.fn(),
+  ReadFile: vi.fn(),
+  WriteFile: vi.fn(),
+  SaveFile: vi.fn(),
+}))
+
+const info = vi.fn()
+const success = vi.fn()
+const errorFn = vi.fn()
+const warning = vi.fn()
+
+vi.mock('@/utils/dialog', () => ({
+  useNotifier: () => ({ info, success, error: errorFn, warning }),
+  useDialoger: () => ({}),
+  useMessager: () => ({}),
+}))
+
+import * as shellProxy from 'wailsjs/go/api/ShellProxy'
+import { useQueryStore } from '@/features/queries/queryStore'
+import { useTabStore } from '@/features/tabs/tabs'
+
+const SERVER_ID = 'srv-1'
+const QUERY_ID = 'q-1'
+
+function setupTabs(activeInnerTabId: string | undefined) {
+  const tabStore = useTabStore()
+  // Stub the getters by spying.
+  vi.spyOn(tabStore, 'currentTabId', 'get').mockReturnValue(SERVER_ID)
+  vi.spyOn(tabStore, 'currentTab', 'get').mockReturnValue({
+    serverId: SERVER_ID,
+    activeInnerTabId,
+  } as never)
+  return tabStore
+}
+
+describe('queryStore background toast', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    info.mockReset()
+    success.mockReset()
+    errorFn.mockReset()
+    warning.mockReset()
+    ;(shellProxy.ExecuteQuery as ReturnType<typeof vi.fn>).mockReset()
+  })
+
+  test('fires info when query tab not active on success', async () => {
+    setupTabs('other-tab')
+    const store = useQueryStore()
+    store.initQueryState(QUERY_ID, 'mydb')
+    ;(shellProxy.ExecuteQuery as ReturnType<typeof vi.fn>).mockResolvedValue({
+      isSuccess: true,
+      data: { documents: [{ a: 1 }], operationType: 'find', affectedCount: 1 },
+    })
+
+    await store.executeQuery(QUERY_ID, {
+      text: 'db.foo.find()',
+      range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 },
+    })
+
+    expect(info).toHaveBeenCalledTimes(1)
+    expect(info.mock.calls[0]![0]).toMatch(/mydb/)
+  })
+
+  test('does NOT fire when query tab IS active', async () => {
+    setupTabs(QUERY_ID)
+    const store = useQueryStore()
+    store.initQueryState(QUERY_ID, 'mydb')
+    ;(shellProxy.ExecuteQuery as ReturnType<typeof vi.fn>).mockResolvedValue({
+      isSuccess: true,
+      data: { documents: [{ a: 1 }], operationType: 'find', affectedCount: 1 },
+    })
+
+    await store.executeQuery(QUERY_ID, {
+      text: 'db.foo.find()',
+      range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 },
+    })
+
+    expect(info).not.toHaveBeenCalled()
+    expect(errorFn).not.toHaveBeenCalled()
+  })
+
+  test('fires error on error result when backgrounded', async () => {
+    setupTabs('other-tab')
+    const store = useQueryStore()
+    store.initQueryState(QUERY_ID, 'mydb')
+    ;(shellProxy.ExecuteQuery as ReturnType<typeof vi.fn>).mockResolvedValue({
+      isSuccess: false,
+      errorCode: 'something_broke',
+      errorDetail: 'detail',
+    })
+
+    await store.executeQuery(QUERY_ID, {
+      text: 'db.foo.find()',
+      range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 },
+    })
+
+    expect(errorFn).toHaveBeenCalledTimes(1)
+    expect(errorFn.mock.calls[0]![0]).toMatch(/mydb/)
+  })
+
+  test('does NOT fire when the query was cancelled', async () => {
+    setupTabs('other-tab')
+    const store = useQueryStore()
+    store.initQueryState(QUERY_ID, 'mydb')
+
+    let resolveExec: (value: unknown) => void = () => {}
+    ;(shellProxy.ExecuteQuery as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise((resolve) => {
+        resolveExec = resolve
+      }),
+    )
+
+    const execPromise = store.executeQuery(QUERY_ID, {
+      text: 'db.foo.find()',
+      range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 },
+    })
+
+    // Mark cancelled before result arrives.
+    const state = store.getQueryState(QUERY_ID)
+    state.cancelled = true
+
+    resolveExec({
+      isSuccess: true,
+      data: { documents: [{ a: 1 }], operationType: 'find', affectedCount: 1 },
+    })
+    await execPromise
+
+    expect(info).not.toHaveBeenCalled()
+    expect(errorFn).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/features/queries/tests/queryStoreState.test.ts
+++ b/frontend/src/features/queries/tests/queryStoreState.test.ts
@@ -1,0 +1,16 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { beforeEach, describe, expect, test } from 'vitest'
+
+import { useQueryStore } from '@/features/queries/queryStore'
+
+describe('queryStore runStartedAt lifecycle', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  test('new query state starts with runStartedAt = null', () => {
+    const store = useQueryStore()
+    const state = store.getQueryState('q1')
+    expect(state.runStartedAt).toBeNull()
+  })
+})

--- a/frontend/src/features/queries/tests/timeFormat.test.ts
+++ b/frontend/src/features/queries/tests/timeFormat.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest'
+import { formatElapsed } from '../timeFormat'
+
+describe('formatElapsed', () => {
+  test('zero ms returns 0:00', () => {
+    expect(formatElapsed(0)).toBe('0:00')
+  })
+
+  test('under one second truncates to 0:00', () => {
+    expect(formatElapsed(500)).toBe('0:00')
+  })
+
+  test('under a minute pads seconds (1500ms -> 0:01)', () => {
+    expect(formatElapsed(1500)).toBe('0:01')
+  })
+
+  test('exact minute returns 1:00', () => {
+    expect(formatElapsed(60000)).toBe('1:00')
+  })
+
+  test('minutes and seconds (65000ms -> 1:05)', () => {
+    expect(formatElapsed(65000)).toBe('1:05')
+  })
+
+  test('just under an hour returns 59:59', () => {
+    expect(formatElapsed(3599000)).toBe('59:59')
+  })
+
+  test('nine minutes fifty-nine seconds (599000ms -> 9:59)', () => {
+    expect(formatElapsed(599000)).toBe('9:59')
+  })
+
+  test('exact hour returns 1:00:00', () => {
+    expect(formatElapsed(3600000)).toBe('1:00:00')
+  })
+
+  test('hour minutes and seconds (3661000ms -> 1:01:01)', () => {
+    expect(formatElapsed(3661000)).toBe('1:01:01')
+  })
+
+  test('truncates sub-second remainder (no rounding up)', () => {
+    expect(formatElapsed(1999)).toBe('0:01')
+    expect(formatElapsed(59999)).toBe('0:59')
+  })
+
+  test('NaN returns 0:00', () => {
+    expect(formatElapsed(NaN)).toBe('0:00')
+  })
+
+  test('negative returns 0:00', () => {
+    expect(formatElapsed(-1000)).toBe('0:00')
+  })
+})

--- a/frontend/src/features/queries/timeFormat.ts
+++ b/frontend/src/features/queries/timeFormat.ts
@@ -1,0 +1,28 @@
+/**
+ * Format an elapsed duration in milliseconds as a clock-style string.
+ *
+ * - Under 1 hour: `m:ss` (seconds zero-padded to 2)
+ * - 1 hour or more: `h:mm:ss` (minutes and seconds zero-padded to 2)
+ * - Negative or NaN input: `"0:00"`
+ * - Sub-second remainder is truncated (floored), never rounded up.
+ */
+export function formatElapsed(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) {
+    return '0:00'
+  }
+
+  const totalSeconds = Math.floor(ms / 1000)
+  const seconds = totalSeconds % 60
+  const totalMinutes = Math.floor(totalSeconds / 60)
+  const minutes = totalMinutes % 60
+  const hours = Math.floor(totalMinutes / 60)
+
+  const ss = seconds.toString().padStart(2, '0')
+
+  if (hours > 0) {
+    const mm = minutes.toString().padStart(2, '0')
+    return `${hours}:${mm}:${ss}`
+  }
+
+  return `${totalMinutes}:${ss}`
+}

--- a/frontend/src/features/tabs/UnifiedContentPane.vue
+++ b/frontend/src/features/tabs/UnifiedContentPane.vue
@@ -22,6 +22,13 @@ type UnifiedTab = {
 
 const tabStore = useTabStore()
 const queryStore = useQueryStore()
+
+function isQueryTabLoading(id: string): boolean {
+  if (!id.startsWith('query-')) {
+    return false
+  }
+  return queryStore.getQueryState(id).loading
+}
 const { t } = useI18n()
 const dialog = useDialog()
 
@@ -261,7 +268,13 @@ async function promptSaveBeforeClose(queryId: string, state: QueryState): Promis
         :tab="uTab.label"
         display-directive="show:lazy">
         <template #tab>
-          <span @contextmenu="onTabContextMenu($event, uTab)">{{ uTab.label }}</span>
+          <span class="inner-tab-label" @contextmenu="onTabContextMenu($event, uTab)">
+            <n-spin
+              v-if="uTab.type === 'query' && isQueryTabLoading(uTab.id)"
+              :size="12"
+              class="inner-tab-spinner" />
+            {{ uTab.label }}
+          </span>
         </template>
         <!-- Query content -->
         <QueryTab v-if="uTab.type === 'query'" :query-id="uTab.id" />
@@ -349,6 +362,16 @@ async function promptSaveBeforeClose(queryId: string, state: QueryState): Promis
   align-items: center;
   justify-content: center;
   height: 100%;
+}
+
+.inner-tab-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.inner-tab-spinner {
+  flex: 0 0 auto;
 }
 
 :deep(.tab-sortable-fallback) {

--- a/frontend/src/features/tabs/UnifiedContentPane.vue
+++ b/frontend/src/features/tabs/UnifiedContentPane.vue
@@ -5,7 +5,7 @@ import { type QueryState } from '@/features/queries/queryStore'
 import { useI18n } from 'vue-i18n'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { ChevronDownIcon } from '@heroicons/vue/24/outline'
-import type { DropdownOption } from 'naive-ui'
+import { useThemeVars, type DropdownOption } from 'naive-ui'
 import QueryTab from '@/features/queries/QueryTab.vue'
 import IndexTab from '@/features/indexes/IndexTab.vue'
 import CollectionStatisticsTab from '@/features/statistics/CollectionStatisticsTab.vue'
@@ -22,6 +22,7 @@ type UnifiedTab = {
 
 const tabStore = useTabStore()
 const queryStore = useQueryStore()
+const themeVars = useThemeVars()
 
 function isQueryTabLoading(id: string): boolean {
   if (!id.startsWith('query-')) {
@@ -268,11 +269,17 @@ async function promptSaveBeforeClose(queryId: string, state: QueryState): Promis
         :tab="uTab.label"
         display-directive="show:lazy">
         <template #tab>
-          <span class="inner-tab-label" @contextmenu="onTabContextMenu($event, uTab)">
-            <n-spin
-              v-if="uTab.type === 'query' && isQueryTabLoading(uTab.id)"
-              :size="12"
-              class="inner-tab-spinner" />
+          <span
+            class="inner-tab-label"
+            :class="{
+              'inner-tab-label--loading': uTab.type === 'query' && isQueryTabLoading(uTab.id),
+            }"
+            :style="
+              uTab.type === 'query' && isQueryTabLoading(uTab.id)
+                ? { '--tab-progress-color': themeVars.primaryColor }
+                : {}
+            "
+            @contextmenu="onTabContextMenu($event, uTab)">
             {{ uTab.label }}
           </span>
         </template>
@@ -365,13 +372,40 @@ async function promptSaveBeforeClose(queryId: string, state: QueryState): Promis
 }
 
 .inner-tab-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+  display: inline-block;
+  position: relative;
 }
 
-.inner-tab-spinner {
-  flex: 0 0 auto;
+.inner-tab-label--loading {
+  padding-bottom: 4px;
+}
+
+.inner-tab-label--loading::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  border-radius: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--tab-progress-color, #2080f0) 40%,
+    var(--tab-progress-color, #2080f0) 60%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: tab-progress-sweep 1.4s linear infinite;
+}
+
+@keyframes tab-progress-sweep {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 :deep(.tab-sortable-fallback) {

--- a/frontend/src/features/tabs/UnifiedContentPane.vue
+++ b/frontend/src/features/tabs/UnifiedContentPane.vue
@@ -396,7 +396,7 @@ async function promptSaveBeforeClose(queryId: string, state: QueryState): Promis
     transparent 100%
   );
   background-size: 200% 100%;
-  animation: tab-progress-sweep 2.4s linear infinite;
+  animation: tab-progress-sweep 1.6s ease-in-out infinite alternate;
 }
 
 @keyframes tab-progress-sweep {

--- a/frontend/src/features/tabs/UnifiedContentPane.vue
+++ b/frontend/src/features/tabs/UnifiedContentPane.vue
@@ -396,7 +396,7 @@ async function promptSaveBeforeClose(queryId: string, state: QueryState): Promis
     transparent 100%
   );
   background-size: 200% 100%;
-  animation: tab-progress-sweep 1.4s linear infinite;
+  animation: tab-progress-sweep 2.4s linear infinite;
 }
 
 @keyframes tab-progress-sweep {

--- a/frontend/src/features/tabs/UnifiedContentPane.vue
+++ b/frontend/src/features/tabs/UnifiedContentPane.vue
@@ -27,7 +27,7 @@ function isQueryTabLoading(id: string): boolean {
   if (!id.startsWith('query-')) {
     return false
   }
-  return queryStore.getQueryState(id).loading
+  return queryStore.queries[id]?.loading ?? false
 }
 const { t } = useI18n()
 const dialog = useDialog()

--- a/frontend/src/features/tabs/UnifiedContentPane.vue
+++ b/frontend/src/features/tabs/UnifiedContentPane.vue
@@ -396,7 +396,7 @@ async function promptSaveBeforeClose(queryId: string, state: QueryState): Promis
     transparent 100%
   );
   background-size: 200% 100%;
-  animation: tab-progress-sweep 1.6s ease-in-out infinite alternate;
+  animation: tab-progress-sweep 2.8s ease-in-out infinite alternate;
 }
 
 @keyframes tab-progress-sweep {

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -443,6 +443,8 @@ export default {
       jumpToQuery: 'Jump to query',
       noMessages: 'No messages yet',
       noFilteredMessages: 'No messages match the current filter',
+      bgFinished: '{db} query finished ({elapsed})',
+      bgFailed: '{db} query failed',
     },
     database: 'Database',
     selectDatabase: 'Select database...',


### PR DESCRIPTION
## Summary

- Adds live `m:ss` elapsed timer to the toolbar Cancel button and results-pane spinner while a query runs (`h:mm:ss` past one hour).
- Renders a small spinner in inner query tab labels while their query is loading, so backgrounded queries are visible at a glance.
- Fires a single completion toast (`info`) when a backgrounded query finishes, and a single error toast (`error`) when it fails. Cancellation and stale runs do not toast. Active foreground queries do not toast.
- No 5s/15s "still running" toasts (rejected during brainstorming — see spec).

## Test plan

- [x] `go test ./...` green
- [x] `bun run lint` clean (eslint + vue-tsc)
- [x] `bun run test` — 399 tests across 25 files pass, including new `timeFormat` and `queryStoreBgToast` suites
- [x] Manual smoke: run a slow query, confirm ticking timer in toolbar + spinner
- [x] Manual smoke: open second query tab, run slow query there, switch away — confirm tab-label spinner, then completion toast on finish

Fixes #174