### PR TITLE
fix(layout): make root content fill window when maximized

### DIFF
--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -12,6 +12,8 @@
 html {
   //text-align: center;
   cursor: default;
+  height: 100%;
+  width: 100%;
   -webkit-user-select: none; /* Chrome, Safari */
   -moz-user-select: none; /* Firefox */
   user-select: none;
@@ -20,6 +22,8 @@ html {
 body {
   margin: 0;
   padding: 0;
+  height: 100%;
+  width: 100%;
   background-color: #0000;
   line-height: 1.5;
   font-family: v-sans, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
@@ -35,7 +39,8 @@ body {
 }
 
 #app {
-  height: 100vh;
+  height: 100%;
+  width: 100%;
 }
 
 .flex-box {


### PR DESCRIPTION
## Problem

When the window is maximized, the content does not resize, leaving white bars on the right and bottom. Dragging the window larger resizes correctly.

## Root cause

`#app` used `height: 100vh`. WebKit2GTK does not recalculate `vh`/viewport units when the window is maximized (it does on a manual drag-resize), so the content stayed at its pre-maximize size and the transparent body showed the window background as white bars.

## Fix

Anchor `html`, `body`, and `#app` to `height: 100%; width: 100%`. Percentage sizing follows the layout reflow against the actual containing block, which tracks the window size reliably across maximize.

## Verification

- `bun run lint` (eslint + vue-tsc) passes.
- Manual: run `wails dev`, maximize the window — content fills, no white bars.

Fixes #266