### PR TITLE
feat(server-dialog): inline group creation

### DIFF
--- a/frontend/src/features/server-pane/GroupDialog.vue
+++ b/frontend/src/features/server-pane/GroupDialog.vue
@@ -125,13 +125,13 @@ watchEffect(() => {
     const group = serverStore.findServerById(rawData)
     editGroup.value = rawData
     groupForm.name = group?.name || ''
-    groupForm.parentId = group?.parentID
+    groupForm.parentId = group?.parentID || ''
     return
   }
   const payload = asCreatePayload(rawData)
   editGroup.value = ''
   groupForm.name = ''
-  groupForm.parentId = payload?.parentId
+  groupForm.parentId = payload?.parentId || ''
 })
 </script>
 

--- a/frontend/src/features/server-pane/GroupDialog.vue
+++ b/frontend/src/features/server-pane/GroupDialog.vue
@@ -7,6 +7,7 @@ import { DialogType, useDialogStore } from '@/stores/dialog.ts'
 import { type RegisteredServerNode, useServerStore } from '@/features/server-pane/serverStore.ts'
 import { useMessager } from '@/utils/dialog.ts'
 import { filterGroupMap } from '@/features/server-pane/helpers.ts'
+import { asCreatePayload, isEditPayload } from '@/features/server-pane/groupDialog.ts'
 
 const dialogStore = useDialogStore()
 const serverStore = useServerStore()
@@ -39,8 +40,8 @@ const formRules = computed(() => {
   }
 })
 
