### PR TITLE
perf(startup): defer system font enumeration off the init path

### DIFF
--- a/frontend/src/app/App.vue
+++ b/frontend/src/app/App.vue
@@ -35,12 +35,16 @@ onMounted(async () => {
   try {
     initializing.value = true
     await settingsStore.loadSettings()
-    await settingsStore.loadFontList()
     await serverStore.refreshServers()
     await browserStore.refreshConnectedServers(true)
   } finally {
     initializing.value = false
   }
+
+  // Enumerating system fonts is expensive (opens+parses every font file) and is
+  // only needed for the settings dialog dropdowns, not for initial render.
+  // Load it in the background so it doesn't gate startup.
+  void settingsStore.loadFontList()
 })
 
 watch(

--- a/frontend/src/features/settings/SettingsDialog.vue
+++ b/frontend/src/features/settings/SettingsDialog.vue
@@ -24,6 +24,9 @@ const initSettings = async () => {
     loading.value = true
     currentTab.value = dialogStore.getDialogData<string>(DialogType.Settings) || 'general'
     await settingsStore.loadSettings()
+    // Fallback: ensure font dropdowns are populated if the background load at
+    // startup failed or hasn't finished yet (no-op once loaded).
+    void settingsStore.loadFontList()
     previousSettings.value = {
       general: settingsStore.general,
       editor: settingsStore.editor,

--- a/frontend/src/features/settings/settingsStore.ts
+++ b/frontend/src/features/settings/settingsStore.ts
@@ -6,8 +6,13 @@ import * as settingsProxy from 'wailsjs/go/api/SettingsProxy'
 import { type models } from 'wailsjs/go/models.ts'
 import { useNotifier } from '@/utils/dialog.ts'
 
+// Tracks an in-flight font enumeration so the expensive backend call isn't
+// fired twice when the background startup load and a settings-open race.
+let fontListInFlight: Promise<void> | null = null
+
 type SettingsStore = models.Settings & {
   fontList: models.Font[]
+  fontListLoaded: boolean
   previousVersion?: models.Settings
 }
 
@@ -56,6 +61,7 @@ export const useSettingsStore = defineStore('settings', {
         maxBackups: 5,
       },
       fontList: [],
+      fontListLoaded: false,
     }) as unknown as SettingsStore,
   getters: {
     themeOptions() {
@@ -200,14 +206,25 @@ export const useSettingsStore = defineStore('settings', {
       i18nGlobal.locale = this.currentLanguage
     },
     async loadFontList(): Promise<void> {
-      const result = await settingsProxy.GetAvailableFonts()
-      if (!result.isSuccess) {
-        const notifier = useNotifier()
-        notifier.error(i18nGlobal.t(`errors.${result.errorCode}`), { title: i18nGlobal.t('errorTitles.saveSettings'), detail: result.errorDetail })
-        return
+      if (this.fontListLoaded || fontListInFlight) {
+        return fontListInFlight ?? undefined
       }
+      fontListInFlight = (async () => {
+        try {
+          const result = await settingsProxy.GetAvailableFonts()
+          if (!result.isSuccess) {
+            const notifier = useNotifier()
+            notifier.error(i18nGlobal.t(`errors.${result.errorCode}`), { title: i18nGlobal.t('errorTitles.saveSettings'), detail: result.errorDetail })
+            return
+          }
 
-      this.fontList = result.data
+          this.fontList = result.data
+          this.fontListLoaded = true
+        } finally {
+          fontListInFlight = null
+        }
+      })()
+      return fontListInFlight
     },
     async saveConfiguration(): Promise<boolean> {
       const payload: models.Settings = {


### PR DESCRIPTION
## Problem

System font enumeration runs at app startup and is awaited in the init chain (`App.vue` `onMounted`), gating first render. `GetInstalledFonts` opens and parses **every** font file on disk (`os.Open` + `sfnt.ParseCollectionReaderAt` per file), so on systems with many fonts this is a real startup penalty.

## Confirmation it isn't needed for render

`fontList` is only consumed by the settings dialog dropdowns (`GeneralSettings`, `EditorSettings`, `MessagesSettings`). The applied UI font comes from `uiFont` → `general.font` (saved settings), **not** the enumerated list. UI renders correctly with an empty `fontList`.

## Change

- **`App.vue`** — fire `loadFontList()` in the background after init instead of awaiting it; no longer gates startup.
- **`settingsStore.ts`** — `loadFontList` idempotent via a `fontListLoaded` flag + `fontListInFlight` promise guard (no double enumeration on race).
- **`SettingsDialog.vue`** — load on open as a fallback (no-op once loaded), so dropdowns still populate if the background load failed or hasn't finished.

## Testing

- `bun run lint` clean
- `bun run test --run settingsStore` — 3 passed