### PR TITLE
fix(server-dialog): save URIs with authMechanism and clean stale auth state

### DIFF
--- a/frontend/src/features/server-pane/authentication/AuthenticationPanel.vue
+++ b/frontend/src/features/server-pane/authentication/AuthenticationPanel.vue
@@ -18,7 +18,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { AuthMethod, OIDCConfig } from '@/types/ConnectionConfig'
-import { setAuthMechanism, type SyncableAuthMechanism } from '../connectionStrings'
+import { clearAuthState, setAuthMechanism, type SyncableAuthMechanism } from '../connectionStrings'
 import NoneFields from './fields/NoneFields.vue'
 import ScramFields from './fields/ScramFields.vue'
 import X509Fields from './fields/X509Fields.vue'
@@ -83,7 +83,8 @@ const SYNCABLE: Partial<Record<AuthMethod, SyncableAuthMechanism>> = {
 function onMethodChange(next: AuthMethod): void {
   emit('update:method', next)
   const mechanism = next === 'none' || next === 'password' ? null : (SYNCABLE[next] ?? null)
-  const newUri = setAuthMechanism(props.uri, mechanism)
+  const cleared = clearAuthState(props.uri)
+  const newUri = mechanism === null ? cleared : setAuthMechanism(cleared, mechanism)
   if (newUri !== props.uri) {
     emit('update:uri', newUri)
   }

--- a/frontend/src/features/server-pane/authentication/authUri.ts
+++ b/frontend/src/features/server-pane/authentication/authUri.ts
@@ -69,9 +69,15 @@ function splitUri(uri: string): UriParts {
 function joinUri(parts: UriParts): string {
   const userinfo = parts.userinfo ? `${parts.userinfo}@` : ''
   const keys = Object.keys(parts.query)
+  // Driver's connstring.Parse requires "/" between host and "?". Insert it
+  // when the host segment has no path of its own.
+  const hostAndPath =
+    keys.length > 0 && parts.hostAndPath.indexOf('/') === -1
+      ? `${parts.hostAndPath}/`
+      : parts.hostAndPath
   const query =
     keys.length === 0 ? '' : `?${keys.map((k) => `${k}=${parts.query[k]}`).join('&')}`
-  return `${parts.scheme}${userinfo}${parts.hostAndPath}${query}`
+  return `${parts.scheme}${userinfo}${hostAndPath}${query}`
 }
 
 function encodeUserinfo(user: string, password?: string): string {

--- a/frontend/src/features/server-pane/connectionStrings.ts
+++ b/frontend/src/features/server-pane/connectionStrings.ts
@@ -55,7 +55,8 @@ const uriOptions: Record<string, OptionValidator | null> = {
   tlsDisableCertificateRevocationCheck: { v: validateBoolean, m: 'uriParser.invalidBoolean' },
   tlsDisableOCSPEndpointCheck: { v: validateBoolean, m: 'uriParser.invalidBoolean' },
   tlsInsecure: { v: validateBoolean, m: 'uriParser.invalidBoolean' },
-  w: { v: validateNonNegativeInteger, m: 'uriParser.invalidNonNegativeInteger' },
+  timeoutMS: { v: validateTimeout, m: 'uriParser.invalidTimeout' },
+  w: { v: validateWriteConcern, m: 'uriParser.invalidWriteConcern' },
   waitQueueTimeoutMS: { v: validateTimeout, m: 'uriParser.invalidTimeout' },
   wTimeoutMS: { v: validateTimeout, m: 'uriParser.invalidTimeout' },
   zlibCompressionLevel: {
@@ -655,7 +656,20 @@ function validateAuthMechanism(authMechanism?: string) {
     return false
   }
 
-  return AuthMechanism.includes(authMechanism!)
+  const upper = authMechanism.toUpperCase()
+  return AuthMechanism.some((m) => m.toUpperCase() === upper)
+}
+
+// MongoDB write-concern value: a non-negative integer, the literal "majority",
+// or a custom write-concern tag set name (any non-empty string).
+function validateWriteConcern(value?: string) {
+  if (!value) {
+    return false
+  }
+  if (value.trim().match(/^[0-9]+$/)) {
+    return Number.parseInt(value) >= 0
+  }
+  return value.length > 0
 }
 
 function validateAuthMechanismProps(authMechanismProps?: string) {
@@ -773,7 +787,7 @@ function validateServerMonitoringMode(value?: string) {
     return false
   }
 
-  return ['auto', 'steam', 'poll'].includes(value.toLowerCase())
+  return ['auto', 'stream', 'poll'].includes(value.toLowerCase())
 }
 
 function validateZlibCompressionLevel(value?: string) {
@@ -839,6 +853,23 @@ export type SyncableAuthMechanism =
   | 'GSSAPI'
   | 'PLAIN'
 
+// The MongoDB connection-string spec (and Go driver's connstring.Parse) requires
+// a "/" between the host list and the "?" that starts the query. Naive string
+// joins like `${host}?${query}` produce "mongodb://host?..." which the driver
+// rejects. Insert the slash whenever the host portion has no path segment.
+export function ensurePathSlash(uri: string): string {
+  const schemeMatch = uri.match(/^(mongodb(?:\+srv)?:\/\/)/)
+  if (!schemeMatch) {
+    return uri
+  }
+  const scheme = schemeMatch[1]!
+  const rest = uri.substring(scheme.length)
+  if (rest.indexOf('/') !== -1) {
+    return uri
+  }
+  return `${scheme}${rest}/`
+}
+
 export function setAuthMechanism(uri: string, mechanism: SyncableAuthMechanism | null): string {
   const queryIdx = uri.indexOf('?')
   const base = queryIdx === -1 ? uri : uri.substring(0, queryIdx)
@@ -866,7 +897,48 @@ export function setAuthMechanism(uri: string, mechanism: SyncableAuthMechanism |
     kept.push(`authMechanism=${mechanism}`)
   }
 
-  return kept.length === 0 ? base : `${base}?${kept.join('&')}`
+  return kept.length === 0 ? base : `${ensurePathSlash(base)}?${kept.join('&')}`
+}
+
+// Strip auth-related state (userinfo and auth/cert query params) so the field
+// component for the newly-picked method starts from a clean URI. Without this
+// switching from password → OIDC leaves stale "user:pass@" in the URI, and
+// switching away from x509 leaves dangling tlsCertificateKey* options.
+const AUTH_QUERY_PARAMS = [
+  'authMechanism',
+  'authMechanismProperties',
+  'authSource',
+  'tlsCertificateKeyFile',
+  'tlsCertificateKeyFilePassword',
+]
+
+export function clearAuthState(uri: string): string {
+  const schemeMatch = uri.match(/^(mongodb(?:\+srv)?:\/\/)/)
+  const scheme = schemeMatch ? schemeMatch[1]! : 'mongodb://'
+  const rest = schemeMatch ? uri.substring(scheme.length) : uri
+
+  const queryIdx = rest.indexOf('?')
+  const beforeQuery = queryIdx === -1 ? rest : rest.substring(0, queryIdx)
+  const queryStr = queryIdx === -1 ? '' : rest.substring(queryIdx + 1)
+
+  const atIdx = beforeQuery.lastIndexOf('@')
+  const hostAndPath = atIdx === -1 ? beforeQuery : beforeQuery.substring(atIdx + 1)
+
+  const stripLower = new Set(AUTH_QUERY_PARAMS.map((p) => p.toLowerCase()))
+  const kept: string[] = []
+  if (queryStr.length > 0) {
+    for (const part of queryStr.split('&')) {
+      const eq = part.indexOf('=')
+      const key = eq === -1 ? part : part.substring(0, eq)
+      if (stripLower.has(key.toLowerCase())) {
+        continue
+      }
+      kept.push(part)
+    }
+  }
+
+  const base = `${scheme}${hostAndPath}`
+  return kept.length === 0 ? base : `${ensurePathSlash(base)}?${kept.join('&')}`
 }
 
 export type SignInBehaviour = 'openBrowser' | 'forceAccountPicker' | 'showUrl'

--- a/frontend/src/features/server-pane/tests/connectionString.test.ts
+++ b/frontend/src/features/server-pane/tests/connectionString.test.ts
@@ -5,6 +5,7 @@ import {
   detectAuthFromUri,
   signInBehaviourFromConfig,
   applySignInBehaviour,
+  clearAuthState,
 } from '@/features/server-pane/connectionStrings.ts'
 import type { OIDCConfig } from '@/types/ConnectionConfig'
 import InvalidUriScenarios from './scenarios/invalid-uris.json' with { type: 'json' }
@@ -227,24 +228,24 @@ function runScenario(scenario: Scenario) {
 describe('connectionString.setAuthMechanism', () => {
   test('appends authMechanism when URI has no query', () => {
     expect(setAuthMechanism('mongodb://host', 'MONGODB-OIDC'))
-      .toBe('mongodb://host?authMechanism=MONGODB-OIDC')
+      .toBe('mongodb://host/?authMechanism=MONGODB-OIDC')
   })
 
   test('appends authMechanism when URI has existing query', () => {
     expect(setAuthMechanism('mongodb://host?tls=true', 'MONGODB-X509'))
-      .toBe('mongodb://host?tls=true&authMechanism=MONGODB-X509')
+      .toBe('mongodb://host/?tls=true&authMechanism=MONGODB-X509')
   })
 
   test('replaces existing authMechanism', () => {
     expect(setAuthMechanism('mongodb://host?authMechanism=MONGODB-OIDC&tls=true', 'MONGODB-AWS'))
-      .toBe('mongodb://host?authMechanism=MONGODB-AWS&tls=true')
+      .toBe('mongodb://host/?authMechanism=MONGODB-AWS&tls=true')
   })
 
   test('strips authMechanism and authMechanismProperties on null', () => {
     expect(setAuthMechanism(
       'mongodb://host?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:gcp&tls=true',
       null,
-    )).toBe('mongodb://host?tls=true')
+    )).toBe('mongodb://host/?tls=true')
   })
 
   test('strips trailing ? when only param removed', () => {
@@ -254,7 +255,7 @@ describe('connectionString.setAuthMechanism', () => {
 
   test('idempotent when stripping absent param', () => {
     expect(setAuthMechanism('mongodb://host?tls=true', null))
-      .toBe('mongodb://host?tls=true')
+      .toBe('mongodb://host/?tls=true')
   })
 
   test('preserves mongodb+srv scheme', () => {
@@ -264,7 +265,78 @@ describe('connectionString.setAuthMechanism', () => {
 
   test('preserves userinfo', () => {
     expect(setAuthMechanism('mongodb://user:pass@host', 'MONGODB-OIDC'))
-      .toBe('mongodb://user:pass@host?authMechanism=MONGODB-OIDC')
+      .toBe('mongodb://user:pass@host/?authMechanism=MONGODB-OIDC')
+  })
+
+  test('preserves explicit path slash', () => {
+    expect(setAuthMechanism('mongodb://host/', 'MONGODB-OIDC'))
+      .toBe('mongodb://host/?authMechanism=MONGODB-OIDC')
+  })
+
+  test('preserves explicit default database', () => {
+    expect(setAuthMechanism('mongodb://host/admin', 'MONGODB-OIDC'))
+      .toBe('mongodb://host/admin?authMechanism=MONGODB-OIDC')
+  })
+})
+
+describe('connectionString.parseUri write concern', () => {
+  test('accepts w=majority', () => {
+    expect(parseUri('mongodb://host/?w=majority').success).toBe(true)
+  })
+
+  test('accepts w=1', () => {
+    expect(parseUri('mongodb://host/?w=1').success).toBe(true)
+  })
+
+  test('accepts w=0', () => {
+    expect(parseUri('mongodb://host/?w=0').success).toBe(true)
+  })
+
+  test('accepts w=customTagSet', () => {
+    expect(parseUri('mongodb://host/?w=myTagSet').success).toBe(true)
+  })
+})
+
+describe('connectionString.parseUri misc params', () => {
+  test('accepts authMechanism in any case', () => {
+    expect(parseUri('mongodb://host/?authMechanism=plain').success).toBe(true)
+    expect(parseUri('mongodb://host/?authMechanism=Plain').success).toBe(true)
+  })
+
+  test('accepts serverMonitoringMode=stream', () => {
+    expect(parseUri('mongodb://host/?serverMonitoringMode=stream').success).toBe(true)
+  })
+
+  test('accepts timeoutMS', () => {
+    expect(parseUri('mongodb://host/?timeoutMS=5000').success).toBe(true)
+  })
+})
+
+describe('connectionString.clearAuthState', () => {
+  test('strips userinfo', () => {
+    expect(clearAuthState('mongodb://user:pass@host/'))
+      .toBe('mongodb://host/')
+  })
+
+  test('strips all auth-related query params', () => {
+    expect(clearAuthState(
+      'mongodb://user@host/?authMechanism=MONGODB-X509&authMechanismProperties=SERVICE_NAME:foo&authSource=$external&tlsCertificateKeyFile=%2Fp&tlsCertificateKeyFilePassword=x&tls=true',
+    )).toBe('mongodb://host/?tls=true')
+  })
+
+  test('keeps non-auth query params', () => {
+    expect(clearAuthState('mongodb://user:pass@host/?tls=true&replicaSet=rs0'))
+      .toBe('mongodb://host/?tls=true&replicaSet=rs0')
+  })
+
+  test('handles URI with no query', () => {
+    expect(clearAuthState('mongodb://user:pass@host'))
+      .toBe('mongodb://host')
+  })
+
+  test('preserves srv scheme', () => {
+    expect(clearAuthState('mongodb+srv://user:pass@cluster/?authMechanism=PLAIN'))
+      .toBe('mongodb+srv://cluster/')
   })
 })
 

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -738,6 +738,7 @@ export default {
     invalidBoolean: 'Invalid boolean value for "{key}": "{value}"',
     invalidPositiveFloat: 'Invalid integer or float for "{key}": "{value}"',
     invalidNonNegativeInteger: 'Invalid non-negative integer for "{key}": "{value}"',
+    invalidWriteConcern: 'Invalid write concern for "{key}": "{value}"',
     invalidPositiveInteger: 'Invalid integer for "{key}": "{value}"',
     invalidMaxStaleness: 'Invalid value for "{key}": "{value}"',
     invalidReadPreferenceMode: 'Invalid read preference mode "{value}"',

--- a/internal/servers/import.go
+++ b/internal/servers/import.go
@@ -146,12 +146,7 @@ func (sm *ServerService) ImportServers(data []byte) (*ImportResult, error) {
 				}
 			}
 
-			var isCluster, isSrv bool
-			cs, parseErr := connstring.Parse(entry.ConnectionConfig.URI)
-			if parseErr == nil {
-				isCluster = len(cs.Hosts) > 1
-				isSrv = cs.Scheme == connstring.SchemeMongoDBSRV
-			}
+			isCluster, isSrv := inferURIShape(entry.ConnectionConfig.URI)
 
 			// Skip duplicate servers (same name, parent, and URI).
 			serverKey := parentID + "\x00" + entry.Name + "\x00" + cfg.URI

--- a/internal/servers/service.go
+++ b/internal/servers/service.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
-	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 )
 
 const ConfigParseErrorEvent = "config-parse-error"
@@ -94,13 +93,7 @@ func (sm *ServerService) AddServer(parentID, name, uri, colour string) error {
 		parentID = ""
 	}
 
-	connString, err := connstring.Parse(uri)
-	if err != nil {
-		return fmt.Errorf("failed to parse connection string: %w", err)
-	}
-
-	isCluster := len(connString.Hosts) > 1
-	isSrv := connString.Scheme == connstring.SchemeMongoDBSRV
+	isCluster, isSrv := inferURIShape(uri)
 
 	servers = append(servers, models.RegisteredServer{
 		ID:        newID,
@@ -172,13 +165,7 @@ func (sm *ServerService) AddServerWithConfig(parentID, name, colour string, cfg 
 		parentID = ""
 	}
 
-	connString, err := connstring.Parse(cfg.URI)
-	if err != nil {
-		return fmt.Errorf("failed to parse connection string: %w", err)
-	}
-
-	isCluster := len(connString.Hosts) > 1
-	isSrv := connString.Scheme == connstring.SchemeMongoDBSRV
+	isCluster, isSrv := inferURIShape(cfg.URI)
 
 	servers = append(servers, models.RegisteredServer{
 		ID:        newID,

--- a/internal/servers/uri_shape.go
+++ b/internal/servers/uri_shape.go
@@ -1,0 +1,37 @@
+package servers
+
+import "strings"
+
+// inferURIShape returns (isCluster, isSrv) for a MongoDB connection string
+// without invoking the driver's strict parser. The driver's connstring.Parse
+// is unsuitable at save time because (1) it performs DNS SRV lookups for
+// mongodb+srv:// URIs and (2) it rejects URIs that omit the "/" between the
+// host list and the "?" query — both of which would cause "save server" to
+// fail for otherwise-recoverable input.
+func inferURIShape(uri string) (isCluster, isSrv bool) {
+	const srvPrefix = "mongodb+srv://"
+	const stdPrefix = "mongodb://"
+
+	if strings.HasPrefix(uri, srvPrefix) {
+		return false, true
+	}
+	if !strings.HasPrefix(uri, stdPrefix) {
+		return false, false
+	}
+
+	rest := uri[len(stdPrefix):]
+
+	// Find the host section: everything up to the first "/" or "?" after
+	// optional userinfo (which ends at "@", but only if "@" appears before
+	// the path/query delimiters).
+	end := len(rest)
+	if i := strings.IndexAny(rest, "/?"); i >= 0 {
+		end = i
+	}
+	hostSection := rest[:end]
+	if at := strings.LastIndex(hostSection, "@"); at >= 0 {
+		hostSection = hostSection[at+1:]
+	}
+
+	return strings.Contains(hostSection, ","), false
+}

--- a/internal/servers/uri_shape_test.go
+++ b/internal/servers/uri_shape_test.go
@@ -1,0 +1,32 @@
+package servers
+
+import "testing"
+
+func TestInferURIShape(t *testing.T) {
+	tests := []struct {
+		name      string
+		uri       string
+		isCluster bool
+		isSrv     bool
+	}{
+		{"plain single host", "mongodb://localhost:27017", false, false},
+		{"plain single host with path", "mongodb://localhost:27017/admin", false, false},
+		{"plain cluster", "mongodb://a,b,c/db", true, false},
+		{"srv URI", "mongodb+srv://cluster.example.com/", false, true},
+		{"srv URI never reports cluster", "mongodb+srv://cluster.example.com/", false, true},
+		{"missing slash before query (bug 257)", "mongodb://host?authMechanism=PLAIN", false, false},
+		{"cluster missing slash before query", "mongodb://a,b?authMechanism=PLAIN", true, false},
+		{"userinfo with @ does not count", "mongodb://user@host/db", false, false},
+		{"cluster with userinfo", "mongodb://user:pass@a,b/db", true, false},
+		{"unknown scheme", "https://host", false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCluster, gotSrv := inferURIShape(tc.uri)
+			if gotCluster != tc.isCluster || gotSrv != tc.isSrv {
+				t.Errorf("inferURIShape(%q) = (%v, %v); want (%v, %v)",
+					tc.uri, gotCluster, gotSrv, tc.isCluster, tc.isSrv)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes save error when connection string includes `authMechanism`: frontend produced `mongodb://host?...` (no `/` before `?`) which the Go driver's `connstring.Parse` rejects. Both `setAuthMechanism` and `authUri.joinUri` now insert the slash, and the backend uses a tolerant `inferURIShape` helper that needs no DNS.
- Switching auth method in the picker now strips stale userinfo and auth-only query params (`authMechanismProperties`, `authSource`, `tlsCertificateKey*`) so e.g. choosing OIDC removes a previously-typed `user:pass`.
- Parameter-validation audit: `w=majority`, `authMechanism` in any case, `serverMonitoringMode=stream` (was rejected due to a `'steam'` typo), and `timeoutMS` are now accepted.

Fixes #257.

## Test plan

- [x] `go test ./internal/servers/...`
- [x] `bun run test` (frontend, 446 tests)
- [x] `bun run lint`
- [x] Manual via `wails dev`: save `mongodb://localhost:27017?authMechanism=PLAIN` (no slash) succeeds; switching from SCRAM to OIDC clears `user:pass@` from the URI.