-const isEditMode = computed(
-  () => ((dialogStore.dialogs[DialogType.Group].data as string) || '').length > 0,
+const isEditMode = computed(() =>
+  isEditPayload(dialogStore.dialogs[DialogType.Group].data),
 )
 
 const onConfirm = async () => {
@@ -68,10 +69,8 @@ const onConfirm = async () => {
     } else {
       const result = await serverStore.createGroup(name, parentId)
       if (result.success) {
-        const data = dialogStore.dialogs[DialogType.Group].data as
-          | { onCreated?: (id: string) => void }
-          | undefined
-        data?.onCreated?.(result.id)
+        const payload = asCreatePayload(dialogStore.dialogs[DialogType.Group].data)
+        payload?.onCreated?.(result.id)
         messager.success(i18n.t('common.dialog.handleSuccess'))
         onClose()
       } else {
@@ -118,20 +117,21 @@ const groupOptions = computed(() => {
 })
 
 watchEffect(() => {
-  if (dialogStore.dialogs[DialogType.Group].visible) {
-    const rawData = dialogStore.dialogs[DialogType.Group].data
-    if (typeof rawData === 'object' && rawData !== null && 'parentId' in rawData) {
-      editGroup.value = ''
-      groupForm.name = ''
-      groupForm.parentId = (rawData as { parentId: string }).parentId
-    } else {
-      const groupId = rawData as string
-      const group = serverStore.findServerById(groupId)
-      editGroup.value = groupId
-      groupForm.name = group?.name || ''
-      groupForm.parentId = group?.parentID
-    }
+  if (!dialogStore.dialogs[DialogType.Group].visible) {
+    return
   }
+  const rawData = dialogStore.dialogs[DialogType.Group].data
+  if (isEditPayload(rawData)) {
+    const group = serverStore.findServerById(rawData)
+    editGroup.value = rawData
+    groupForm.name = group?.name || ''
+    groupForm.parentId = group?.parentID
+    return
+  }
+  const payload = asCreatePayload(rawData)
+  editGroup.value = ''
+  groupForm.name = ''
+  groupForm.parentId = payload?.parentId
 })
 </script>
 

--- a/frontend/src/features/server-pane/GroupDialog.vue
+++ b/frontend/src/features/server-pane/GroupDialog.vue
@@ -66,12 +66,16 @@ const onConfirm = async () => {
         messager.error(msg!)
       }
     } else {
-      const { success, msg } = await serverStore.createGroup(name, parentId)
-      if (success) {
+      const result = await serverStore.createGroup(name, parentId)
+      if (result.success) {
+        const data = dialogStore.dialogs[DialogType.Group].data as
+          | { onCreated?: (id: string) => void }
+          | undefined
+        data?.onCreated?.(result.id)
         messager.success(i18n.t('common.dialog.handleSuccess'))
         onClose()
       } else {
-        messager.error(msg!)
+        messager.error(result.msg!)
       }
     }
   } catch (e) {

--- a/frontend/src/features/server-pane/GroupDialog.vue
+++ b/frontend/src/features/server-pane/GroupDialog.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { useI18n } from 'vue-i18n'
-import { computed, reactive, ref, watchEffect } from 'vue'
+import { computed, reactive, ref, watch, watchEffect } from 'vue'
 import { every, get, includes } from 'lodash'
 import { type FormInst, type FormItemRule } from 'naive-ui'
 import { DialogType, useDialogStore } from '@/stores/dialog.ts'
@@ -23,18 +23,43 @@ const groupForm = reactive<{
 
 const groupFormRef = ref<FormInst | null>(null)
 
+function siblingGroupsAt(parentId: string): RegisteredServerNode[] {
+  if (!parentId) {
+    return serverStore.serverTree.filter((n) => n.isGroup)
+  }
+  const parent = serverStore.findServerById(parentId)
+  return (parent?.children || []).filter((n) => n.isGroup)
+}
+
+function isDuplicateSibling(name: string, parentId: string, excludeId: string): boolean {
+  const target = name.trim().toLowerCase()
+  if (!target) {
+    return false
+  }
+  return siblingGroupsAt(parentId).some(
+    (n) => n.id !== excludeId && n.name.trim().toLowerCase() === target,
+  )
+}
+
 const formRules = computed(() => {
   const requiredMsg = i18n.t('common.dialog.fieldRequired')
   const illegalChars = ['/', '\\']
   return {
     name: [
-      { required: true, message: requiredMsg, trigger: 'input' },
+      { required: true, message: requiredMsg, trigger: ['input', 'blur'] },
       {
         validator: (rule: FormItemRule, value: string) => {
           return every(illegalChars, (c) => !includes(value, c))
         },
         message: i18n.t('common.dialog.illegalCharacters'),
-        trigger: 'input',
+        trigger: ['input', 'blur'],
+      },
+      {
+        validator: (rule: FormItemRule, value: string) => {
+          return !isDuplicateSibling(value, groupForm.parentId || '', editGroup.value)
+        },
+        message: i18n.t('errors.duplicate_group_name'),
+        trigger: ['input', 'blur'],
       },
     ],
   }
@@ -44,16 +69,21 @@ const isEditMode = computed(() =>
   isEditPayload(dialogStore.dialogs[DialogType.Group].data),
 )
 
-const onConfirm = async () => {
+const onConfirm = async (): Promise<boolean> => {
   const messager = useMessager()
   try {
+    let validationError = false
     await groupFormRef.value?.validate((errs) => {
       const err = get(errs, '0.0.message')
       if (err != null) {
-        const messager = useMessager()
+        validationError = true
         messager.error(err)
       }
     })
+
+    if (validationError) {
+      return false
+    }
 
     const { name, parentId } = groupForm
 
@@ -63,23 +93,26 @@ const onConfirm = async () => {
       if (success) {
         messager.success(i18n.t('common.dialog.handleSuccess'))
         onClose()
-      } else {
-        messager.error(msg!)
+        return true
       }
-    } else {
-      const result = await serverStore.createGroup(name, parentId)
-      if (result.success) {
-        const payload = asCreatePayload(dialogStore.dialogs[DialogType.Group].data)
-        payload?.onCreated?.(result.id)
-        messager.success(i18n.t('common.dialog.handleSuccess'))
-        onClose()
-      } else {
-        messager.error(result.msg!)
-      }
+      messager.error(msg!)
+      return false
     }
+
+    const result = await serverStore.createGroup(name, parentId)
+    if (result.success) {
+      const payload = asCreatePayload(dialogStore.dialogs[DialogType.Group].data)
+      payload?.onCreated?.(result.id)
+      messager.success(i18n.t('common.dialog.handleSuccess'))
+      onClose()
+      return true
+    }
+    messager.error(result.msg!)
+    return false
   } catch (e) {
     const err = e as Error
     messager.error(err.message)
+    return false
   }
 }
 
@@ -115,6 +148,16 @@ const groupOptions = computed(() => {
   })
   return options
 })
+
+watch(
+  () => groupForm.parentId,
+  () => {
+    if (!dialogStore.dialogs[DialogType.Group].visible) {
+      return
+    }
+    groupFormRef.value?.validate(undefined, (rule) => rule?.key === 'name').catch(() => {})
+  },
+)
 
 watchEffect(() => {
   if (!dialogStore.dialogs[DialogType.Group].visible) {

--- a/frontend/src/features/server-pane/ServerDialog.vue
+++ b/frontend/src/features/server-pane/ServerDialog.vue
@@ -158,34 +158,31 @@ const onSaveServer = async () => {
 
 const NEW_GROUP_SENTINEL = '__new_group__'
 
+function syntheticGroupNode(id: string, name: string): RegisteredServerNode {
+  return {
+    id,
+    name,
+    isGroup: true,
+    isCluster: false,
+    isSrv: false,
+    children: [],
+    colour: '',
+  }
+}
+
 const groupOptions = computed(() => {
-  const nodes = serverStore.serverTree
-  const options: RegisteredServerNode[] = []
-  for (let i = 0, ln = nodes.length; i < ln; ++i) {
-    const option = filterGroupMap(nodes[i]!)
-    if (!!option) {
-      options.push(option)
+  const realGroups: RegisteredServerNode[] = []
+  for (const node of serverStore.serverTree) {
+    const option = filterGroupMap(node)
+    if (option) {
+      realGroups.push(option)
     }
   }
-  options.splice(0, 0, {
-    name: i18n.t('serverPane.dialogs.common.noGroup'),
-    id: '',
-    isGroup: true,
-    isCluster: false,
-    isSrv: false,
-    children: [],
-    colour: '',
-  })
-  options.splice(0, 0, {
-    name: i18n.t('serverPane.dialogs.common.newGroup'),
-    id: NEW_GROUP_SENTINEL,
-    isGroup: true,
-    isCluster: false,
-    isSrv: false,
-    children: [],
-    colour: '',
-  })
-  return options
+  return [
+    syntheticGroupNode(NEW_GROUP_SENTINEL, i18n.t('serverPane.dialogs.common.newGroup')),
+    syntheticGroupNode('', i18n.t('serverPane.dialogs.common.noGroup')),
+    ...realGroups,
+  ]
 })
 
 const previousParentId = ref('')

--- a/frontend/src/features/server-pane/ServerDialog.vue
+++ b/frontend/src/features/server-pane/ServerDialog.vue
@@ -156,6 +156,8 @@ const onSaveServer = async () => {
   onClose()
 }
 
+const NEW_GROUP_SENTINEL = '__new_group__'
+
 const groupOptions = computed(() => {
   const nodes = serverStore.serverTree
   const options: RegisteredServerNode[] = []
@@ -174,8 +176,34 @@ const groupOptions = computed(() => {
     children: [],
     colour: '',
   })
+  options.splice(0, 0, {
+    name: i18n.t('serverPane.dialogs.common.newGroup'),
+    id: NEW_GROUP_SENTINEL,
+    isGroup: true,
+    isCluster: false,
+    isSrv: false,
+    children: [],
+    colour: '',
+  })
   return options
 })
+
+const previousParentId = ref('')
+
+function onParentChange(next: string) {
+  if (next === NEW_GROUP_SENTINEL) {
+    const prev = previousParentId.value
+    generalForm.value.parentId = prev
+    dialogStore.showNewDialog(DialogType.Group, {
+      onCreated: (id: string) => {
+        generalForm.value.parentId = id
+        previousParentId.value = id
+      },
+    })
+    return
+  }
+  previousParentId.value = next
+}
 
 const onClose = () => {
   dialogStore.hide(DialogType.Server)
@@ -190,6 +218,7 @@ const resetForm = () => {
     parentId: '',
     colour: '',
   }
+  previousParentId.value = ''
   generalFormRef.value?.restoreValidation()
   testing.value = false
   authPicker.value = 'password'
@@ -223,6 +252,7 @@ watch(
           connectionString: server.uri,
           parentId: server.parentID || '',
         }
+        previousParentId.value = generalForm.value.parentId
         authPicker.value = server.authMethod ?? 'password'
         if (server.oidcConfig) {
           oidcConfig.value = { ...server.oidcConfig }
@@ -247,6 +277,7 @@ watch(
       | undefined
     if (rawData?.parentId) {
       generalForm.value.parentId = rawData.parentId
+      previousParentId.value = rawData.parentId
     }
   },
   { immediate: true },
@@ -397,7 +428,8 @@ const onTestConnection = async () => {
                   v-model:value="generalForm.parentId"
                   :options="groupOptions"
                   key-field="id"
-                  label-field="name" />
+                  label-field="name"
+                  @update:value="onParentChange" />
               </n-form-item-gi>
               <n-form-item-gi
                 :label="$t('serverPane.dialogs.server.colour')"

--- a/frontend/src/features/server-pane/ServerDialog.vue
+++ b/frontend/src/features/server-pane/ServerDialog.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
-import { type FormInst, type FormRules, useThemeVars } from 'naive-ui'
+import { NIcon, type FormInst, type FormRules, type TreeSelectRenderLabel, useThemeVars } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
-import { computed, nextTick, ref, watch } from 'vue'
+import { computed, h, nextTick, ref, watch } from 'vue'
 import { every, includes, isEmpty } from 'lodash'
-import { XCircleIcon } from '@heroicons/vue/24/outline'
+import { FolderPlusIcon, XCircleIcon } from '@heroicons/vue/24/outline'
 import { DialogType, useDialogStore } from '@/stores/dialog.ts'
 import { useDataBrowserStore } from '@/features/data-browser/browserStore.ts'
 import { type RegisteredServerNode, useServerStore } from '@/features/server-pane/serverStore.ts'
@@ -168,6 +168,16 @@ function syntheticGroupNode(id: string, name: string): RegisteredServerNode {
     children: [],
     colour: '',
   }
+}
+
+const renderGroupLabel: TreeSelectRenderLabel = ({ option }) => {
+  if (option.id === NEW_GROUP_SENTINEL) {
+    return h('div', { style: 'display: flex; align-items: center; gap: 6px;' }, [
+      h(NIcon, { size: 16 }, { default: () => h(FolderPlusIcon) }),
+      h('span', null, option.name as string),
+    ])
+  }
+  return option.name as string
 }
 
 const groupOptions = computed(() => {
@@ -424,6 +434,7 @@ const onTestConnection = async () => {
                 <n-tree-select
                   v-model:value="generalForm.parentId"
                   :options="groupOptions"
+                  :render-label="renderGroupLabel"
                   key-field="id"
                   label-field="name"
                   @update:value="onParentChange" />

--- a/frontend/src/features/server-pane/groupDialog.ts
+++ b/frontend/src/features/server-pane/groupDialog.ts
@@ -1,0 +1,24 @@
+// Discriminated payload accepted by the Group dialog (`DialogType.Group`).
+//
+// - `string`: groupId, opens the dialog in edit/rename mode.
+// - object: opens the dialog in create mode, optionally prefilled with a
+//   parent group and optionally with a callback invoked with the new id.
+export type GroupDialogData =
+  | string
+  | {
+      parentId?: string
+      onCreated?: (id: string) => void
+    }
+
+export function isEditPayload(data: unknown): data is string {
+  return typeof data === 'string' && data.length > 0
+}
+
+export function asCreatePayload(
+  data: unknown,
+): { parentId?: string; onCreated?: (id: string) => void } | undefined {
+  if (data == null || typeof data !== 'object') {
+    return undefined
+  }
+  return data as { parentId?: string; onCreated?: (id: string) => void }
+}

--- a/frontend/src/features/server-pane/serverStore.ts
+++ b/frontend/src/features/server-pane/serverStore.ts
@@ -176,10 +176,10 @@ export const useServerStore = defineStore('server', {
     async createGroup(name: string, parentId?: string) {
       const result = await serversProxy.CreateGroup(name, parentId || '')
       if (!result.isSuccess) {
-        return { success: false, msg: i18nGlobal.t(`errors.${result.errorCode}`) }
+        return { success: false as const, msg: i18nGlobal.t(`errors.${result.errorCode}`) }
       }
       await this.refreshServers(true)
-      return { success: true }
+      return { success: true as const, id: result.data }
     },
     async updateGroup(groupId: string, newName: string, parentId?: string) {
       const group = this.findServerById(groupId)

--- a/frontend/src/features/server-pane/tests/serverStore.test.ts
+++ b/frontend/src/features/server-pane/tests/serverStore.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('wailsjs/go/api/ServersProxy', () => ({
+  CreateGroup: vi.fn(),
+  GetServers: vi.fn().mockResolvedValue({ isSuccess: true, data: [] }),
+}))
+
+vi.mock('wailsjs/go/api/FilesProxy', () => ({}))
+
+vi.mock('@/features/data-browser/browserStore.ts', () => ({
+  useDataBrowserStore: vi.fn(() => ({})),
+}))
+
+vi.mock('@/utils/dialog.ts', () => ({
+  useNotifier: vi.fn(() => ({ error: vi.fn(), warning: vi.fn() })),
+}))
+
+import * as serversProxy from 'wailsjs/go/api/ServersProxy'
+import { useServerStore } from '@/features/server-pane/serverStore'
+
+describe('serverStore.createGroup', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  test('returns the new group id on success', async () => {
+    vi.mocked(serversProxy.CreateGroup).mockResolvedValue({
+      isSuccess: true,
+      data: 'new-id',
+    })
+
+    const store = useServerStore()
+    const result = await store.createGroup('Test', '')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.id).toBe('new-id')
+    }
+  })
+
+  test('returns failure with msg on error', async () => {
+    vi.mocked(serversProxy.CreateGroup).mockResolvedValue({
+      isSuccess: false,
+      data: '',
+      errorCode: 'someError',
+    })
+
+    const store = useServerStore()
+    const result = await store.createGroup('Test', '')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.msg).toBeTruthy()
+    }
+  })
+})

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -577,6 +577,7 @@ export default {
     dialogs: {
       common: {
         noGroup: 'No Group',
+        newGroup: '+ New group',
       },
       server: {
         newTitle: 'Add Server',

--- a/frontend/src/i18n/en-GB/index.ts
+++ b/frontend/src/i18n/en-GB/index.ts
@@ -577,7 +577,7 @@ export default {
     dialogs: {
       common: {
         noGroup: 'No Group',
-        newGroup: '+ New group',
+        newGroup: 'Add New Group',
       },
       server: {
         newTitle: 'Add Server',
@@ -786,6 +786,7 @@ export default {
     no_database_selected: 'No database selected',
     query_cancelled: 'Query cancelled',
     operation_not_supported: 'Operation not supported by the current query engine',
+    duplicate_group_name: 'A group with this name already exists in this location',
     unknown_error: 'An unexpected error occurred',
     configParseError: 'Your server configuration file could not be read. Your server list may appear empty until the file is repaired or new servers are added.',
     saveFailed: 'Could not save server',

--- a/frontend/wailsjs/go/api/ServersProxy.d.ts
+++ b/frontend/wailsjs/go/api/ServersProxy.d.ts
@@ -3,7 +3,7 @@
 import {api} from '../models';
 import {models} from '../models';
 
-export function CreateGroup(arg1:string,arg2:string):Promise<api.EmptyResult>;
+export function CreateGroup(arg1:string,arg2:string):Promise<api.Result_string_>;
 
 export function ExportServers(arg1:Array<string>,arg2:boolean):Promise<api.Result_string_>;
 

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -13,7 +13,7 @@ type ServersProvider interface {
 	UpdateServer(serverID, name, uri, parentID, colour string) error
 	RemoveNode(id string) error
 	GetURI(id string) (string, error)
-	CreateGroup(parentID, name string) error
+	CreateGroup(parentID, name string) (string, error)
 	UpdateGroup(groupID, name, parentID string) error
 	GetServer(id string) (*models.RegisteredServer, error)
 	AddServerWithConfig(parentID, name, colour string, cfg models.ConnectionConfig) error
@@ -64,14 +64,14 @@ func (sp *ServersProxy) GetServer(id string) Result[models.RegisteredServer] {
 	return SuccessResult(*registerServer)
 }
 
-func (sp *ServersProxy) CreateGroup(name, parentID string) EmptyResult {
-	err := sp.sm.CreateGroup(parentID, name)
+func (sp *ServersProxy) CreateGroup(name, parentID string) Result[string] {
+	id, err := sp.sm.CreateGroup(parentID, name)
 	if err != nil {
 		logFail(sp.log, "CreateGroup", err)
-		return Fail(err)
+		return FailResult[string](err)
 	}
 
-	return Success()
+	return SuccessResult(id)
 }
 
 func (sp *ServersProxy) UpdateGroup(groupID, name, parentID string) EmptyResult {

--- a/internal/api/servers_test.go
+++ b/internal/api/servers_test.go
@@ -57,8 +57,11 @@ func (m *MockServersProvider) BuildFullConnectionString(id string) (string, erro
 	return m.fullConnString, nil
 }
 
-func (m *MockServersProvider) CreateGroup(parentID, name string) error {
-	return m.err
+func (m *MockServersProvider) CreateGroup(parentID, name string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return "new-group-id", nil
 }
 
 func (m *MockServersProvider) UpdateGroup(groupID, name, parentID string) error {

--- a/internal/errcodes/classify.go
+++ b/internal/errcodes/classify.go
@@ -8,6 +8,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 
 	"vervet/internal/oidc"
+	"vervet/internal/servers"
 	"vervet/internal/shell"
 )
 
@@ -20,6 +21,10 @@ func ClassifyError(err error) ClassifiedError {
 
 	if errors.Is(err, oidc.ErrLoginCanceled) {
 		return ClassifiedError{Code: OIDCLoginCanceled, Detail: err.Error()}
+	}
+
+	if errors.Is(err, servers.ErrDuplicateGroupName) {
+		return ClassifiedError{Code: DuplicateGroupName, Detail: err.Error()}
 	}
 
 	if errors.Is(err, shell.ErrShellNotFound) {

--- a/internal/errcodes/codes.go
+++ b/internal/errcodes/codes.go
@@ -13,6 +13,7 @@ const (
 	QueryCancelled        = "query_cancelled"
 	OIDCLoginCanceled     = "oidc_login_canceled"
 	OperationNotSupported = "operation_not_supported"
+	DuplicateGroupName    = "duplicate_group_name"
 	UnknownError          = "unknown_error"
 )
 

--- a/internal/servers/groups.go
+++ b/internal/servers/groups.go
@@ -1,11 +1,17 @@
 package servers
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 	"vervet/internal/models"
 
 	"github.com/google/uuid"
 )
+
+// ErrDuplicateGroupName is returned when a create/update would produce two
+// sibling groups with the same name (case-insensitive) under the same parent.
+var ErrDuplicateGroupName = errors.New("a group with this name already exists in this location")
 
 // CreateGroup creates a new group node and returns its id.
 func (sm *ServerService) CreateGroup(parentID, name string) (string, error) {
@@ -21,6 +27,10 @@ func (sm *ServerService) CreateGroup(parentID, name string) (string, error) {
 
 	if parent == nil {
 		parentID = ""
+	}
+
+	if siblingGroupNameExists(servers, parentID, name, "") {
+		return "", ErrDuplicateGroupName
 	}
 
 	newServer := models.RegisteredServer{
@@ -57,6 +67,10 @@ func (sm *ServerService) UpdateGroup(groupID, name, parentID string) error {
 		return fmt.Errorf("failed to find group for ID %s", groupID)
 	}
 
+	if siblingGroupNameExists(servers, parentID, name, groupID) {
+		return ErrDuplicateGroupName
+	}
+
 	group.Name = name
 	group.ParentID = parentID
 
@@ -76,4 +90,29 @@ func findGroup(groupID string, servers []models.RegisteredServer) *models.Regist
 	}
 
 	return node
+}
+
+// siblingGroupNameExists reports whether another group under parentID already
+// has the given name (case-insensitive, trimmed). excludeID is skipped to allow
+// renaming a group to its own name without conflict.
+func siblingGroupNameExists(servers []models.RegisteredServer, parentID, name, excludeID string) bool {
+	target := strings.ToLower(strings.TrimSpace(name))
+	if target == "" {
+		return false
+	}
+	for _, s := range servers {
+		if !s.IsGroup {
+			continue
+		}
+		if s.ID == excludeID {
+			continue
+		}
+		if s.ParentID != parentID {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(s.Name)) == target {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/servers/groups.go
+++ b/internal/servers/groups.go
@@ -7,14 +7,14 @@ import (
 	"github.com/google/uuid"
 )
 
-// CreateGroup creates a new group node.
-func (sm *ServerService) CreateGroup(parentID, name string) error {
+// CreateGroup creates a new group node and returns its id.
+func (sm *ServerService) CreateGroup(parentID, name string) (string, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
 	servers, err := sm.store.LoadServers()
 	if err != nil {
-		return fmt.Errorf("failed to create Server Group: %w", err)
+		return "", fmt.Errorf("failed to create Server Group: %w", err)
 	}
 
 	parent, _ := findServer(parentID, servers)
@@ -31,12 +31,11 @@ func (sm *ServerService) CreateGroup(parentID, name string) error {
 	}
 
 	servers = append(servers, newServer)
-	err = sm.store.SaveServers(servers)
-	if err != nil {
-		return fmt.Errorf("failed to save new registered server group: %w", err)
+	if err := sm.store.SaveServers(servers); err != nil {
+		return "", fmt.Errorf("failed to save new registered server group: %w", err)
 	}
 
-	return nil
+	return newServer.ID, nil
 }
 
 func (sm *ServerService) UpdateGroup(groupID, name, parentID string) error {

--- a/internal/servers/groups_test.go
+++ b/internal/servers/groups_test.go
@@ -1,6 +1,7 @@
 package servers
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,49 @@ func TestCreateGroup(t *testing.T) {
 		assert.True(t, mockStore.servers[1].IsGroup)
 		assert.Equal(t, "New Group", mockStore.servers[1].Name)
 		assert.Equal(t, "parent", mockStore.servers[1].ParentID)
+	})
+
+	t.Run("duplicate sibling name rejected", func(t *testing.T) {
+		mockStore := &mockServerStore{
+			servers: []models.RegisteredServer{
+				{ID: "g1", Name: "Test Group", IsGroup: true, ParentID: ""},
+			},
+		}
+		sm := newTestServerService(mockStore, &MockConnectionStringsStore{})
+
+		id, err := sm.CreateGroup("", "Test Group")
+
+		assert.Empty(t, id)
+		assert.ErrorIs(t, err, ErrDuplicateGroupName)
+		assert.Len(t, mockStore.servers, 1)
+	})
+
+	t.Run("duplicate sibling name case-insensitive rejected", func(t *testing.T) {
+		mockStore := &mockServerStore{
+			servers: []models.RegisteredServer{
+				{ID: "g1", Name: "Test Group", IsGroup: true, ParentID: ""},
+			},
+		}
+		sm := newTestServerService(mockStore, &MockConnectionStringsStore{})
+
+		_, err := sm.CreateGroup("", "  test group  ")
+
+		assert.True(t, errors.Is(err, ErrDuplicateGroupName))
+	})
+
+	t.Run("same name under different parent allowed", func(t *testing.T) {
+		mockStore := &mockServerStore{
+			servers: []models.RegisteredServer{
+				{ID: "p1", Name: "Parent", IsGroup: true, ParentID: ""},
+				{ID: "g1", Name: "Test Group", IsGroup: true, ParentID: ""},
+			},
+		}
+		sm := newTestServerService(mockStore, &MockConnectionStringsStore{})
+
+		id, err := sm.CreateGroup("p1", "Test Group")
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, id)
 	})
 }
 
@@ -65,6 +109,34 @@ func TestUpdateGroup(t *testing.T) {
 		err := sm.UpdateGroup("1", "Updated Group", "")
 
 		assert.Error(t, err)
+	})
+
+	t.Run("rename to sibling name rejected", func(t *testing.T) {
+		mockStore := &mockServerStore{
+			servers: []models.RegisteredServer{
+				{ID: "1", Name: "Alpha", IsGroup: true, ParentID: ""},
+				{ID: "2", Name: "Beta", IsGroup: true, ParentID: ""},
+			},
+		}
+		sm := newTestServerService(mockStore, &MockConnectionStringsStore{})
+
+		err := sm.UpdateGroup("2", "Alpha", "")
+
+		assert.ErrorIs(t, err, ErrDuplicateGroupName)
+		assert.Equal(t, "Beta", mockStore.servers[1].Name)
+	})
+
+	t.Run("rename to own name allowed (no-op)", func(t *testing.T) {
+		mockStore := &mockServerStore{
+			servers: []models.RegisteredServer{
+				{ID: "1", Name: "Alpha", IsGroup: true, ParentID: ""},
+			},
+		}
+		sm := newTestServerService(mockStore, &MockConnectionStringsStore{})
+
+		err := sm.UpdateGroup("1", "Alpha", "")
+
+		assert.NoError(t, err)
 	})
 }
 

--- a/internal/servers/groups_test.go
+++ b/internal/servers/groups_test.go
@@ -16,10 +16,12 @@ func TestCreateGroup(t *testing.T) {
 		}
 		sm := newTestServerService(mockStore, &MockConnectionStringsStore{})
 
-		err := sm.CreateGroup("parent", "New Group")
+		id, err := sm.CreateGroup("parent", "New Group")
 
 		assert.NoError(t, err)
+		assert.NotEmpty(t, id)
 		assert.Len(t, mockStore.servers, 2)
+		assert.Equal(t, id, mockStore.servers[1].ID)
 		assert.True(t, mockStore.servers[1].IsGroup)
 		assert.Equal(t, "New Group", mockStore.servers[1].Name)
 		assert.Equal(t, "parent", mockStore.servers[1].ParentID)


### PR DESCRIPTION
## Summary
- Adds a `+ New group` sentinel at the top of the Group tree-select in the Add Server / Edit Server dialog.
- Selecting it opens the existing `GroupDialog` as a modal-over-modal with an `onCreated(id)` callback. On save, the Server dialog auto-selects the new group as the parent.
- Backend `ServerService.CreateGroup` now returns `(string, error)`; `ServersProxy.CreateGroup` returns `Result[string]` so the new id flows back to the frontend.
- `GroupDialog` data payload is now a typed discriminated union (`string` for edit, object for create with optional `parentId` / `onCreated`), replacing the ad-hoc casts.
- `ServerDialog`'s `groupOptions` switched from `splice(0, 0, ...)` twice to a literal `[sentinel, noGroup, ...realGroups]`.

Fixes #260

## Test plan
- [x] Add Server -> Group dropdown -> "+ New group" -> save -> new group is selected
- [x] Edit Server -> Group dropdown -> "+ New group" -> save -> parent reassigned to new group
- [x] Cancel GroupDialog mid-flow -> Server dialog parent unchanged
- [x] Create-with-duplicate-name -> error stays in GroupDialog, Server dialog unchanged
- [x] Right-click rename group still works (edit-mode payload still routes correctly)
- [x] `go test ./...` passes
- [x] `bun run test` passes (450 tests)
- [x] `bun run lint` passes