### PR TITLE
fix(oidc): make copied connection string Compass-compatible

### DIFF
--- a/internal/servers/connection_string_builder.go
+++ b/internal/servers/connection_string_builder.go
@@ -6,11 +6,15 @@ import (
 )
 
 // buildOIDCURI returns rawURI with authMechanism=MONGODB-OIDC and
-// authMechanismProperties=ALLOWED_HOSTS:* injected into its query string.
-// Existing values for either parameter are preserved (idempotent).
+// authSource=$external injected into its query string. Existing values for
+// either parameter are preserved (idempotent). url.Values.Encode emits the
+// "$" of "$external" as "%24external".
 //
-// The defaults match what internal/clientregistry/registry.go applies at
-// connect time, so the returned URI is usable as-is in mongosh.
+// ALLOWED_HOSTS is deliberately NOT injected: it is a client-side-only OIDC
+// property that the MongoDB OIDC spec forbids in connection strings, and tools
+// such as Compass reject a URI that carries it. Vervet applies ALLOWED_HOSTS:*
+// programmatically at connect time (internal/clientregistry/registry.go), so
+// the copied URI works in external clients without it.
 func buildOIDCURI(rawURI string) (string, error) {
 	u, err := url.Parse(rawURI)
 	if err != nil {
@@ -21,8 +25,8 @@ func buildOIDCURI(rawURI string) (string, error) {
 	if q.Get("authMechanism") == "" {
 		q.Set("authMechanism", "MONGODB-OIDC")
 	}
-	if q.Get("authMechanismProperties") == "" {
-		q.Set("authMechanismProperties", "ALLOWED_HOSTS:*")
+	if q.Get("authSource") == "" {
+		q.Set("authSource", "$external")
 	}
 	u.RawQuery = q.Encode()
 	return u.String(), nil

--- a/internal/servers/connection_string_builder_test.go
+++ b/internal/servers/connection_string_builder_test.go
@@ -18,11 +18,24 @@ func TestBuildOIDCURI_AddsBothParamsWhenAbsent(t *testing.T) {
 	require.NoError(t, err)
 	q := u.Query()
 	assert.Equal(t, "MONGODB-OIDC", q.Get("authMechanism"))
-	assert.Equal(t, "ALLOWED_HOSTS:*", q.Get("authMechanismProperties"))
+	assert.Equal(t, "$external", q.Get("authSource"))
 	assert.Equal(t, "true", q.Get("retryWrites"))
 }
 
-func TestBuildOIDCURI_IdempotentWhenBothPresent(t *testing.T) {
+// ALLOWED_HOSTS is a client-side-only OIDC property that Compass rejects, so it
+// must never appear in the copied URI. authSource must be encoded as
+// %24external (Compass rejects a bare "$external").
+func TestBuildOIDCURI_OmitsAllowedHostsAndEncodesExternal(t *testing.T) {
+	in := "mongodb://example.com:27017/"
+	out, err := buildOIDCURI(in)
+	require.NoError(t, err)
+
+	assert.NotContains(t, out, "ALLOWED_HOSTS")
+	assert.NotContains(t, out, "authMechanismProperties")
+	assert.Contains(t, out, "authSource=%24external")
+}
+
+func TestBuildOIDCURI_PreservesUserMechProps(t *testing.T) {
 	in := "mongodb://example.com/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure"
 	out, err := buildOIDCURI(in)
 	require.NoError(t, err)
@@ -32,9 +45,20 @@ func TestBuildOIDCURI_IdempotentWhenBothPresent(t *testing.T) {
 	q := u.Query()
 	assert.Equal(t, "MONGODB-OIDC", q.Get("authMechanism"))
 	assert.Equal(t, "ENVIRONMENT:azure", q.Get("authMechanismProperties"))
+	assert.Equal(t, "$external", q.Get("authSource"))
 }
 
-func TestBuildOIDCURI_FillsPropertiesWhenMechanismPresent(t *testing.T) {
+func TestBuildOIDCURI_PreservesExistingAuthSource(t *testing.T) {
+	in := "mongodb://example.com/?authMechanism=MONGODB-OIDC&authSource=admin"
+	out, err := buildOIDCURI(in)
+	require.NoError(t, err)
+
+	u, err := url.Parse(out)
+	require.NoError(t, err)
+	assert.Equal(t, "admin", u.Query().Get("authSource"))
+}
+
+func TestBuildOIDCURI_FillsParamsWhenMechanismPresent(t *testing.T) {
 	in := "mongodb://example.com/?authMechanism=MONGODB-OIDC"
 	out, err := buildOIDCURI(in)
 	require.NoError(t, err)
@@ -43,7 +67,7 @@ func TestBuildOIDCURI_FillsPropertiesWhenMechanismPresent(t *testing.T) {
 	require.NoError(t, err)
 	q := u.Query()
 	assert.Equal(t, "MONGODB-OIDC", q.Get("authMechanism"))
-	assert.Equal(t, "ALLOWED_HOSTS:*", q.Get("authMechanismProperties"))
+	assert.Equal(t, "$external", q.Get("authSource"))
 }
 
 func TestBuildOIDCURI_PreservesUserInfoAndHostList(t *testing.T) {
@@ -59,7 +83,7 @@ func TestBuildOIDCURI_PreservesUserInfoAndHostList(t *testing.T) {
 	q := u.Query()
 	assert.Equal(t, "true", q.Get("ssl"))
 	assert.Equal(t, "MONGODB-OIDC", q.Get("authMechanism"))
-	assert.Equal(t, "ALLOWED_HOSTS:*", q.Get("authMechanismProperties"))
+	assert.Equal(t, "$external", q.Get("authSource"))
 }
 
 func TestBuildOIDCURI_SrvScheme(t *testing.T) {
@@ -72,7 +96,7 @@ func TestBuildOIDCURI_SrvScheme(t *testing.T) {
 	u, err := url.Parse(out)
 	require.NoError(t, err)
 	assert.Equal(t, "MONGODB-OIDC", u.Query().Get("authMechanism"))
-	assert.Equal(t, "ALLOWED_HOSTS:*", u.Query().Get("authMechanismProperties"))
+	assert.Equal(t, "$external", u.Query().Get("authSource"))
 }
 
 func TestBuildOIDCURI_ErrorOnUnparseable(t *testing.T) {

--- a/internal/servers/service_test.go
+++ b/internal/servers/service_test.go
@@ -410,7 +410,8 @@ func TestBuildFullConnectionString_OIDC_AddsParams(t *testing.T) {
 	u, err := url.Parse(got)
 	require.NoError(t, err)
 	assert.Equal(t, "MONGODB-OIDC", u.Query().Get("authMechanism"))
-	assert.Equal(t, "ALLOWED_HOSTS:*", u.Query().Get("authMechanismProperties"))
+	assert.Equal(t, "$external", u.Query().Get("authSource"))
+	assert.NotContains(t, got, "ALLOWED_HOSTS")
 }
 
 func TestBuildFullConnectionString_OIDC_PreservesUserParams(t *testing.T) {


### PR DESCRIPTION
## Problem

The OIDC URI produced by **Copy Connection String** doesn't work when pasted into MongoDB Compass:

1. It injects `authMechanismProperties=ALLOWED_HOSTS:*`. `ALLOWED_HOSTS` is a client-side-only OIDC property that the MongoDB OIDC spec forbids in connection strings; Compass rejects a URI carrying it.
2. It omits `authSource`. OIDC needs an explicit `authSource` of `$external`, encoded as `%24external` in the URI.

## Fix

`buildOIDCURI` now:
- **Drops `ALLOWED_HOSTS`** from the copied URI. Vervet still applies `ALLOWED_HOSTS:*` programmatically at connect time (`internal/clientregistry/registry.go`), so our own connections are unaffected.
- **Injects `authSource=$external`** (`url.Values.Encode` emits it as `%24external`).
- Preserves user-supplied `authMechanismProperties` (e.g. `ENVIRONMENT:azure`) and any existing `authSource`.

Example output:
```
mongodb://example.com:27017/?authMechanism=MONGODB-OIDC&authSource=%24external
```

## Tests

Updated `connection_string_builder_test.go` and `service_test.go`. Full `go test ./...` passes.