### PR TITLE
fix(uri): reject non-lowercase scheme to match driver

### DIFF
--- a/frontend/src/features/server-pane/tests/connectionString.test.ts
+++ b/frontend/src/features/server-pane/tests/connectionString.test.ts
@@ -225,6 +225,18 @@ function runScenario(scenario: Scenario) {
   }
 }
 
+describe('connectionString.parseUri scheme case-sensitive', () => {
+  test('rejects uppercase MONGODB:// scheme to match driver', () => {
+    const result = parseUri('MONGODB://host:27017/?authSource=admin')
+    expect(result.success).toBe(false)
+  })
+
+  test('rejects mixed-case MongoDB+SRV:// scheme to match driver', () => {
+    const result = parseUri('MongoDB+SRV://cluster.example.com/')
+    expect(result.success).toBe(false)
+  })
+})
+
 describe('connectionString.setAuthMechanism', () => {
   test('appends authMechanism when URI has no query', () => {
     expect(setAuthMechanism('mongodb://host', 'MONGODB-OIDC'))

--- a/internal/servers/uri_shape.go
+++ b/internal/servers/uri_shape.go
@@ -12,10 +12,10 @@ func inferURIShape(uri string) (isCluster, isSrv bool) {
 	const srvPrefix = "mongodb+srv://"
 	const stdPrefix = "mongodb://"
 
-	if len(uri) >= len(srvPrefix) && strings.EqualFold(uri[:len(srvPrefix)], srvPrefix) {
+	if strings.HasPrefix(uri, srvPrefix) {
 		return false, true
 	}
-	if len(uri) < len(stdPrefix) || !strings.EqualFold(uri[:len(stdPrefix)], stdPrefix) {
+	if !strings.HasPrefix(uri, stdPrefix) {
 		return false, false
 	}
 


### PR DESCRIPTION
## Summary
- Revert prior loosening that let `MONGODB://` / `MongoDB+SRV://` URIs through. The mongo-driver only accepts lowercase `mongodb://` / `mongodb+srv://`, so accepting them on save just deferred the error until connect time.
- Frontend `parseUri` and backend `inferURIShape` both back to strict case-sensitive scheme matching.
- Save now fails fast with the existing "URI should begin with mongodb:// or mongodb+srv://" message.

## Test plan
- [x] Try to save a URI with `MONGODB://...` — rejected at save with clear message
- [x] `mongodb://...` and `mongodb+srv://...` still save and connect
- [x] `bun run test` passes
- [x] `go test ./internal/...` passes