### PR TITLE
fix(oidc): skip browser login during shutdown

### DIFF
--- a/internal/oidc/token_manager.go
+++ b/internal/oidc/token_manager.go
@@ -21,6 +21,12 @@ import (
 // benign user action, not an error to surface as a failure notification.
 var ErrLoginCanceled = errors.New("OIDC login canceled by user")
 
+// ErrShuttingDown is returned by the OIDC human callback when the application
+// is shutting down. The MongoDB driver invokes the callback during
+// disconnect-time re-authentication; without this guard a dead OIDC
+// connection would pop a browser login while Vervet is closing.
+var ErrShuttingDown = errors.New("OIDC login skipped: application shutting down")
+
 type CachedToken struct {
 	AccessToken  string
 	RefreshToken string
@@ -40,6 +46,7 @@ type TokenManager struct {
 	browserMu    sync.Mutex
 	activeServer *activeCallbackServer
 	canceled     bool
+	shuttingDown bool
 
 	promptMu         sync.Mutex
 	forcePromptOnce  map[string]string
@@ -146,7 +153,16 @@ func (tm *TokenManager) CleanupServer(serverID string) {
 // Shutdown cancels any in-flight browser login and releases its listener.
 // Call this on application exit.
 func (tm *TokenManager) Shutdown() {
+	tm.browserMu.Lock()
+	tm.shuttingDown = true
+	tm.browserMu.Unlock()
 	tm.closeBrowserServer()
+}
+
+func (tm *TokenManager) isShuttingDown() bool {
+	tm.browserMu.Lock()
+	defer tm.browserMu.Unlock()
+	return tm.shuttingDown
 }
 
 // HumanCallback returns the OIDCHumanCallback for the given server.
@@ -184,6 +200,13 @@ func (tm *TokenManager) HumanCallback(serverID string, cfg *models.OIDCConfig) o
 				tm.log.Warn("Token refresh failed, falling back to browser login",
 					slog.String("serverID", serverID), slog.Any("error", refreshErr))
 			}
+		}
+
+		// Don't pop an interactive browser login while the app is closing.
+		// The driver invokes this callback during disconnect-time re-auth; a
+		// dead OIDC connection would otherwise launch a browser on exit.
+		if tm.isShuttingDown() {
+			return nil, ErrShuttingDown
 		}
 
 		// 3. Browser login — resolve provider info from server or user config

--- a/internal/oidc/token_manager_test.go
+++ b/internal/oidc/token_manager_test.go
@@ -1,12 +1,34 @@
 package oidc
 
 import (
+	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"net/http"
 	"testing"
 	"time"
+
+	"vervet/internal/models"
+
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
+
+// stubStore is a minimal connectionStrings.Store for OIDC callback tests.
+type stubStore struct {
+	cfg models.ConnectionConfig
+}
+
+func (s *stubStore) StoreRegisteredServerURI(string, string) error { return nil }
+func (s *stubStore) GetRegisteredServerURI(string) (string, error) { return "", nil }
+func (s *stubStore) DeleteRegisteredServerURI(string) error        { return nil }
+func (s *stubStore) StoreConnectionConfig(string, models.ConnectionConfig) error {
+	return nil
+}
+func (s *stubStore) GetConnectionConfig(string) (models.ConnectionConfig, error) {
+	return s.cfg, nil
+}
+func (s *stubStore) UpdateRefreshToken(string, string) error { return nil }
 
 func TestGetCachedToken_ReturnsCachedToken(t *testing.T) {
 	tm := NewTokenManager(slog.Default(), nil)
@@ -105,4 +127,34 @@ func TestCloseBrowserServer_AllowsRetry(t *testing.T) {
 		t.Fatalf("port still bound after closeBrowserServer: %v", err)
 	}
 	listener2.Close()
+}
+
+// After Shutdown, the OIDC human callback must not start an interactive
+// browser login. Otherwise closing Vervet while an OIDC connection is dead
+// (no valid cached token, refresh unavailable) triggers the driver's
+// disconnect-time re-auth, popping a login browser during app exit.
+func TestHumanCallback_DoesNotLaunchBrowserAfterShutdown(t *testing.T) {
+	store := &stubStore{cfg: models.ConnectionConfig{AuthMethod: models.AuthOIDC}}
+	tm := NewTokenManager(slog.Default(), store)
+	tm.Init(context.Background())
+
+	browserOpened := false
+	tm.SetOpenBrowser(func(string) { browserOpened = true })
+
+	tm.Shutdown()
+
+	cb := tm.HumanCallback("server-1", &models.OIDCConfig{})
+	_, err := cb(context.Background(), &options.OIDCArgs{
+		IDPInfo: &options.IDPInfo{
+			Issuer:   "https://idp.example.com",
+			ClientID: "client-1",
+		},
+	})
+
+	if !errors.Is(err, ErrShuttingDown) {
+		t.Fatalf("expected ErrShuttingDown, got %v", err)
+	}
+	if browserOpened {
+		t.Fatal("browser login was launched during shutdown")
+	}
 }


### PR DESCRIPTION
## Problem

When Vervet closes with a dead OIDC connection (e.g. network card disconnected), it pops a browser login window during shutdown.

## Root cause

On exit, `Shutdown()` → `connectionManager.DisconnectAll()` → `client.Disconnect()` per client. The MongoDB driver runs disconnect-time cleanup (`endSessions` / pool drain), which forces a fresh OIDC handshake on a dead connection → invokes `HumanCallback`. With an expired cached token and a failed/unavailable refresh, the callback falls through to step 3 (`browserLogin`) and launches an interactive browser during app close.

`tm.Shutdown()` only closed the *current* in-flight browser server; the disconnect-triggered callback then started a *new* one with nothing to stop it.

## Fix

- Add `ErrShuttingDown` sentinel.
- Set a `shuttingDown` flag in `Shutdown()` (guarded by `browserMu`).
- `HumanCallback` returns `ErrShuttingDown` before initiating browser login when shutting down. Cached-token and refresh paths are untouched, so a clean disconnect still works when the token is valid.

## Test

`TestHumanCallback_DoesNotLaunchBrowserAfterShutdown` — after `Shutdown()`, the callback returns `ErrShuttingDown` and the browser spy never fires. Full `go test ./...` passes.