### PR TITLE
fix: connection-string parsing, config save, and tab close bugs

### DIFF
--- a/frontend/src/app/AppContent.vue
+++ b/frontend/src/app/AppContent.vue
@@ -37,16 +37,6 @@ const settingsStore = useSettingsStore()
 const updateStore = useUpdateStore()
 const buildInfoStore = useBuildInfoStore()
 
-runtime.EventsOn('oidc-reauth-required', (serverID: string) => {
-  const server = serverStore.findServerById(serverID)
-  const name = server?.name ?? serverID
-  notification.warning({
-    title: i18n.t('oidc.reAuthTitle'),
-    content: i18n.t('oidc.reAuthMessage', { name }),
-    duration: 10000,
-  })
-})
-
 runtime.EventsOn('config-parse-error', (detail: string) => {
   notification.warning({
     title: i18n.t('errorTitles.configParseError'),

--- a/frontend/src/app/AppContent.vue
+++ b/frontend/src/app/AppContent.vue
@@ -46,6 +46,15 @@ runtime.EventsOn('config-parse-error', (detail: string) => {
   })
 })
 
+// Keep frontend state in sync when the backend drops a connection without
+// the user clicking disconnect (e.g. network loss, server-side timeout).
+// Without this the tab and connection entry persist, and a later click on
+// the tab's close button silently no-ops because browserStore.disconnect
+// short-circuits on a missing connection.
+runtime.EventsOn('connection-disconnected', (serverId: string) => {
+  dataBrowserStore._cleanupConnection(serverId)
+})
+
 const data = reactive({
   navMenuWidth: 50,
   toolbarHeight: 38,

--- a/frontend/src/features/data-browser/browserStore.ts
+++ b/frontend/src/features/data-browser/browserStore.ts
@@ -322,13 +322,19 @@ export const useDataBrowserStore = defineStore('browser', {
           const notifier = useNotifier()
           notifier.warning(i18nGlobal.t('errorTitles.disconnect'), { detail: result.errorDetail })
         }
-        // Always clean up frontend state — backend registry also always cleans up
-        this.connections = this.connections.filter((x) => x.serverID !== serverId)
-        delete this.serverTreeStates[serverId]
-        const tabStore = useTabStore()
-        tabStore.removeTabById(serverId)
       }
+      this._cleanupConnection(serverId)
       return true
+    },
+    // Drop a connection's frontend state without calling the backend. Used by
+    // the backend-emitted "connection-disconnected" event, and as the shared
+    // cleanup path for user-initiated disconnect. Always invoked so that the
+    // tab close button cannot get wedged when the connections list has
+    // drifted from the backend.
+    _cleanupConnection(serverId: string) {
+      this.connections = this.connections.filter((x) => x.serverID !== serverId)
+      delete this.serverTreeStates[serverId]
+      useTabStore().removeTabById(serverId)
     },
     async refreshConnectedServers(force: boolean = false) {
       if (!force && !isEmpty(this.connections)) {

--- a/frontend/src/features/server-pane/authentication/AuthenticationPanel.vue
+++ b/frontend/src/features/server-pane/authentication/AuthenticationPanel.vue
@@ -80,10 +80,12 @@ const SYNCABLE: Partial<Record<AuthMethod, SyncableAuthMechanism>> = {
   plain: 'PLAIN',
 }
 
+const USERINFO_METHODS: ReadonlySet<AuthMethod> = new Set(['password', 'plain', 'gssapi'])
+
 function onMethodChange(next: AuthMethod): void {
   emit('update:method', next)
   const mechanism = next === 'none' || next === 'password' ? null : (SYNCABLE[next] ?? null)
-  const cleared = clearAuthState(props.uri)
+  const cleared = clearAuthState(props.uri, { stripUserinfo: !USERINFO_METHODS.has(next) })
   const newUri = mechanism === null ? cleared : setAuthMechanism(cleared, mechanism)
   if (newUri !== props.uri) {
     emit('update:uri', newUri)

--- a/frontend/src/features/server-pane/authentication/authUri.ts
+++ b/frontend/src/features/server-pane/authentication/authUri.ts
@@ -1,3 +1,5 @@
+import { ensurePathSlash } from '../connectionStrings'
+
 export interface ScramAuth {
   username: string
   password: string
@@ -69,15 +71,12 @@ function splitUri(uri: string): UriParts {
 function joinUri(parts: UriParts): string {
   const userinfo = parts.userinfo ? `${parts.userinfo}@` : ''
   const keys = Object.keys(parts.query)
-  // Driver's connstring.Parse requires "/" between host and "?". Insert it
-  // when the host segment has no path of its own.
-  const hostAndPath =
-    keys.length > 0 && parts.hostAndPath.indexOf('/') === -1
-      ? `${parts.hostAndPath}/`
-      : parts.hostAndPath
-  const query =
-    keys.length === 0 ? '' : `?${keys.map((k) => `${k}=${parts.query[k]}`).join('&')}`
-  return `${parts.scheme}${userinfo}${hostAndPath}${query}`
+  const base = `${parts.scheme}${userinfo}${parts.hostAndPath}`
+  if (keys.length === 0) {
+    return base
+  }
+  const query = keys.map((k) => `${k}=${parts.query[k]}`).join('&')
+  return `${ensurePathSlash(base)}?${query}`
 }
 
 function encodeUserinfo(user: string, password?: string): string {

--- a/frontend/src/features/server-pane/connectionStrings.ts
+++ b/frontend/src/features/server-pane/connectionStrings.ts
@@ -370,7 +370,7 @@ function splitHosts(hosts: string, defaultPort: number | undefined | null): Pars
 
     if (portNumber) {
       const port = Number.parseInt(portNumber)
-      if (port > 0 && port < 65535) {
+      if (port > 0 && port <= 65535) {
         parsedAddresses.push({ host: host!, port: port })
       } else {
         return {
@@ -593,9 +593,9 @@ const parseOptions = (query: string, separator?: string): ParseResult<UriOptions
     if (key!.toLowerCase() === 'readpreferencetags') {
       if (isDuplicateOption(normalizedKey, options)) {
         options[normalizedKey] = [...(options[normalizedKey] as string[]), value!]
+      } else {
+        options[normalizedKey] = [value!]
       }
-
-      options[normalizedKey] = [value!]
     } else {
       if (isDuplicateOption(normalizedKey, options)) {
         console.warn(`Duplicate option '${normalizedKey}' found in query string`)
@@ -606,7 +606,13 @@ const parseOptions = (query: string, separator?: string): ParseResult<UriOptions
         const pairs = value!.split(',')
         for (const pair of pairs) {
           const [key, value] = chopFirst(pair, ':')
-          authMechProps[decodeURIComponent(key!)] = decodeURIComponent(value!)
+          if (!key || value === undefined) {
+            return {
+              success: false,
+              error: i18nGlobal.t('uriParser.invalidQueryOption', { option: pair }),
+            }
+          }
+          authMechProps[decodeURIComponent(key)] = decodeURIComponent(value)
         }
         options[normalizedKey] = authMechProps
       } else {
@@ -661,15 +667,15 @@ function validateAuthMechanism(authMechanism?: string) {
 }
 
 // MongoDB write-concern value: a non-negative integer, the literal "majority",
-// or a custom write-concern tag set name (any non-empty string).
+// or a custom write-concern tag set name (an identifier).
 function validateWriteConcern(value?: string) {
   if (!value) {
     return false
   }
-  if (value.trim().match(/^[0-9]+$/)) {
-    return Number.parseInt(value) >= 0
+  if (/^[0-9]+$/.test(value)) {
+    return true
   }
-  return value.length > 0
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value)
 }
 
 function validateAuthMechanismProps(authMechanismProps?: string) {
@@ -739,7 +745,7 @@ function validateCompressors(compressors?: string) {
     return true
   }
 
-  const list = compressors.indexOf(',') ? compressors.split(',') : [compressors]
+  const list = compressors.includes(',') ? compressors.split(',') : [compressors]
   for (const compressor of list) {
     if (!SupportedCompressors.includes(compressor.toLowerCase())) {
       return false
@@ -912,7 +918,8 @@ const AUTH_QUERY_PARAMS = [
   'tlsCertificateKeyFilePassword',
 ]
 
-export function clearAuthState(uri: string): string {
+export function clearAuthState(uri: string, opts?: { stripUserinfo?: boolean }): string {
+  const stripUserinfo = opts?.stripUserinfo ?? true
   const schemeMatch = uri.match(/^(mongodb(?:\+srv)?:\/\/)/)
   const scheme = schemeMatch ? schemeMatch[1]! : 'mongodb://'
   const rest = schemeMatch ? uri.substring(scheme.length) : uri
@@ -922,7 +929,8 @@ export function clearAuthState(uri: string): string {
   const queryStr = queryIdx === -1 ? '' : rest.substring(queryIdx + 1)
 
   const atIdx = beforeQuery.lastIndexOf('@')
-  const hostAndPath = atIdx === -1 ? beforeQuery : beforeQuery.substring(atIdx + 1)
+  const hostAndPath =
+    stripUserinfo && atIdx !== -1 ? beforeQuery.substring(atIdx + 1) : beforeQuery
 
   const stripLower = new Set(AUTH_QUERY_PARAMS.map((p) => p.toLowerCase()))
   const kept: string[] = []

--- a/frontend/src/features/tabs/ConnectedServerTabs.vue
+++ b/frontend/src/features/tabs/ConnectedServerTabs.vue
@@ -161,7 +161,15 @@ const exThemeVars = computed(() => {
 .value-tab {
   --wails-draggable: none;
   position: relative;
-  border: 1px solic v-bind('exThemeVars.splitColor') !important;
+  border: 1px solid v-bind('exThemeVars.splitColor') !important;
+}
+
+// Pin the close button itself out of the titlebar drag region. Without
+// this Wails occasionally absorbs the first mousedown on the small X
+// hitbox as a window-drag start, swallowing the click.
+:deep(.n-tabs-tab__close) {
+  --wails-draggable: none;
+  pointer-events: auto;
 }
 .value-tab-active {
   background-color: v-bind('themeVars.tabColor') !important;

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -711,10 +711,6 @@ export default {
     filter: 'Filter',
     typeName: 'Server',
   },
-  oidc: {
-    reAuthTitle: 'Session Expired',
-    reAuthMessage: 'OIDC session expired for {name}. Reconnect to re-authenticate.',
-  },
   dialog: {
     common: {},
     about: {

--- a/internal/infrastructure/store.go
+++ b/internal/infrastructure/store.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"vervet/internal/logging"
 )
 
@@ -18,6 +19,7 @@ type Store interface {
 type cfgStore struct {
 	ConfigPath string
 	log        *slog.Logger
+	mu         sync.Mutex
 }
 
 func NewStore(filename string, log *slog.Logger) (Store, error) {
@@ -32,6 +34,9 @@ func NewStore(filename string, log *slog.Logger) (Store, error) {
 }
 
 func (s *cfgStore) Read() ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if _, err := os.Stat(s.ConfigPath); os.IsNotExist(err) {
 		err := os.WriteFile(s.ConfigPath, []byte{}, 0600)
 		if err != nil {
@@ -48,21 +53,46 @@ func (s *cfgStore) Read() ([]byte, error) {
 	return d, nil
 }
 
+// Save writes data atomically: it writes to a sibling temp file, fsyncs,
+// then renames over the target. A mutex serialises concurrent callers so
+// two goroutines cannot interleave truncate+write on the same path.
 func (s *cfgStore) Save(data []byte) error {
-	f, err := os.Create(s.ConfigPath)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dir := filepath.Dir(s.ConfigPath)
+	tmp, err := os.CreateTemp(dir, filepath.Base(s.ConfigPath)+".tmp-*")
 	if err != nil {
 		return fmt.Errorf("error saving configuration: %w", err)
 	}
-	defer f.Close()
+	tmpPath := tmp.Name()
 
-	if _, err := f.Write(data); err != nil {
-		return fmt.Errorf("error saving configuration: %w", err)
+	cleanup := func() {
+		_ = os.Remove(tmpPath)
 	}
 
-	if err := f.Sync(); err != nil {
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
 		return fmt.Errorf("error saving configuration: %w", err)
 	}
-
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("error saving configuration: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("error saving configuration: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0600); err != nil {
+		cleanup()
+		return fmt.Errorf("error saving configuration: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.ConfigPath); err != nil {
+		cleanup()
+		return fmt.Errorf("error saving configuration: %w", err)
+	}
 	return nil
 }
 

--- a/internal/servers/uri_shape.go
+++ b/internal/servers/uri_shape.go
@@ -12,10 +12,10 @@ func inferURIShape(uri string) (isCluster, isSrv bool) {
 	const srvPrefix = "mongodb+srv://"
 	const stdPrefix = "mongodb://"
 
-	if strings.HasPrefix(uri, srvPrefix) {
+	if len(uri) >= len(srvPrefix) && strings.EqualFold(uri[:len(srvPrefix)], srvPrefix) {
 		return false, true
 	}
-	if !strings.HasPrefix(uri, stdPrefix) {
+	if len(uri) < len(stdPrefix) || !strings.EqualFold(uri[:len(stdPrefix)], stdPrefix) {
 		return false, false
 	}
 


### PR DESCRIPTION
## Summary
- Fix connection-string parser edge cases: accept port 65535, preserve all `readPreferenceTags`, reject malformed `authMechanismProperties` instead of throwing, tighten write-concern validator, fix `validateCompressors` falsy `indexOf` check.
- Preserve userinfo when switching between auth methods that share it (password ↔ plain ↔ gssapi) via new `clearAuthState({ stripUserinfo })` option.
- `authUri.joinUri` delegates path-slash insertion to shared `ensurePathSlash` so the two implementations cannot drift.
- `servers/uri_shape`: case-insensitive scheme prefix match so `MONGODB://` / `MongoDB+SRV://` are classified correctly.
- `infrastructure/store.Save`: serialise with a mutex and write atomically via temp file + rename so concurrent callers and mid-write crashes cannot corrupt the YAML.
- Drop dead `oidc-reauth-required` listener and its i18n keys (no backend emitter).
- Tab close reliability: `browserStore.disconnect` no longer gates frontend cleanup on the connection still existing; listen for backend `connection-disconnected` and route through shared `_cleanupConnection`; opt the close-button hitbox out of the Wails titlebar drag region; fix `solic` typo in tab border CSS.

## Test plan
- [x] Add/edit server with URI containing port 65535 — saved without error
- [x] URI with multiple `readPreferenceTags` round-trips with all tags preserved
- [x] Switch auth method password ↔ plain ↔ gssapi — userinfo retained
- [x] Switch away from a userinfo-based method to e.g. x509 — userinfo cleared
- [ ] `MONGODB+SRV://...` URI classified as srv cluster
- [x] Close server tab after backend-initiated disconnect — tab closes cleanly on first click
- [x] First click on tab close X always registers (no Wails drag swallow)
- [x] `bun run lint` passes
- [x] `go test ./...` passes