### PR TITLE
refactor: migrate to mongo-driver v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible // indirect
-	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
@@ -58,7 +57,6 @@ require (
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/moby/term v0.5.2 // indirect
-	github.com/montanaflynn/stats v0.9.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -104,7 +102,6 @@ require (
 	github.com/wailsapp/go-webview2 v1.0.23 // indirect
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	github.com/zalando/go-keyring v0.2.8
-	go.mongodb.org/mongo-driver v1.17.9
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/go-sourcemap/sourcemap v2.1.4+incompatible h1:a+iTbH5auLKxaNwQFg0B+TC
 github.com/go-sourcemap/sourcemap v2.1.4+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
-github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
-github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
@@ -131,8 +129,6 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/montanaflynn/stats v0.9.0 h1:tsBJ0RXwph9BmAuFoCmqGv6e8xa0MENQ8m0ptKq29mQ=
-github.com/montanaflynn/stats v0.9.0/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
@@ -193,8 +189,6 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
-go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=
-go.mongodb.org/mongo-driver v1.17.9/go.mod h1:LlOhpH5NUEfhxcAwG0UEkMqwYcc4JU18gtCdGudk/tQ=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/clientregistry/registry.go
+++ b/internal/clientregistry/registry.go
@@ -10,9 +10,9 @@ import (
 	"vervet/internal/models"
 	"vervet/internal/oidc"
 
-	"go.mongodb.org/mongo-driver/event"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/event"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 type registeredClient struct {
@@ -69,7 +69,7 @@ func (r *ClientRegistry) Connect(serverID, name, uri string) (*mongo.Client, err
 	ctx, cancel := context.WithTimeout(r.ctx, 10*time.Second)
 	defer cancel()
 
-	client, err := mongo.Connect(ctx, clientOptions)
+	client, err := mongo.Connect(clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
@@ -137,7 +137,7 @@ func (r *ClientRegistry) ConnectWithConfig(serverID, name string, cfg models.Con
 	ctx, cancel := context.WithTimeout(r.ctx, connectTimeout)
 	defer cancel()
 
-	client, err := mongo.Connect(ctx, clientOptions)
+	client, err := mongo.Connect(clientOptions)
 	if err != nil {
 		if cfg.AuthMethod == models.AuthOIDC {
 			r.tokenManager.CleanupServer(serverID)

--- a/internal/collections/service.go
+++ b/internal/collections/service.go
@@ -11,8 +11,8 @@ import (
 	"vervet/internal/models"
 	"vervet/internal/schema"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 const operationTimeout = 30 * time.Second

--- a/internal/connections/manager.go
+++ b/internal/connections/manager.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 const (
@@ -93,7 +93,7 @@ func (cm *ConnectionManager) TestConnection(uri string) (bool, error) {
 	ctx, cancel := context.WithTimeout(cm.ctx, 30*time.Second)
 	defer cancel()
 
-	client, err := mongo.Connect(ctx, clientOptions)
+	client, err := mongo.Connect(clientOptions)
 	if err != nil {
 		return false, fmt.Errorf("failed to connect to database: %w", err)
 	}
@@ -122,7 +122,7 @@ func (cm *ConnectionManager) TestConnectionWithConfig(ctx context.Context, cfg m
 	connectCtx, connectCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer connectCancel()
 
-	client, err := mongo.Connect(connectCtx, clientOptions)
+	client, err := mongo.Connect(clientOptions)
 	if err != nil {
 		return false, fmt.Errorf("failed to connect to database: %w", err)
 	}

--- a/internal/databases/service.go
+++ b/internal/databases/service.go
@@ -9,8 +9,8 @@ import (
 	"time"
 	"vervet/internal/logging"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 const operationTimeout = 30 * time.Second

--- a/internal/errcodes/classify.go
+++ b/internal/errcodes/classify.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strings"
 
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"vervet/internal/oidc"
 	"vervet/internal/servers"

--- a/internal/errcodes/classify_test.go
+++ b/internal/errcodes/classify_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"vervet/internal/errcodes"
 	"vervet/internal/shell"

--- a/internal/export/csv.go
+++ b/internal/export/csv.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/csv"
 
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func serializeCSV(docs []bson.M, columns []string, opts CSVOptions) ([]byte, error) {

--- a/internal/export/csv_test.go
+++ b/internal/export/csv_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func serializeCSVHelper(t *testing.T, docs []bson.M, opts CSVOptions) string {

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -3,7 +3,7 @@ package export
 import (
 	"fmt"
 
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func Serialize(docs []bson.M, opts Options) ([]byte, error) {

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func TestSerialize_UnknownFormat(t *testing.T) {

--- a/internal/export/flatten.go
+++ b/internal/export/flatten.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 type flatPair struct {

--- a/internal/export/flatten_test.go
+++ b/internal/export/flatten_test.go
@@ -5,8 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func TestFlattenDoc_Scalars(t *testing.T) {
@@ -52,7 +51,7 @@ func TestFlattenDoc_ArraysOfObjectsStayAsEJSONString(t *testing.T) {
 }
 
 func TestFlattenDoc_ObjectIDSerializedAsExtJSON(t *testing.T) {
-	oid := primitive.NewObjectID()
+	oid := bson.NewObjectID()
 	doc := bson.M{"_id": oid}
 	pairs, err := flattenDoc(doc)
 	require.NoError(t, err)

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // serializeJSONImpl renders docs as a pretty-printed Extended JSON array.

--- a/internal/export/json_test.go
+++ b/internal/export/json_test.go
@@ -6,8 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func TestSerializeJSON_BasicDocs(t *testing.T) {
@@ -27,7 +26,7 @@ func TestSerializeJSON_BasicDocs(t *testing.T) {
 }
 
 func TestSerializeJSON_PreservesBSONTypesAsExtJSON(t *testing.T) {
-	oid := primitive.NewObjectID()
+	oid := bson.NewObjectID()
 	docs := []bson.M{{"_id": oid, "value": "x"}}
 
 	out, err := Serialize(docs, Options{Format: FormatJSON})

--- a/internal/export/ndjson.go
+++ b/internal/export/ndjson.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func serializeNDJSON(docs []bson.M) ([]byte, error) {

--- a/internal/export/ndjson_test.go
+++ b/internal/export/ndjson_test.go
@@ -6,8 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func TestSerializeNDJSON_OneLinePerDoc(t *testing.T) {
@@ -35,7 +34,7 @@ func TestSerializeNDJSON_EmptyDocsYieldsEmptyBytes(t *testing.T) {
 }
 
 func TestSerializeNDJSON_PreservesBSONTypes(t *testing.T) {
-	oid := primitive.NewObjectID()
+	oid := bson.NewObjectID()
 	out, err := Serialize([]bson.M{{"_id": oid}}, Options{Format: FormatNDJSON})
 	require.NoError(t, err)
 	assert.Contains(t, string(out), `"$oid"`)

--- a/internal/export/service.go
+++ b/internal/export/service.go
@@ -9,7 +9,7 @@ import (
 
 	"vervet/internal/api"
 
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // FileFilter describes a file type filter for the save dialog.

--- a/internal/indexes/service.go
+++ b/internal/indexes/service.go
@@ -8,9 +8,9 @@ import (
 	"vervet/internal/logging"
 	"vervet/internal/models"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // ClientProvider provides access to active MongoDB connections
@@ -162,7 +162,7 @@ func (s *IndexService) EditIndex(serverID, dbName, collectionName string, reques
 		// Same name — must drop first to avoid name conflict
 		oldSpec, captureErr := s.captureIndex(collection, request.OldName)
 
-		_, err = collection.Indexes().DropOne(s.ctx, request.OldName)
+		err = collection.Indexes().DropOne(s.ctx, request.OldName)
 		if err != nil {
 			return fmt.Errorf("failed to drop old index: %w", err)
 		}
@@ -182,7 +182,7 @@ func (s *IndexService) EditIndex(serverID, dbName, collectionName string, reques
 			return fmt.Errorf("failed to create new index: %w", err)
 		}
 
-		_, err = collection.Indexes().DropOne(s.ctx, request.OldName)
+		err = collection.Indexes().DropOne(s.ctx, request.OldName)
 		if err != nil {
 			return fmt.Errorf("new index created but failed to drop old index %q: %w", request.OldName, err)
 		}
@@ -198,7 +198,7 @@ func (s *IndexService) DropIndex(serverID, dbName, collectionName, indexName str
 	}
 
 	collection := client.Database(dbName).Collection(collectionName)
-	_, err = collection.Indexes().DropOne(s.ctx, indexName)
+	err = collection.Indexes().DropOne(s.ctx, indexName)
 	if err != nil {
 		return fmt.Errorf("failed to drop index: %w", err)
 	}

--- a/internal/oidc/token_manager.go
+++ b/internal/oidc/token_manager.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	gooidc "github.com/coreos/go-oidc/v3/oidc"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"golang.org/x/oauth2"
 
 	"vervet/internal/connectionStrings"
@@ -37,10 +37,10 @@ type TokenManager struct {
 	ctx         context.Context
 	log         *slog.Logger
 	store       connectionStrings.Store
-	mu           sync.RWMutex
-	cache        map[string]*CachedToken
-	openBrowser  func(url string)
-	emitAuthURL  func(serverID, url string)
+	mu          sync.RWMutex
+	cache       map[string]*CachedToken
+	openBrowser func(url string)
+	emitAuthURL func(serverID, url string)
 
 	// browserMu protects activeServer — the in-flight OIDC callback HTTP server.
 	browserMu    sync.Mutex
@@ -48,8 +48,8 @@ type TokenManager struct {
 	canceled     bool
 	shuttingDown bool
 
-	promptMu         sync.Mutex
-	forcePromptOnce  map[string]string
+	promptMu        sync.Mutex
+	forcePromptOnce map[string]string
 }
 
 func NewTokenManager(log *slog.Logger, store connectionStrings.Store) *TokenManager {

--- a/internal/oidc/token_manager_test.go
+++ b/internal/oidc/token_manager_test.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -156,5 +157,77 @@ func TestHumanCallback_DoesNotLaunchBrowserAfterShutdown(t *testing.T) {
 	}
 	if browserOpened {
 		t.Fatal("browser login was launched during shutdown")
+	}
+}
+
+func newTestManager() *TokenManager {
+	// Discard logger keeps test output pristine; store is unused on the paths
+	// under test (cached-token, resolveIDPInfo, resolveScopes, MachineCallback).
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewTokenManager(log, nil)
+}
+
+func TestHumanCallback_ReturnsCachedToken(t *testing.T) {
+	tm := newTestManager()
+	exp := time.Now().Add(time.Hour)
+	tm.cacheToken("srv1", &CachedToken{AccessToken: "cached-abc", ExpiresAt: exp})
+
+	cb := tm.HumanCallback("srv1", &models.OIDCConfig{})
+	cred, err := cb(context.Background(), &options.OIDCArgs{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cred.AccessToken != "cached-abc" {
+		t.Errorf("AccessToken = %q, want %q", cred.AccessToken, "cached-abc")
+	}
+	if cred.ExpiresAt == nil || !cred.ExpiresAt.Equal(exp) {
+		t.Errorf("ExpiresAt = %v, want %v", cred.ExpiresAt, exp)
+	}
+}
+
+func TestResolveIDPInfo_ConfigOverridesServer(t *testing.T) {
+	tm := newTestManager()
+	idp := &options.IDPInfo{Issuer: "https://server-issuer", ClientID: "server-cid"}
+
+	// No config override → server values win.
+	url, cid := tm.resolveIDPInfo(idp, &models.OIDCConfig{})
+	if url != "https://server-issuer" || cid != "server-cid" {
+		t.Errorf("got (%q,%q), want server values", url, cid)
+	}
+
+	// Config set → config wins.
+	url, cid = tm.resolveIDPInfo(idp, &models.OIDCConfig{ProviderURL: "https://cfg-issuer", ClientID: "cfg-cid"})
+	if url != "https://cfg-issuer" || cid != "cfg-cid" {
+		t.Errorf("got (%q,%q), want config values", url, cid)
+	}
+}
+
+func TestResolveScopes_Precedence(t *testing.T) {
+	tm := newTestManager()
+
+	// Config scopes win.
+	got := tm.resolveScopes(&options.IDPInfo{RequestScopes: []string{"srv"}}, &models.OIDCConfig{Scopes: []string{"cfg"}})
+	if len(got) != 1 || got[0] != "cfg" {
+		t.Errorf("got %v, want [cfg]", got)
+	}
+
+	// Else server-requested scopes.
+	got = tm.resolveScopes(&options.IDPInfo{RequestScopes: []string{"srv"}}, &models.OIDCConfig{})
+	if len(got) != 1 || got[0] != "srv" {
+		t.Errorf("got %v, want [srv]", got)
+	}
+
+	// Else default openid.
+	got = tm.resolveScopes(nil, nil)
+	if len(got) != 1 || got[0] != "openid" {
+		t.Errorf("got %v, want [openid]", got)
+	}
+}
+
+func TestMachineCallback_NotImplemented(t *testing.T) {
+	tm := newTestManager()
+	cb := tm.MachineCallback("srv1")
+	if _, err := cb(context.Background(), &options.OIDCArgs{}); err == nil {
+		t.Fatal("expected not-implemented error, got nil")
 	}
 }

--- a/internal/oidc/token_manager_test.go
+++ b/internal/oidc/token_manager_test.go
@@ -12,7 +12,7 @@ import (
 
 	"vervet/internal/models"
 
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // stubStore is a minimal connectionStrings.Store for OIDC callback tests.

--- a/internal/queryengine/bson_integration_test.go
+++ b/internal/queryengine/bson_integration_test.go
@@ -14,10 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mongodb"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 var (
@@ -48,7 +47,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("failed to get connection string: %v", err)
 	}
 
-	testClient, err = mongo.Connect(ctx, options.Client().ApplyURI(testURI))
+	testClient, err = mongo.Connect(options.Client().ApplyURI(testURI))
 	if err != nil {
 		log.Fatalf("failed to connect to MongoDB: %v", err)
 	}
@@ -107,29 +106,29 @@ func TestIntegration_Issue124_InsertOneWithUUID(t *testing.T) {
 	err = testClient.Database(db).Collection("test-collection").FindOne(ctx, bson.M{}).Decode(&doc)
 	require.NoError(t, err)
 
-	bin, ok := doc["_id"].(primitive.Binary)
-	require.True(t, ok, "expected _id to be primitive.Binary, got %T", doc["_id"])
+	bin, ok := doc["_id"].(bson.Binary)
+	require.True(t, ok, "expected _id to be bson.Binary, got %T", doc["_id"])
 	assert.Equal(t, byte(0x04), bin.Subtype)
 	assert.Len(t, bin.Data, 16)
 	assert.Equal(t, "CustomerOnly", doc["CheckType"])
 	assert.Nil(t, doc["ContactId"])
-	assert.IsType(t, primitive.DateTime(0), doc["CreatedAt"])
+	assert.IsType(t, bson.DateTime(0), doc["CreatedAt"])
 }
 
 // --- BSON type constructor tests ---
 
 func TestIntegration_UUID_NoArgs_GeneratesRandomUUID(t *testing.T) {
 	doc := insertAndReadBack(t, `db.test.insertOne({ _id: UUID() })`)
-	bin, ok := doc["_id"].(primitive.Binary)
-	require.True(t, ok, "expected primitive.Binary, got %T", doc["_id"])
+	bin, ok := doc["_id"].(bson.Binary)
+	require.True(t, ok, "expected bson.Binary, got %T", doc["_id"])
 	assert.Equal(t, byte(0x04), bin.Subtype)
 	assert.Len(t, bin.Data, 16)
 }
 
 func TestIntegration_UUID_WithString_StoresCorrectBytes(t *testing.T) {
 	doc := insertAndReadBack(t, `db.test.insertOne({ _id: UUID("550e8400-e29b-41d4-a716-446655440000") })`)
-	bin, ok := doc["_id"].(primitive.Binary)
-	require.True(t, ok, "expected primitive.Binary, got %T", doc["_id"])
+	bin, ok := doc["_id"].(bson.Binary)
+	require.True(t, ok, "expected bson.Binary, got %T", doc["_id"])
 	assert.Equal(t, byte(0x04), bin.Subtype)
 	assert.Equal(t, "550e8400e29b41d4a716446655440000",
 		fmt.Sprintf("%x", bin.Data))
@@ -137,27 +136,27 @@ func TestIntegration_UUID_WithString_StoresCorrectBytes(t *testing.T) {
 
 func TestIntegration_ObjectId_NoArgs(t *testing.T) {
 	doc := insertAndReadBack(t, `db.test.insertOne({ _id: ObjectId() })`)
-	_, ok := doc["_id"].(primitive.ObjectID)
-	assert.True(t, ok, "expected primitive.ObjectID, got %T", doc["_id"])
+	_, ok := doc["_id"].(bson.ObjectID)
+	assert.True(t, ok, "expected bson.ObjectID, got %T", doc["_id"])
 }
 
 func TestIntegration_ObjectId_WithHex(t *testing.T) {
 	doc := insertAndReadBack(t, `db.test.insertOne({ _id: ObjectId("507f1f77bcf86cd799439011") })`)
-	oid, ok := doc["_id"].(primitive.ObjectID)
-	require.True(t, ok, "expected primitive.ObjectID, got %T", doc["_id"])
+	oid, ok := doc["_id"].(bson.ObjectID)
+	require.True(t, ok, "expected bson.ObjectID, got %T", doc["_id"])
 	assert.Equal(t, "507f1f77bcf86cd799439011", oid.Hex())
 }
 
 func TestIntegration_ISODate_NoArgs(t *testing.T) {
 	doc := insertAndReadBack(t, `db.test.insertOne({ ts: ISODate() })`)
-	_, ok := doc["ts"].(primitive.DateTime)
-	assert.True(t, ok, "expected primitive.DateTime, got %T", doc["ts"])
+	_, ok := doc["ts"].(bson.DateTime)
+	assert.True(t, ok, "expected bson.DateTime, got %T", doc["ts"])
 }
 
 func TestIntegration_ISODate_WithString(t *testing.T) {
 	doc := insertAndReadBack(t, `db.test.insertOne({ ts: ISODate("2024-06-15T12:00:00Z") })`)
-	dt, ok := doc["ts"].(primitive.DateTime)
-	require.True(t, ok, "expected primitive.DateTime, got %T", doc["ts"])
+	dt, ok := doc["ts"].(bson.DateTime)
+	require.True(t, ok, "expected bson.DateTime, got %T", doc["ts"])
 	expected := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
 	assert.Equal(t, expected.UnixMilli(), int64(dt))
 }
@@ -178,34 +177,34 @@ func TestIntegration_NumberLong(t *testing.T) {
 
 func TestIntegration_NumberDecimal(t *testing.T) {
 	doc := insertAndReadBack(t, `db.test.insertOne({ val: NumberDecimal("123.456") })`)
-	_, ok := doc["val"].(primitive.Decimal128)
-	assert.True(t, ok, "expected primitive.Decimal128, got %T", doc["val"])
+	_, ok := doc["val"].(bson.Decimal128)
+	assert.True(t, ok, "expected bson.Decimal128, got %T", doc["val"])
 }
 
 func TestIntegration_Timestamp(t *testing.T) {
 	doc := insertAndReadBack(t, `db.test.insertOne({ ts: Timestamp(1700000000, 1) })`)
-	ts, ok := doc["ts"].(primitive.Timestamp)
-	require.True(t, ok, "expected primitive.Timestamp, got %T", doc["ts"])
+	ts, ok := doc["ts"].(bson.Timestamp)
+	require.True(t, ok, "expected bson.Timestamp, got %T", doc["ts"])
 	assert.Equal(t, uint32(1700000000), ts.T)
 	assert.Equal(t, uint32(1), ts.I)
 }
 
 func TestIntegration_MinKey(t *testing.T) {
 	doc := insertAndReadBack(t, `db.test.insertOne({ val: MinKey() })`)
-	_, ok := doc["val"].(primitive.MinKey)
-	assert.True(t, ok, "expected primitive.MinKey, got %T", doc["val"])
+	_, ok := doc["val"].(bson.MinKey)
+	assert.True(t, ok, "expected bson.MinKey, got %T", doc["val"])
 }
 
 func TestIntegration_MaxKey(t *testing.T) {
 	doc := insertAndReadBack(t, `db.test.insertOne({ val: MaxKey() })`)
-	_, ok := doc["val"].(primitive.MaxKey)
-	assert.True(t, ok, "expected primitive.MaxKey, got %T", doc["val"])
+	_, ok := doc["val"].(bson.MaxKey)
+	assert.True(t, ok, "expected bson.MaxKey, got %T", doc["val"])
 }
 
 func TestIntegration_BinData(t *testing.T) {
 	doc := insertAndReadBack(t, `db.test.insertOne({ data: BinData(0, "aGVsbG8=") })`)
-	bin, ok := doc["data"].(primitive.Binary)
-	require.True(t, ok, "expected primitive.Binary, got %T", doc["data"])
+	bin, ok := doc["data"].(bson.Binary)
+	require.True(t, ok, "expected bson.Binary, got %T", doc["data"])
 	assert.Equal(t, byte(0x00), bin.Subtype)
 	assert.Equal(t, []byte("hello"), bin.Data)
 }

--- a/internal/queryengine/bson_types.go
+++ b/internal/queryengine/bson_types.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/google/uuid"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // registerBSONTypes registers mongosh-compatible BSON type constructors as globals
@@ -40,15 +40,15 @@ func registerBSONTypes(rt *goja.Runtime) error {
 	return nil
 }
 
-// bsonObjectId returns a function that creates a primitive.ObjectID.
+// bsonObjectId returns a function that creates a bson.ObjectID.
 // Usage: ObjectId() — new random ID, or ObjectId("hex") — from hex string.
 func bsonObjectId(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 || goja.IsUndefined(call.Arguments[0]) {
-			return wrapBSONValue(rt, primitive.NewObjectID())
+			return wrapBSONValue(rt, bson.NewObjectID())
 		}
 		hex := call.Arguments[0].String()
-		oid, err := primitive.ObjectIDFromHex(hex)
+		oid, err := bson.ObjectIDFromHex(hex)
 		if err != nil {
 			panic(rt.NewGoError(fmt.Errorf("ObjectId: %w", err)))
 		}
@@ -56,12 +56,12 @@ func bsonObjectId(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	}
 }
 
-// bsonISODate returns a function that creates a primitive.DateTime.
+// bsonISODate returns a function that creates a bson.DateTime.
 // Usage: ISODate() — now, or ISODate("2024-01-15T00:00:00Z") — from ISO string.
 func bsonISODate(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 || goja.IsUndefined(call.Arguments[0]) {
-			return wrapBSONValue(rt, primitive.NewDateTimeFromTime(time.Now()))
+			return wrapBSONValue(rt, bson.NewDateTimeFromTime(time.Now()))
 		}
 		str := call.Arguments[0].String()
 		t, err := time.Parse(time.RFC3339, str)
@@ -76,7 +76,7 @@ func bsonISODate(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 				}
 			}
 		}
-		return wrapBSONValue(rt, primitive.NewDateTimeFromTime(t))
+		return wrapBSONValue(rt, bson.NewDateTimeFromTime(t))
 	}
 }
 
@@ -181,7 +181,7 @@ func wrapBSONValue(rt *goja.Runtime, val any) goja.Value {
 	return obj
 }
 
-// bsonNumberDecimal returns a function that creates a primitive.Decimal128.
+// bsonNumberDecimal returns a function that creates a bson.Decimal128.
 // Usage: NumberDecimal("123.456").
 func bsonNumberDecimal(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(call goja.FunctionCall) goja.Value {
@@ -189,7 +189,7 @@ func bsonNumberDecimal(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 			panic(rt.NewGoError(fmt.Errorf("NumberDecimal requires a string argument")))
 		}
 		str := call.Arguments[0].String()
-		d, err := primitive.ParseDecimal128(str)
+		d, err := bson.ParseDecimal128(str)
 		if err != nil {
 			panic(rt.NewGoError(fmt.Errorf("NumberDecimal: %w", err)))
 		}
@@ -197,13 +197,13 @@ func bsonNumberDecimal(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	}
 }
 
-// bsonUUID returns a function that creates a primitive.Binary with subtype 4.
+// bsonUUID returns a function that creates a bson.Binary with subtype 4.
 // Usage: UUID() for a random UUID, or UUID("550e8400-e29b-41d4-a716-446655440000") for a specific one.
 func bsonUUID(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			id := uuid.New()
-			return wrapBSONValue(rt, primitive.Binary{Subtype: 0x04, Data: id[:]})
+			return wrapBSONValue(rt, bson.Binary{Subtype: 0x04, Data: id[:]})
 		}
 		str := call.Arguments[0].String()
 		// Strip hyphens from UUID string
@@ -220,11 +220,11 @@ func bsonUUID(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 		if len(data) != 16 {
 			panic(rt.NewGoError(fmt.Errorf("UUID: must be 16 bytes, got %d", len(data))))
 		}
-		return wrapBSONValue(rt, primitive.Binary{Subtype: 0x04, Data: data})
+		return wrapBSONValue(rt, bson.Binary{Subtype: 0x04, Data: data})
 	}
 }
 
-// bsonTimestamp returns a function that creates a primitive.Timestamp.
+// bsonTimestamp returns a function that creates a bson.Timestamp.
 // Supports three forms:
 //   - Timestamp(t, i)          — positional: seconds since epoch + increment
 //   - Timestamp({t: <int>, i: <int>}) — object form (mongosh style), both fields optional
@@ -232,7 +232,7 @@ func bsonUUID(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 func bsonTimestamp(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 || goja.IsUndefined(call.Arguments[0]) {
-			return wrapBSONValue(rt, primitive.Timestamp{
+			return wrapBSONValue(rt, bson.Timestamp{
 				T: uint32(time.Now().Unix()),
 				I: 1,
 			})
@@ -261,7 +261,7 @@ func bsonTimestamp(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 					i = uint32(n)
 				}
 			}
-			return wrapBSONValue(rt, primitive.Timestamp{T: t, I: i})
+			return wrapBSONValue(rt, bson.Timestamp{T: t, I: i})
 		}
 
 		// Positional form: Timestamp(t, i)
@@ -270,27 +270,27 @@ func bsonTimestamp(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 		}
 		t := uint32(call.Arguments[0].ToInteger())
 		i := uint32(call.Arguments[1].ToInteger())
-		return wrapBSONValue(rt, primitive.Timestamp{T: t, I: i})
+		return wrapBSONValue(rt, bson.Timestamp{T: t, I: i})
 	}
 }
 
-// bsonMinKey returns a function that creates a primitive.MinKey.
+// bsonMinKey returns a function that creates a bson.MinKey.
 // Usage: MinKey()
 func bsonMinKey(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(call goja.FunctionCall) goja.Value {
-		return wrapBSONValue(rt, primitive.MinKey{})
+		return wrapBSONValue(rt, bson.MinKey{})
 	}
 }
 
-// bsonMaxKey returns a function that creates a primitive.MaxKey.
+// bsonMaxKey returns a function that creates a bson.MaxKey.
 // Usage: MaxKey()
 func bsonMaxKey(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(call goja.FunctionCall) goja.Value {
-		return wrapBSONValue(rt, primitive.MaxKey{})
+		return wrapBSONValue(rt, bson.MaxKey{})
 	}
 }
 
-// bsonBinData returns a function that creates a primitive.Binary.
+// bsonBinData returns a function that creates a bson.Binary.
 // Usage: BinData(subtype, base64String).
 func bsonBinData(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(call goja.FunctionCall) goja.Value {
@@ -304,6 +304,6 @@ func bsonBinData(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 		if err != nil {
 			panic(rt.NewGoError(fmt.Errorf("BinData: %w", err)))
 		}
-		return wrapBSONValue(rt, primitive.Binary{Subtype: subtype, Data: data})
+		return wrapBSONValue(rt, bson.Binary{Subtype: subtype, Data: data})
 	}
 }

--- a/internal/queryengine/bson_types_test.go
+++ b/internal/queryengine/bson_types_test.go
@@ -6,8 +6,7 @@ import (
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func setupRuntimeWithBSON(t *testing.T) *goja.Runtime {
@@ -37,8 +36,8 @@ func TestObjectId_NoArgs_ReturnsNewObjectID(t *testing.T) {
 	val, err := rt.RunString(`ObjectId()`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	_, ok := bsonVal.(primitive.ObjectID)
-	assert.True(t, ok, "expected primitive.ObjectID, got %T", bsonVal)
+	_, ok := bsonVal.(bson.ObjectID)
+	assert.True(t, ok, "expected bson.ObjectID, got %T", bsonVal)
 }
 
 func TestObjectId_WithHex_ReturnsCorrectID(t *testing.T) {
@@ -46,7 +45,7 @@ func TestObjectId_WithHex_ReturnsCorrectID(t *testing.T) {
 	val, err := rt.RunString(`ObjectId("507f1f77bcf86cd799439011")`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	oid, ok := bsonVal.(primitive.ObjectID)
+	oid, ok := bsonVal.(bson.ObjectID)
 	require.True(t, ok)
 	assert.Equal(t, "507f1f77bcf86cd799439011", oid.Hex())
 }
@@ -62,8 +61,8 @@ func TestISODate_NoArgs_ReturnsNow(t *testing.T) {
 	val, err := rt.RunString(`ISODate()`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	_, ok := bsonVal.(primitive.DateTime)
-	assert.True(t, ok, "expected primitive.DateTime, got %T", bsonVal)
+	_, ok := bsonVal.(bson.DateTime)
+	assert.True(t, ok, "expected bson.DateTime, got %T", bsonVal)
 }
 
 func TestISODate_WithRFC3339_ReturnsCorrectDate(t *testing.T) {
@@ -71,7 +70,7 @@ func TestISODate_WithRFC3339_ReturnsCorrectDate(t *testing.T) {
 	val, err := rt.RunString(`ISODate("2024-01-15T10:30:00Z")`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	dt, ok := bsonVal.(primitive.DateTime)
+	dt, ok := bsonVal.(bson.DateTime)
 	require.True(t, ok)
 	tm := dt.Time()
 	assert.Equal(t, 2024, tm.Year())
@@ -84,7 +83,7 @@ func TestISODate_DateOnly_Works(t *testing.T) {
 	val, err := rt.RunString(`ISODate("2024-01-15")`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	dt, ok := bsonVal.(primitive.DateTime)
+	dt, ok := bsonVal.(bson.DateTime)
 	require.True(t, ok)
 	assert.Equal(t, 2024, dt.Time().Year())
 }
@@ -148,8 +147,8 @@ func TestNumberDecimal_Valid_ReturnsDecimal128(t *testing.T) {
 	val, err := rt.RunString(`NumberDecimal("123.456")`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	_, ok := bsonVal.(primitive.Decimal128)
-	assert.True(t, ok, "expected primitive.Decimal128, got %T", bsonVal)
+	_, ok := bsonVal.(bson.Decimal128)
+	assert.True(t, ok, "expected bson.Decimal128, got %T", bsonVal)
 }
 
 func TestNumberDecimal_NoArgs_Panics(t *testing.T) {
@@ -163,7 +162,7 @@ func TestUUID_Valid_ReturnsBinary(t *testing.T) {
 	val, err := rt.RunString(`UUID("550e8400-e29b-41d4-a716-446655440000")`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	bin, ok := bsonVal.(primitive.Binary)
+	bin, ok := bsonVal.(bson.Binary)
 	require.True(t, ok)
 	assert.Equal(t, byte(0x04), bin.Subtype)
 	assert.Len(t, bin.Data, 16)
@@ -174,7 +173,7 @@ func TestUUID_NoArgs_GeneratesRandomUUID(t *testing.T) {
 	val, err := rt.RunString(`UUID()`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	bin, ok := bsonVal.(primitive.Binary)
+	bin, ok := bsonVal.(bson.Binary)
 	require.True(t, ok)
 	assert.Equal(t, byte(0x04), bin.Subtype)
 	assert.Len(t, bin.Data, 16)
@@ -183,7 +182,7 @@ func TestUUID_NoArgs_GeneratesRandomUUID(t *testing.T) {
 	val2, err := rt.RunString(`UUID()`)
 	require.NoError(t, err)
 	bsonVal2 := extractBSONValue(t, val2)
-	bin2, ok := bsonVal2.(primitive.Binary)
+	bin2, ok := bsonVal2.(bson.Binary)
 	require.True(t, ok)
 	assert.NotEqual(t, bin.Data, bin2.Data)
 }
@@ -193,7 +192,7 @@ func TestTimestamp_Valid_ReturnsTimestamp(t *testing.T) {
 	val, err := rt.RunString(`Timestamp(1700000000, 1)`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	ts, ok := bsonVal.(primitive.Timestamp)
+	ts, ok := bsonVal.(bson.Timestamp)
 	require.True(t, ok)
 	assert.Equal(t, uint32(1700000000), ts.T)
 	assert.Equal(t, uint32(1), ts.I)
@@ -204,7 +203,7 @@ func TestTimestamp_NoArgs_ReturnsCurrentTime(t *testing.T) {
 	val, err := rt.RunString(`Timestamp()`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	ts, ok := bsonVal.(primitive.Timestamp)
+	ts, ok := bsonVal.(bson.Timestamp)
 	require.True(t, ok)
 	assert.True(t, ts.T > 0, "expected non-zero timestamp")
 	assert.Equal(t, uint32(1), ts.I)
@@ -215,7 +214,7 @@ func TestTimestamp_ObjectForm_ReturnsTimestamp(t *testing.T) {
 	val, err := rt.RunString(`Timestamp({t: 1700000000, i: 5})`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	ts, ok := bsonVal.(primitive.Timestamp)
+	ts, ok := bsonVal.(bson.Timestamp)
 	require.True(t, ok)
 	assert.Equal(t, uint32(1700000000), ts.T)
 	assert.Equal(t, uint32(5), ts.I)
@@ -226,7 +225,7 @@ func TestTimestamp_ObjectForm_DefaultI(t *testing.T) {
 	val, err := rt.RunString(`Timestamp({t: 1700000000})`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	ts, ok := bsonVal.(primitive.Timestamp)
+	ts, ok := bsonVal.(bson.Timestamp)
 	require.True(t, ok)
 	assert.Equal(t, uint32(1700000000), ts.T)
 	assert.Equal(t, uint32(1), ts.I)
@@ -243,8 +242,8 @@ func TestMinKey_ReturnsMinKey(t *testing.T) {
 	val, err := rt.RunString(`MinKey()`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	_, ok := bsonVal.(primitive.MinKey)
-	assert.True(t, ok, "expected primitive.MinKey, got %T", bsonVal)
+	_, ok := bsonVal.(bson.MinKey)
+	assert.True(t, ok, "expected bson.MinKey, got %T", bsonVal)
 }
 
 func TestMaxKey_ReturnsMaxKey(t *testing.T) {
@@ -252,8 +251,8 @@ func TestMaxKey_ReturnsMaxKey(t *testing.T) {
 	val, err := rt.RunString(`MaxKey()`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	_, ok := bsonVal.(primitive.MaxKey)
-	assert.True(t, ok, "expected primitive.MaxKey, got %T", bsonVal)
+	_, ok := bsonVal.(bson.MaxKey)
+	assert.True(t, ok, "expected bson.MaxKey, got %T", bsonVal)
 }
 
 func TestBinData_Valid_ReturnsBinary(t *testing.T) {
@@ -261,7 +260,7 @@ func TestBinData_Valid_ReturnsBinary(t *testing.T) {
 	val, err := rt.RunString(`BinData(0, "aGVsbG8=")`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	bin, ok := bsonVal.(primitive.Binary)
+	bin, ok := bsonVal.(bson.Binary)
 	require.True(t, ok)
 	assert.Equal(t, byte(0), bin.Subtype)
 	assert.Equal(t, []byte("hello"), bin.Data)
@@ -287,8 +286,8 @@ func TestConvertToBson_UnwrapsRegex(t *testing.T) {
 
 	for _, elem := range bsonDoc {
 		if elem.Key == "name" {
-			regex, ok := elem.Value.(primitive.Regex)
-			require.True(t, ok, "expected primitive.Regex, got %T", elem.Value)
+			regex, ok := elem.Value.(bson.Regex)
+			require.True(t, ok, "expected bson.Regex, got %T", elem.Value)
 			assert.Equal(t, "foo", regex.Pattern)
 			assert.Equal(t, "i", regex.Options)
 		}
@@ -318,8 +317,8 @@ func TestDecimal128_IsAliasForNumberDecimal(t *testing.T) {
 	val, err := rt.RunString(`Decimal128("99.99")`)
 	require.NoError(t, err)
 	bsonVal := extractBSONValue(t, val)
-	_, ok := bsonVal.(primitive.Decimal128)
-	assert.True(t, ok, "expected primitive.Decimal128, got %T", bsonVal)
+	_, ok := bsonVal.(bson.Decimal128)
+	assert.True(t, ok, "expected bson.Decimal128, got %T", bsonVal)
 }
 
 func TestDouble_WithNumber_ReturnsFloat64(t *testing.T) {
@@ -376,7 +375,7 @@ func TestConvertToBson_UnwrapsBSONValue(t *testing.T) {
 	for _, elem := range bsonDoc {
 		switch elem.Key {
 		case "_id":
-			oid, ok := elem.Value.(primitive.ObjectID)
+			oid, ok := elem.Value.(bson.ObjectID)
 			require.True(t, ok, "expected ObjectID, got %T", elem.Value)
 			assert.Equal(t, "507f1f77bcf86cd799439011", oid.Hex())
 		case "count":

--- a/internal/queryengine/collection_info_integration_test.go
+++ b/internal/queryengine/collection_info_integration_test.go
@@ -25,7 +25,7 @@ func TestIntegration_CollectionStats(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.stats()`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "ns")
+	assert.Contains(t, resultText(result), "ns")
 }
 
 func TestIntegration_CollectionIsCapped_False(t *testing.T) {
@@ -41,7 +41,7 @@ func TestIntegration_CollectionIsCapped_False(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.isCapped()`)
 	require.NoError(t, err)
-	assert.Equal(t, "false", result.RawOutput)
+	assert.Equal(t, "false", resultText(result))
 }
 
 func TestIntegration_CollectionIsCapped_True(t *testing.T) {
@@ -58,7 +58,7 @@ func TestIntegration_CollectionIsCapped_True(t *testing.T) {
 	engine := NewGojaEngine(testClient, 0)
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.capped.isCapped()`)
 	require.NoError(t, err)
-	assert.Equal(t, "true", result.RawOutput)
+	assert.Equal(t, "true", resultText(result))
 }
 
 func TestIntegration_CollectionSizeHelpers(t *testing.T) {
@@ -75,7 +75,7 @@ func TestIntegration_CollectionSizeHelpers(t *testing.T) {
 	for _, method := range []string{"dataSize", "storageSize", "totalSize", "totalIndexSize"} {
 		result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.`+method+`()`)
 		require.NoError(t, err, method)
-		assert.NotEmpty(t, result.RawOutput, method)
+		assert.NotEmpty(t, resultText(result), method)
 	}
 }
 
@@ -92,7 +92,7 @@ func TestIntegration_CollectionGetIndexes(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.getIndexes()`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "_id_")
+	assert.Contains(t, resultText(result), "_id_")
 }
 
 func TestIntegration_CollectionCount(t *testing.T) {
@@ -108,7 +108,7 @@ func TestIntegration_CollectionCount(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.count({})`)
 	require.NoError(t, err)
-	assert.Equal(t, "3", result.RawOutput)
+	assert.Equal(t, "3", resultText(result))
 }
 
 func TestIntegration_CollectionRename(t *testing.T) {
@@ -127,7 +127,7 @@ func TestIntegration_CollectionRename(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.newname.count({})`)
 	require.NoError(t, err)
-	assert.Equal(t, "1", result.RawOutput)
+	assert.Equal(t, "1", resultText(result))
 }
 
 func TestIntegration_CollectionValidate(t *testing.T) {
@@ -143,7 +143,7 @@ func TestIntegration_CollectionValidate(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.validate()`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "valid")
+	assert.Contains(t, resultText(result), "valid")
 }
 
 func TestIntegration_CollectionFindAndModify_Update(t *testing.T) {
@@ -165,7 +165,7 @@ func TestIntegration_CollectionFindAndModify_Update(t *testing.T) {
 		})
 	`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "new")
+	assert.Contains(t, resultText(result), "new")
 }
 
 func TestIntegration_CollectionFindAndModify_Remove(t *testing.T) {
@@ -184,5 +184,5 @@ func TestIntegration_CollectionFindAndModify_Remove(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.count({})`)
 	require.NoError(t, err)
-	assert.Equal(t, "0", result.RawOutput)
+	assert.Equal(t, "0", resultText(result))
 }

--- a/internal/queryengine/collection_info_integration_test.go
+++ b/internal/queryengine/collection_info_integration_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 func TestIntegration_CollectionStats(t *testing.T) {

--- a/internal/queryengine/db_commands_integration_test.go
+++ b/internal/queryengine/db_commands_integration_test.go
@@ -21,7 +21,7 @@ func TestIntegration_RunCommand_Ping(t *testing.T) {
 	engine := NewGojaEngine(testClient, 0)
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.runCommand({ ping: 1 })`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "ok")
+	assert.Contains(t, resultText(result), "ok")
 }
 
 // TestIntegration_RunCommand_PropertyAccess guards the v2 normalizer fix:
@@ -39,7 +39,7 @@ func TestIntegration_RunCommand_PropertyAccess(t *testing.T) {
 	engine := NewGojaEngine(testClient, 0)
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.runCommand({ ping: 1 }).ok`)
 	require.NoError(t, err)
-	assert.Equal(t, "1", result.RawOutput, "command result property must be reachable from JS, not undefined")
+	assert.Equal(t, "1", resultText(result), "command result property must be reachable from JS, not undefined")
 }
 
 func TestIntegration_RunCommand_CollStats(t *testing.T) {
@@ -58,7 +58,7 @@ func TestIntegration_RunCommand_CollStats(t *testing.T) {
 	// Run collStats
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.runCommand({ collStats: "test" })`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "ns")
+	assert.Contains(t, resultText(result), "ns")
 }
 
 func TestIntegration_AdminCommand_ListDatabases(t *testing.T) {
@@ -71,7 +71,7 @@ func TestIntegration_AdminCommand_ListDatabases(t *testing.T) {
 	engine := NewGojaEngine(testClient, 0)
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.adminCommand({ listDatabases: 1 })`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "databases")
+	assert.Contains(t, resultText(result), "databases")
 }
 
 func TestIntegration_RunCommand_InvalidCommand_Errors(t *testing.T) {
@@ -105,8 +105,8 @@ func TestIntegration_GetCollectionNames(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getCollectionNames()`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "alpha")
-	assert.Contains(t, result.RawOutput, "beta")
+	assert.Contains(t, resultText(result), "alpha")
+	assert.Contains(t, resultText(result), "beta")
 }
 
 func TestIntegration_GetCollectionInfos(t *testing.T) {
@@ -122,7 +122,7 @@ func TestIntegration_GetCollectionInfos(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getCollectionInfos()`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "infocoll")
+	assert.Contains(t, resultText(result), "infocoll")
 }
 
 func TestIntegration_CreateCollection(t *testing.T) {
@@ -135,7 +135,7 @@ func TestIntegration_CreateCollection(t *testing.T) {
 	engine := NewGojaEngine(testClient, 0)
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.createCollection("newcoll")`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "ok")
+	assert.Contains(t, resultText(result), "ok")
 
 	// Verify collection exists
 	names, err := testClient.Database(db).ListCollectionNames(ctx, map[string]any{})
@@ -156,7 +156,7 @@ func TestIntegration_CreateView(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.createView("myview", "src", [{ $project: { x: 1 } }])`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "ok")
+	assert.Contains(t, resultText(result), "ok")
 
 	infos, err := testClient.Database(db).ListCollectionNames(ctx, map[string]any{"name": "myview"})
 	require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestIntegration_DropDatabase(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.dropDatabase()`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "ok")
+	assert.Contains(t, resultText(result), "ok")
 }
 
 func TestIntegration_Stats(t *testing.T) {
@@ -192,7 +192,7 @@ func TestIntegration_Stats(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.stats()`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "collections")
+	assert.Contains(t, resultText(result), "collections")
 }
 
 func TestIntegration_Version(t *testing.T) {
@@ -206,8 +206,8 @@ func TestIntegration_Version(t *testing.T) {
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.version()`)
 	require.NoError(t, err)
 	// Should return a version string like "7.0.x"
-	assert.NotEmpty(t, result.RawOutput)
-	assert.Contains(t, result.RawOutput, ".")
+	assert.NotEmpty(t, resultText(result))
+	assert.Contains(t, resultText(result), ".")
 }
 
 func TestIntegration_GetSiblingDB(t *testing.T) {

--- a/internal/queryengine/db_commands_integration_test.go
+++ b/internal/queryengine/db_commands_integration_test.go
@@ -24,6 +24,24 @@ func TestIntegration_RunCommand_Ping(t *testing.T) {
 	assert.Contains(t, result.RawOutput, "ok")
 }
 
+// TestIntegration_RunCommand_PropertyAccess guards the v2 normalizer fix:
+// bson.M gained methods in mongo-driver v2, so goja stopped reflecting command
+// results as JS objects. Accessing a property of the result then returns
+// undefined. normalizeForJS restores plain-object reflection; this asserts the
+// property is actually reachable from JS end-to-end.
+func TestIntegration_RunCommand_PropertyAccess(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db := dbName(t)
+	defer testClient.Database(db).Drop(ctx)
+
+	engine := NewGojaEngine(testClient, 0)
+	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.runCommand({ ping: 1 }).ok`)
+	require.NoError(t, err)
+	assert.Equal(t, "1", result.RawOutput, "command result property must be reachable from JS, not undefined")
+}
+
 func TestIntegration_RunCommand_CollStats(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/internal/queryengine/dispatch.go
+++ b/internal/queryengine/dispatch.go
@@ -7,8 +7,8 @@ import (
 
 	"vervet/internal/models"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 // dispatch executes a captured operation against MongoDB using the Go driver.

--- a/internal/queryengine/dispatch_indexes.go
+++ b/internal/queryengine/dispatch_indexes.go
@@ -6,8 +6,8 @@ import (
 
 	"vervet/internal/models"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 func dispatchCreateIndex(ctx context.Context, coll *mongo.Collection, op CapturedOp) (models.QueryResult, error) {
@@ -73,14 +73,10 @@ func dispatchDropIndex(ctx context.Context, coll *mongo.Collection, op CapturedO
 		return models.QueryResult{}, fmt.Errorf("dropIndex argument must be a string")
 	}
 
-	res, err := coll.Indexes().DropOne(ctx, name)
-	if err != nil {
-		return models.QueryResult{}, fmt.Errorf("dropIndex failed: %w", err)
-	}
-
 	var result bson.M
-	if err := bson.Unmarshal(res, &result); err != nil {
-		return models.QueryResult{}, fmt.Errorf("dropIndex failed to parse response: %w", err)
+	cmd := bson.D{{Key: "dropIndexes", Value: coll.Name()}, {Key: "index", Value: name}}
+	if err := coll.Database().RunCommand(ctx, cmd).Decode(&result); err != nil {
+		return models.QueryResult{}, fmt.Errorf("dropIndex failed: %w", err)
 	}
 
 	qr := singleToResult(result)
@@ -91,14 +87,10 @@ func dispatchDropIndex(ctx context.Context, coll *mongo.Collection, op CapturedO
 func dispatchDropIndexes(ctx context.Context, coll *mongo.Collection, op CapturedOp) (models.QueryResult, error) {
 	if len(op.Args) < 1 {
 		// dropIndexes supports deleting all indexes with no arguments
-		res, err := coll.Indexes().DropAll(ctx)
-		if err != nil {
-			return models.QueryResult{}, fmt.Errorf("dropIndexes failed: %w", err)
-		}
-
 		var result bson.M
-		if err := bson.Unmarshal(res, &result); err != nil {
-			return models.QueryResult{}, fmt.Errorf("dropIndexes failed to parse response: %w", err)
+		cmd := bson.D{{Key: "dropIndexes", Value: coll.Name()}, {Key: "index", Value: "*"}}
+		if err := coll.Database().RunCommand(ctx, cmd).Decode(&result); err != nil {
+			return models.QueryResult{}, fmt.Errorf("dropIndexes failed: %w", err)
 		}
 
 		qr := singleToResult(result)
@@ -108,14 +100,10 @@ func dispatchDropIndexes(ctx context.Context, coll *mongo.Collection, op Capture
 
 	name, ok := op.Args[0].(string)
 	if ok {
-		res, err := coll.Indexes().DropOne(ctx, name)
-		if err != nil {
-			return models.QueryResult{}, fmt.Errorf("dropIndexes failed: %w", err)
-		}
-
 		var result bson.M
-		if err := bson.Unmarshal(res, &result); err != nil {
-			return models.QueryResult{}, fmt.Errorf("dropIndexes failed to parse response: %w", err)
+		cmd := bson.D{{Key: "dropIndexes", Value: coll.Name()}, {Key: "index", Value: name}}
+		if err := coll.Database().RunCommand(ctx, cmd).Decode(&result); err != nil {
+			return models.QueryResult{}, fmt.Errorf("dropIndexes failed: %w", err)
 		}
 
 		qr := singleToResult(result)
@@ -139,13 +127,10 @@ func dispatchDropIndexes(ctx context.Context, coll *mongo.Collection, op Capture
 
 	var results []bson.M
 	for _, key := range keys {
-		res, err := coll.Indexes().DropOne(ctx, key)
-		if err != nil {
-			return models.QueryResult{}, fmt.Errorf("dropIndexes failed on '%s': %w", key, err)
-		}
 		var r bson.M
-		if err := bson.Unmarshal(res, &r); err != nil {
-			return models.QueryResult{}, fmt.Errorf("dropIndexes failed to parse response for '%s': %w", key, err)
+		cmd := bson.D{{Key: "dropIndexes", Value: coll.Name()}, {Key: "index", Value: key}}
+		if err := coll.Database().RunCommand(ctx, cmd).Decode(&r); err != nil {
+			return models.QueryResult{}, fmt.Errorf("dropIndexes failed on '%s': %w", key, err)
 		}
 		results = append(results, r)
 	}

--- a/internal/queryengine/dispatch_read.go
+++ b/internal/queryengine/dispatch_read.go
@@ -7,15 +7,21 @@ import (
 
 	"vervet/internal/models"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 func dispatchFind(ctx context.Context, coll *mongo.Collection, op CapturedOp) (models.QueryResult, error) {
 	filter := bson.D{}
 	if len(op.Args) > 0 && op.Args[0] != nil {
 		filter = toBsonDoc(op.Args[0])
+	}
+
+	if op.MaxTimeMS > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(op.MaxTimeMS)*time.Millisecond)
+		defer cancel()
 	}
 
 	opts := options.Find()
@@ -43,7 +49,7 @@ func dispatchFind(ctx context.Context, coll *mongo.Collection, op CapturedOp) (m
 }
 
 // applyFindOptions applies the shared cursor-scoped options from op to the given FindOptions.
-func applyFindOptions(opts *options.FindOptions, op CapturedOp) {
+func applyFindOptions(opts *options.FindOptionsBuilder, op CapturedOp) {
 	if op.Limit > 0 {
 		opts.SetLimit(op.Limit)
 	}
@@ -61,9 +67,6 @@ func applyFindOptions(opts *options.FindOptions, op CapturedOp) {
 		} else {
 			opts.SetHint(op.Hint)
 		}
-	}
-	if op.MaxTimeMS > 0 {
-		opts.SetMaxTime(time.Duration(op.MaxTimeMS) * time.Millisecond)
 	}
 	if op.BatchSize > 0 {
 		opts.SetBatchSize(op.BatchSize)
@@ -254,8 +257,8 @@ func dispatchDistinct(ctx context.Context, coll *mongo.Collection, op CapturedOp
 		filter = toBsonDoc(op.Args[1])
 	}
 
-	results, err := coll.Distinct(ctx, field, filter)
-	if err != nil {
+	var results []any
+	if err := coll.Distinct(ctx, field, filter).Decode(&results); err != nil {
 		return models.QueryResult{}, fmt.Errorf("distinct failed: %w", err)
 	}
 

--- a/internal/queryengine/dispatch_write.go
+++ b/internal/queryengine/dispatch_write.go
@@ -6,8 +6,8 @@ import (
 
 	"vervet/internal/models"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 func dispatchInsertOne(ctx context.Context, coll *mongo.Collection, op CapturedOp) (models.QueryResult, error) {

--- a/internal/queryengine/ejson.go
+++ b/internal/queryengine/ejson.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/dop251/goja"
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // registerEJSON registers the EJSON global object in the Goja runtime,
@@ -91,7 +91,7 @@ func ejsonParse(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 			panic(rt.NewGoError(fmt.Errorf("EJSON.parse: %w", err)))
 		}
 
-		return rt.ToValue(result)
+		return toJSValue(rt, result)
 	}
 }
 
@@ -119,7 +119,7 @@ func ejsonSerialize(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 			panic(rt.NewGoError(fmt.Errorf("EJSON.serialize: %w", err)))
 		}
 
-		return rt.ToValue(result)
+		return toJSValue(rt, result)
 	}
 }
 
@@ -145,6 +145,6 @@ func ejsonDeserialize(rt *goja.Runtime) func(goja.FunctionCall) goja.Value {
 			panic(rt.NewGoError(fmt.Errorf("EJSON.deserialize: %w", err)))
 		}
 
-		return rt.ToValue(result)
+		return toJSValue(rt, result)
 	}
 }

--- a/internal/queryengine/exec_context.go
+++ b/internal/queryengine/exec_context.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/dop251/goja"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 // execContext holds the dependencies needed by proxy methods to execute

--- a/internal/queryengine/goja_engine.go
+++ b/internal/queryengine/goja_engine.go
@@ -13,7 +13,7 @@ import (
 	"github.com/dop251/goja_nodejs/console"
 	"github.com/dop251/goja_nodejs/process"
 	"github.com/dop251/goja_nodejs/require"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 // GojaEngine implements QueryEngine using the goja JavaScript runtime.

--- a/internal/queryengine/goja_engine_test.go
+++ b/internal/queryengine/goja_engine_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // setupRuntime creates a Goja runtime with a database proxy.

--- a/internal/queryengine/goja_helpers.go
+++ b/internal/queryengine/goja_helpers.go
@@ -5,7 +5,7 @@ import (
 	"vervet/internal/models"
 
 	"github.com/dop251/goja"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // toGojaValue converts a QueryResult into a Goja-native value so scripts
@@ -15,13 +15,13 @@ func toGojaValue(rt *goja.Runtime, result models.QueryResult) goja.Value {
 		return rt.ToValue(result.RawOutput)
 	}
 	if result.Single && len(result.Documents) > 0 {
-		return rt.ToValue(result.Documents[0])
+		return toJSValue(rt, result.Documents[0])
 	}
-	return rt.ToValue(result.Documents)
+	return toJSValue(rt, result.Documents)
 }
 
 // exportArgs converts Goja function call arguments to plain Go values.
-// RegExp objects are converted to primitive.Regex so they survive Export()
+// RegExp objects are converted to bson.Regex so they survive Export()
 // and flow through convertToBson correctly.
 func exportArgs(call goja.FunctionCall) []any {
 	args := make([]any, len(call.Arguments))
@@ -32,7 +32,7 @@ func exportArgs(call goja.FunctionCall) []any {
 }
 
 // exportValue converts a single goja.Value to a Go value, recursively walking
-// objects and arrays to convert RegExp values to wrapped primitive.Regex before
+// objects and arrays to convert RegExp values to wrapped bson.Regex before
 // they are lost to Export().
 func exportValue(val goja.Value) any {
 	if val == nil || goja.IsUndefined(val) || goja.IsNull(val) {
@@ -59,12 +59,12 @@ func exportValue(val goja.Value) any {
 	}
 }
 
-// regexpToBSON converts a goja RegExp object into a BSON-wrapped primitive.Regex.
+// regexpToBSON converts a goja RegExp object into a BSON-wrapped bson.Regex.
 func regexpToBSON(obj *goja.Object) map[string]any {
 	pattern := obj.Get("source").String()
 	flags := obj.Get("flags").String()
 	return map[string]any{
-		"__bsonValue": &bsonWrapper{Value: primitive.Regex{
+		"__bsonValue": &bsonWrapper{Value: bson.Regex{
 			Pattern: pattern,
 			Options: mongoRegexOptions(flags),
 		}},

--- a/internal/queryengine/goja_helpers_test.go
+++ b/internal/queryengine/goja_helpers_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func TestToGojaValue_EmptyDocuments(t *testing.T) {
@@ -96,8 +96,8 @@ func TestExportValue_Regex_ConvertsToBSONRegex(t *testing.T) {
 	w, ok := bsonVal.(*bsonWrapper)
 	require.True(t, ok, "expected *bsonWrapper, got %T", bsonVal)
 
-	regex, ok := w.Value.(primitive.Regex)
-	require.True(t, ok, "expected primitive.Regex, got %T", w.Value)
+	regex, ok := w.Value.(bson.Regex)
+	require.True(t, ok, "expected bson.Regex, got %T", w.Value)
 	assert.Equal(t, "foo", regex.Pattern)
 	assert.Equal(t, "i", regex.Options)
 }
@@ -117,7 +117,7 @@ func TestExportValue_NestedRegex_PreservedInDocument(t *testing.T) {
 	w, ok := nameVal["__bsonValue"].(*bsonWrapper)
 	require.True(t, ok)
 
-	regex, ok := w.Value.(primitive.Regex)
+	regex, ok := w.Value.(bson.Regex)
 	require.True(t, ok)
 	assert.Equal(t, "bar", regex.Pattern)
 	assert.Equal(t, "im", regex.Options)
@@ -144,7 +144,7 @@ func TestExportValue_RegexInArray_Preserved(t *testing.T) {
 		require.True(t, ok)
 		w, ok := m["__bsonValue"].(*bsonWrapper)
 		require.True(t, ok)
-		regex, ok := w.Value.(primitive.Regex)
+		regex, ok := w.Value.(bson.Regex)
 		require.True(t, ok)
 		assert.Equal(t, expected.pattern, regex.Pattern)
 		assert.Equal(t, expected.options, regex.Options)

--- a/internal/queryengine/helpers_integration_test.go
+++ b/internal/queryengine/helpers_integration_test.go
@@ -1,0 +1,21 @@
+//go:build integration
+
+package queryengine
+
+import (
+	"encoding/json"
+
+	"vervet/internal/models"
+)
+
+// resultText returns a searchable string view of a query result. Scalar and
+// string results live in RawOutput; objects and arrays (e.g. db.runCommand,
+// db.getUsers, db.getCollectionNames) are structured and land in Documents
+// instead, so fall back to their JSON encoding.
+func resultText(r models.QueryResult) string {
+	if r.RawOutput != "" {
+		return r.RawOutput
+	}
+	b, _ := json.Marshal(r.Documents)
+	return string(b)
+}

--- a/internal/queryengine/js_normalize.go
+++ b/internal/queryengine/js_normalize.go
@@ -1,0 +1,59 @@
+package queryengine
+
+import (
+	"github.com/dop251/goja"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// normalizeForJS converts driver result values into plain Go containers before
+// they cross into the goja runtime. In mongo-driver v2, bson.M and bson.D gained
+// methods (String, MarshalJSON), and goja only reflects a map as a JS object when
+// the map type has zero methods (see goja runtime.go: `NumMethod() == 0`). Without
+// this, a bson.M is wrapped as an opaque object exposing "String" instead of its
+// keys. Stripping M/D/A down to method-less map[string]any / []any restores the
+// v1 reflection behaviour. Scalar BSON types (ObjectID, DateTime, ...) reflected
+// identically in v1 and v2, so they pass through untouched.
+func normalizeForJS(v any) any {
+	switch val := v.(type) {
+	case bson.M:
+		out := make(map[string]any, len(val))
+		for k, elem := range val {
+			out[k] = normalizeForJS(elem)
+		}
+		return out
+	case bson.D:
+		// ponytail: D is flattened to an object (last-wins on duplicate keys). v1
+		// exposed D as an array to JS, but D is not on the result path (results are
+		// bson.M); this branch is defensive.
+		out := make(map[string]any, len(val))
+		for _, e := range val {
+			out[e.Key] = normalizeForJS(e.Value)
+		}
+		return out
+	case bson.A:
+		out := make([]any, len(val))
+		for i, elem := range val {
+			out[i] = normalizeForJS(elem)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, elem := range val {
+			out[i] = normalizeForJS(elem)
+		}
+		return out
+	case []bson.M:
+		out := make([]any, len(val))
+		for i, elem := range val {
+			out[i] = normalizeForJS(elem)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// toJSValue normalizes a driver result value and hands it to the goja runtime.
+func toJSValue(rt *goja.Runtime, v any) goja.Value {
+	return rt.ToValue(normalizeForJS(v))
+}

--- a/internal/queryengine/js_normalize.go
+++ b/internal/queryengine/js_normalize.go
@@ -21,6 +21,12 @@ func normalizeForJS(v any) any {
 			out[k] = normalizeForJS(elem)
 		}
 		return out
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, elem := range val {
+			out[k] = normalizeForJS(elem)
+		}
+		return out
 	case bson.D:
 		// ponytail: D is flattened to an object (last-wins on duplicate keys). v1
 		// exposed D as an array to JS, but D is not on the result path (results are

--- a/internal/queryengine/js_normalize_test.go
+++ b/internal/queryengine/js_normalize_test.go
@@ -1,0 +1,38 @@
+package queryengine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestNormalizeForJS_NestedContainers(t *testing.T) {
+	in := bson.M{
+		"a":   bson.M{"b": 1},
+		"arr": bson.A{bson.M{"c": 2}},
+	}
+
+	out, ok := normalizeForJS(in).(map[string]any)
+	require.True(t, ok, "top level should be plain map[string]any")
+
+	nested, ok := out["a"].(map[string]any)
+	require.True(t, ok, "nested bson.M should become map[string]any")
+	assert.Equal(t, 1, nested["b"])
+
+	arr, ok := out["arr"].([]any)
+	require.True(t, ok, "bson.A should become []any")
+	require.Len(t, arr, 1)
+	elem, ok := arr[0].(map[string]any)
+	require.True(t, ok, "element bson.M should become map[string]any")
+	assert.Equal(t, 2, elem["c"])
+}
+
+func TestNormalizeForJS_ScalarPassthrough(t *testing.T) {
+	oid := bson.NewObjectID()
+	out := normalizeForJS(oid)
+	got, ok := out.(bson.ObjectID)
+	require.True(t, ok, "scalar BSON type should pass through unchanged")
+	assert.Equal(t, oid, got)
+}

--- a/internal/queryengine/js_normalize_test.go
+++ b/internal/queryengine/js_normalize_test.go
@@ -29,6 +29,22 @@ func TestNormalizeForJS_NestedContainers(t *testing.T) {
 	assert.Equal(t, 2, elem["c"])
 }
 
+func TestNormalizeForJS_PlainMapRecurses(t *testing.T) {
+	// The distinct path wraps results in a synthesized map[string]any whose
+	// values can be nested bson.M/D — those must be normalized too.
+	in := map[string]any{"values": []any{bson.M{"k": 1}}}
+
+	out, ok := normalizeForJS(in).(map[string]any)
+	require.True(t, ok, "top level should be plain map[string]any")
+
+	arr, ok := out["values"].([]any)
+	require.True(t, ok, "values should be []any")
+	require.Len(t, arr, 1)
+	elem, ok := arr[0].(map[string]any)
+	require.True(t, ok, "nested bson.M should become map[string]any")
+	assert.Equal(t, 1, elem["k"])
+}
+
 func TestNormalizeForJS_ScalarPassthrough(t *testing.T) {
 	oid := bson.NewObjectID()
 	out := normalizeForJS(oid)

--- a/internal/queryengine/jsmodules/jsmodules.go
+++ b/internal/queryengine/jsmodules/jsmodules.go
@@ -29,4 +29,3 @@ func nodeError(rt *goja.Runtime, code, msg string) *goja.Object {
 	_ = obj.Set("code", code)
 	return obj
 }
-

--- a/internal/queryengine/lazy_cursor.go
+++ b/internal/queryengine/lazy_cursor.go
@@ -249,7 +249,7 @@ func (c *lazyCursor) toGojaObject() goja.Value {
 			panic(rt.NewGoError(err))
 		}
 		for _, doc := range c.results {
-			if _, err := fn(goja.Undefined(), rt.ToValue(doc)); err != nil {
+			if _, err := fn(goja.Undefined(), toJSValue(rt, doc)); err != nil {
 				panic(rt.NewGoError(err))
 			}
 		}
@@ -270,7 +270,7 @@ func (c *lazyCursor) toGojaObject() goja.Value {
 		}
 		mapped := make([]any, len(c.results))
 		for i, doc := range c.results {
-			val, err := fn(goja.Undefined(), rt.ToValue(doc))
+			val, err := fn(goja.Undefined(), toJSValue(rt, doc))
 			if err != nil {
 				panic(rt.NewGoError(err))
 			}
@@ -318,7 +318,7 @@ func (c *lazyCursor) toGojaObject() goja.Value {
 		}
 		doc := c.results[c.index]
 		c.index++
-		return rt.ToValue(doc)
+		return toJSValue(rt, doc)
 	})
 
 	_ = obj.Set("explain", func(call goja.FunctionCall) goja.Value {

--- a/internal/queryengine/lazy_cursor_integration_test.go
+++ b/internal/queryengine/lazy_cursor_integration_test.go
@@ -25,7 +25,7 @@ func TestIntegration_Cursor_Explain(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.find({ x: 1 }).explain()`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "queryPlanner")
+	assert.Contains(t, resultText(result), "queryPlanner")
 }
 
 func TestIntegration_Cursor_ExplainWithVerbosity(t *testing.T) {
@@ -42,7 +42,7 @@ func TestIntegration_Cursor_ExplainWithVerbosity(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.test.find({ x: 1 }).explain("executionStats")`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "executionStats")
+	assert.Contains(t, resultText(result), "executionStats")
 }
 
 func TestIntegration_Cursor_Hint(t *testing.T) {

--- a/internal/queryengine/proxy_collection_info.go
+++ b/internal/queryengine/proxy_collection_info.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/dop251/goja"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // collStatsMap runs the collStats command and returns the result document.
@@ -61,7 +61,7 @@ func setCollectionInfoMethods(obj *goja.Object, ec *execContext, collName string
 		if err != nil {
 			panic(rt.NewGoError(fmt.Errorf("stats: %w", err)))
 		}
-		return rt.ToValue(result)
+		return toJSValue(rt, result)
 	})
 
 	_ = obj.Set("isCapped", func() goja.Value {
@@ -160,7 +160,7 @@ func setCollectionInfoMethods(obj *goja.Object, ec *execContext, collName string
 		if err := ec.client.Database("admin").RunCommand(ec.ctx, cmd).Decode(&result); err != nil {
 			panic(rt.NewGoError(fmt.Errorf("renameCollection: %w", err)))
 		}
-		return rt.ToValue(result)
+		return toJSValue(rt, result)
 	})
 
 	_ = obj.Set("validate", func(call goja.FunctionCall) goja.Value {
@@ -181,7 +181,7 @@ func setCollectionInfoMethods(obj *goja.Object, ec *execContext, collName string
 		if err := ec.client.Database(ec.dbName).RunCommand(ec.ctx, cmd).Decode(&result); err != nil {
 			panic(rt.NewGoError(fmt.Errorf("validate: %w", err)))
 		}
-		return rt.ToValue(result)
+		return toJSValue(rt, result)
 	})
 
 	_ = obj.Set("findAndModify", func(call goja.FunctionCall) goja.Value {
@@ -197,7 +197,7 @@ func setCollectionInfoMethods(obj *goja.Object, ec *execContext, collName string
 		if err != nil {
 			panic(rt.NewGoError(err))
 		}
-		return rt.ToValue(result)
+		return toJSValue(rt, result)
 	})
 }
 

--- a/internal/queryengine/proxy_db_collections.go
+++ b/internal/queryengine/proxy_db_collections.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/dop251/goja"
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // dbGetCollectionNames returns a function: db.getCollectionNames(filter?) → string[]
@@ -58,7 +58,7 @@ func dbGetCollectionInfos(ec *execContext) func(goja.FunctionCall) goja.Value {
 			out[i] = r
 		}
 
-		return ec.rt.ToValue(out)
+		return toJSValue(ec.rt, out)
 	}
 }
 
@@ -114,7 +114,7 @@ func dbCreateView(ec *execContext) func(goja.FunctionCall) goja.Value {
 			panic(ec.rt.NewGoError(fmt.Errorf("createView: %w", err)))
 		}
 
-		return ec.rt.ToValue(result)
+		return toJSValue(ec.rt, result)
 	}
 }
 
@@ -144,6 +144,6 @@ func dbAggregate(ec *execContext) func(goja.FunctionCall) goja.Value {
 			out[i] = r
 		}
 
-		return ec.rt.ToValue(out)
+		return toJSValue(ec.rt, out)
 	}
 }

--- a/internal/queryengine/proxy_db_commands.go
+++ b/internal/queryengine/proxy_db_commands.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/dop251/goja"
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // dbRunCommand returns a Goja-callable function that executes a command document
@@ -25,7 +25,7 @@ func dbRunCommand(ec *execContext, dbName string) func(goja.FunctionCall) goja.V
 			panic(ec.rt.NewGoError(fmt.Errorf("runCommand: %w", err)))
 		}
 
-		return ec.rt.ToValue(result)
+		return toJSValue(ec.rt, result)
 	}
 }
 
@@ -40,7 +40,7 @@ func dbStats(ec *execContext) func(goja.FunctionCall) goja.Value {
 			panic(ec.rt.NewGoError(fmt.Errorf("stats: %w", err)))
 		}
 
-		return ec.rt.ToValue(result)
+		return toJSValue(ec.rt, result)
 	}
 }
 

--- a/internal/queryengine/proxy_db_roles.go
+++ b/internal/queryengine/proxy_db_roles.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/dop251/goja"
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // buildRoleCommand constructs a createRole command doc from a mongosh-style role spec.
@@ -70,7 +70,7 @@ func dbCreateRole(ec *execContext) func(goja.FunctionCall) goja.Value {
 		if err != nil {
 			panic(ec.rt.NewGoError(fmt.Errorf("createRole: %w", err)))
 		}
-		return ec.rt.ToValue(runDBCommand(ec, "createRole", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "createRole", cmd))
 	}
 }
 
@@ -82,7 +82,7 @@ func dbDropRole(ec *execContext) func(goja.FunctionCall) goja.Value {
 		}
 		name := call.Arguments[0].String()
 		cmd := bson.D{{Key: "dropRole", Value: name}}
-		return ec.rt.ToValue(runDBCommand(ec, "dropRole", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "dropRole", cmd))
 	}
 }
 
@@ -99,7 +99,7 @@ func dbGetRole(ec *execContext) func(goja.FunctionCall) goja.Value {
 		if len(roles) == 0 {
 			return goja.Null()
 		}
-		return ec.rt.ToValue(roles[0])
+		return toJSValue(ec.rt, roles[0])
 	}
 }
 
@@ -113,7 +113,7 @@ func dbGetRoles(ec *execContext) func(goja.FunctionCall) goja.Value {
 		for i, r := range roles {
 			out[i] = r
 		}
-		return ec.rt.ToValue(out)
+		return toJSValue(ec.rt, out)
 	}
 }
 
@@ -128,7 +128,7 @@ func dbUpdateRole(ec *execContext) func(goja.FunctionCall) goja.Value {
 		if err != nil {
 			panic(ec.rt.NewGoError(fmt.Errorf("updateRole: %w", err)))
 		}
-		return ec.rt.ToValue(runDBCommand(ec, "updateRole", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "updateRole", cmd))
 	}
 }
 
@@ -141,7 +141,7 @@ func dbGrantPrivilegesToRole(ec *execContext) func(goja.FunctionCall) goja.Value
 		name := call.Arguments[0].String()
 		privs := convertToBson(exportValue(call.Arguments[1]))
 		cmd := bson.D{{Key: "grantPrivilegesToRole", Value: name}, {Key: "privileges", Value: privs}}
-		return ec.rt.ToValue(runDBCommand(ec, "grantPrivilegesToRole", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "grantPrivilegesToRole", cmd))
 	}
 }
 
@@ -154,7 +154,7 @@ func dbRevokePrivilegesFromRole(ec *execContext) func(goja.FunctionCall) goja.Va
 		name := call.Arguments[0].String()
 		privs := convertToBson(exportValue(call.Arguments[1]))
 		cmd := bson.D{{Key: "revokePrivilegesFromRole", Value: name}, {Key: "privileges", Value: privs}}
-		return ec.rt.ToValue(runDBCommand(ec, "revokePrivilegesFromRole", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "revokePrivilegesFromRole", cmd))
 	}
 }
 
@@ -167,7 +167,7 @@ func dbGrantRolesToRole(ec *execContext) func(goja.FunctionCall) goja.Value {
 		name := call.Arguments[0].String()
 		roles := convertToBson(exportValue(call.Arguments[1]))
 		cmd := bson.D{{Key: "grantRolesToRole", Value: name}, {Key: "roles", Value: roles}}
-		return ec.rt.ToValue(runDBCommand(ec, "grantRolesToRole", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "grantRolesToRole", cmd))
 	}
 }
 
@@ -180,7 +180,7 @@ func dbRevokeRolesFromRole(ec *execContext) func(goja.FunctionCall) goja.Value {
 		name := call.Arguments[0].String()
 		roles := convertToBson(exportValue(call.Arguments[1]))
 		cmd := bson.D{{Key: "revokeRolesFromRole", Value: name}, {Key: "roles", Value: roles}}
-		return ec.rt.ToValue(runDBCommand(ec, "revokeRolesFromRole", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "revokeRolesFromRole", cmd))
 	}
 }
 
@@ -188,6 +188,6 @@ func dbDropAllRoles(ec *execContext) func(goja.FunctionCall) goja.Value {
 	return func(call goja.FunctionCall) goja.Value {
 		requireClient(ec)
 		cmd := bson.D{{Key: "dropAllRolesFromDatabase", Value: 1}}
-		return ec.rt.ToValue(runDBCommand(ec, "dropAllRoles", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "dropAllRoles", cmd))
 	}
 }

--- a/internal/queryengine/proxy_db_roles_integration_test.go
+++ b/internal/queryengine/proxy_db_roles_integration_test.go
@@ -25,14 +25,14 @@ func TestIntegration_CreateRole_GetRole_DropRole(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getRole("reader1")`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "reader1")
+	assert.Contains(t, resultText(result), "reader1")
 
 	_, err = engine.ExecuteQuery(ctx, testURI, db, `db.dropRole("reader1")`)
 	require.NoError(t, err)
 
 	result, err = engine.ExecuteQuery(ctx, testURI, db, `db.getRole("reader1")`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "null")
+	assert.Contains(t, resultText(result), "null")
 }
 
 func TestIntegration_GetRoles(t *testing.T) {
@@ -50,8 +50,8 @@ func TestIntegration_GetRoles(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getRoles()`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "r1")
-	assert.Contains(t, result.RawOutput, "r2")
+	assert.Contains(t, resultText(result), "r1")
+	assert.Contains(t, resultText(result), "r2")
 }
 
 func TestIntegration_UpdateRole(t *testing.T) {
@@ -70,7 +70,7 @@ func TestIntegration_UpdateRole(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getRole("r3")`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "r3")
+	assert.Contains(t, resultText(result), "r3")
 }
 
 func TestIntegration_GrantRevokePrivilegesToRole(t *testing.T) {
@@ -128,6 +128,6 @@ func TestIntegration_DropAllRoles(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getRoles()`)
 	require.NoError(t, err)
-	assert.NotContains(t, result.RawOutput, "\"r6\"")
-	assert.NotContains(t, result.RawOutput, "\"r7\"")
+	assert.NotContains(t, resultText(result), "\"r6\"")
+	assert.NotContains(t, resultText(result), "\"r7\"")
 }

--- a/internal/queryengine/proxy_db_users.go
+++ b/internal/queryengine/proxy_db_users.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/dop251/goja"
-	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // buildUserCommand constructs a createUser command doc from a mongosh-style user spec.
@@ -81,7 +81,7 @@ func dbCreateUser(ec *execContext) func(goja.FunctionCall) goja.Value {
 		if err != nil {
 			panic(ec.rt.NewGoError(fmt.Errorf("createUser: %w", err)))
 		}
-		return ec.rt.ToValue(runDBCommand(ec, "createUser", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "createUser", cmd))
 	}
 }
 
@@ -93,7 +93,7 @@ func dbDropUser(ec *execContext) func(goja.FunctionCall) goja.Value {
 		}
 		name := call.Arguments[0].String()
 		cmd := bson.D{{Key: "dropUser", Value: name}}
-		return ec.rt.ToValue(runDBCommand(ec, "dropUser", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "dropUser", cmd))
 	}
 }
 
@@ -110,7 +110,7 @@ func dbGetUser(ec *execContext) func(goja.FunctionCall) goja.Value {
 		if len(users) == 0 {
 			return goja.Null()
 		}
-		return ec.rt.ToValue(users[0])
+		return toJSValue(ec.rt, users[0])
 	}
 }
 
@@ -124,7 +124,7 @@ func dbGetUsers(ec *execContext) func(goja.FunctionCall) goja.Value {
 		for i, u := range users {
 			out[i] = u
 		}
-		return ec.rt.ToValue(out)
+		return toJSValue(ec.rt, out)
 	}
 }
 
@@ -139,7 +139,7 @@ func dbUpdateUser(ec *execContext) func(goja.FunctionCall) goja.Value {
 		if err != nil {
 			panic(ec.rt.NewGoError(fmt.Errorf("updateUser: %w", err)))
 		}
-		return ec.rt.ToValue(runDBCommand(ec, "updateUser", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "updateUser", cmd))
 	}
 }
 
@@ -152,7 +152,7 @@ func dbChangeUserPassword(ec *execContext) func(goja.FunctionCall) goja.Value {
 		name := call.Arguments[0].String()
 		pwd := call.Arguments[1].String()
 		cmd := bson.D{{Key: "updateUser", Value: name}, {Key: "pwd", Value: pwd}}
-		return ec.rt.ToValue(runDBCommand(ec, "changeUserPassword", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "changeUserPassword", cmd))
 	}
 }
 
@@ -165,7 +165,7 @@ func dbGrantRolesToUser(ec *execContext) func(goja.FunctionCall) goja.Value {
 		name := call.Arguments[0].String()
 		roles := convertToBson(exportValue(call.Arguments[1]))
 		cmd := bson.D{{Key: "grantRolesToUser", Value: name}, {Key: "roles", Value: roles}}
-		return ec.rt.ToValue(runDBCommand(ec, "grantRolesToUser", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "grantRolesToUser", cmd))
 	}
 }
 
@@ -178,7 +178,7 @@ func dbRevokeRolesFromUser(ec *execContext) func(goja.FunctionCall) goja.Value {
 		name := call.Arguments[0].String()
 		roles := convertToBson(exportValue(call.Arguments[1]))
 		cmd := bson.D{{Key: "revokeRolesFromUser", Value: name}, {Key: "roles", Value: roles}}
-		return ec.rt.ToValue(runDBCommand(ec, "revokeRolesFromUser", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "revokeRolesFromUser", cmd))
 	}
 }
 
@@ -186,6 +186,6 @@ func dbDropAllUsers(ec *execContext) func(goja.FunctionCall) goja.Value {
 	return func(call goja.FunctionCall) goja.Value {
 		requireClient(ec)
 		cmd := bson.D{{Key: "dropAllUsersFromDatabase", Value: 1}}
-		return ec.rt.ToValue(runDBCommand(ec, "dropAllUsers", cmd))
+		return toJSValue(ec.rt, runDBCommand(ec, "dropAllUsers", cmd))
 	}
 }

--- a/internal/queryengine/proxy_db_users_integration_test.go
+++ b/internal/queryengine/proxy_db_users_integration_test.go
@@ -25,14 +25,14 @@ func TestIntegration_CreateUser_GetUser_DropUser(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getUser("alice")`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "alice")
+	assert.Contains(t, resultText(result), "alice")
 
 	_, err = engine.ExecuteQuery(ctx, testURI, db, `db.dropUser("alice")`)
 	require.NoError(t, err)
 
 	result, err = engine.ExecuteQuery(ctx, testURI, db, `db.getUser("alice")`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "null")
+	assert.Contains(t, resultText(result), "null")
 }
 
 func TestIntegration_GetUsers(t *testing.T) {
@@ -50,8 +50,8 @@ func TestIntegration_GetUsers(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getUsers()`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "u1")
-	assert.Contains(t, result.RawOutput, "u2")
+	assert.Contains(t, resultText(result), "u1")
+	assert.Contains(t, resultText(result), "u2")
 }
 
 func TestIntegration_UpdateUser(t *testing.T) {
@@ -70,7 +70,7 @@ func TestIntegration_UpdateUser(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getUser("bob")`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "read")
+	assert.Contains(t, resultText(result), "read")
 }
 
 func TestIntegration_ChangeUserPassword(t *testing.T) {
@@ -104,7 +104,7 @@ func TestIntegration_GrantRevokeRolesToUser(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getUser("dan")`)
 	require.NoError(t, err)
-	assert.Contains(t, result.RawOutput, "read")
+	assert.Contains(t, resultText(result), "read")
 
 	_, err = engine.ExecuteQuery(ctx, testURI, db, `db.revokeRolesFromUser("dan", [{ role: "read", db: "`+db+`" }])`)
 	require.NoError(t, err)
@@ -128,6 +128,6 @@ func TestIntegration_DropAllUsers(t *testing.T) {
 
 	result, err := engine.ExecuteQuery(ctx, testURI, db, `db.getUsers()`)
 	require.NoError(t, err)
-	assert.NotContains(t, result.RawOutput, "e1")
-	assert.NotContains(t, result.RawOutput, "e2")
+	assert.NotContains(t, resultText(result), "e1")
+	assert.NotContains(t, resultText(result), "e2")
 }

--- a/internal/schema/accretion.go
+++ b/internal/schema/accretion.go
@@ -8,8 +8,7 @@ import (
 
 	"vervet/internal/models"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func (a *accumulator) add(doc bson.M) {
@@ -70,7 +69,7 @@ func applyValue(n *fieldNode, v any) {
 		recordNum(ts, float64(val))
 	case float64:
 		recordNum(ts, val)
-	case primitive.DateTime:
+	case bson.DateTime:
 		recordNum(ts, float64(val))
 	case time.Time:
 		recordNum(ts, float64(val.UnixMilli()))
@@ -134,15 +133,15 @@ func bsonTypeName(v any) string {
 		return "long"
 	case float64:
 		return "double"
-	case primitive.Decimal128:
+	case bson.Decimal128:
 		return "decimal"
-	case primitive.ObjectID:
+	case bson.ObjectID:
 		return "objectId"
-	case primitive.DateTime, time.Time:
+	case bson.DateTime, time.Time:
 		return "date"
-	case primitive.Binary:
+	case bson.Binary:
 		return "binary"
-	case primitive.Regex:
+	case bson.Regex:
 		return "regex"
 	case bson.M:
 		return "object"

--- a/internal/schema/sample.go
+++ b/internal/schema/sample.go
@@ -7,9 +7,9 @@ import (
 
 	"vervet/internal/models"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 const defaultSampleSize = 1000

--- a/internal/schema/sample_integration_test.go
+++ b/internal/schema/sample_integration_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mongodb"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 var testClient *mongo.Client
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("conn string: %v", err)
 	}
 
-	testClient, err = mongo.Connect(ctx, options.Client().ApplyURI(uri))
+	testClient, err = mongo.Connect(options.Client().ApplyURI(uri))
 	if err != nil {
 		log.Fatalf("connect: %v", err)
 	}

--- a/internal/schema/sample_test.go
+++ b/internal/schema/sample_test.go
@@ -7,8 +7,7 @@ import (
 
 	"vervet/internal/models"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func TestSample_NilClientReturnsError(t *testing.T) {
@@ -134,8 +133,8 @@ func TestAccretion_NullDistinctFromMissing(t *testing.T) {
 
 func TestAccretion_DateMinMax(t *testing.T) {
 	acc := newAccumulator()
-	t1 := primitive.NewDateTimeFromTime(time.Unix(1000, 0))
-	t2 := primitive.NewDateTimeFromTime(time.Unix(5000, 0))
+	t1 := bson.NewDateTimeFromTime(time.Unix(1000, 0))
+	t2 := bson.NewDateTimeFromTime(time.Unix(5000, 0))
 	acc.add(bson.M{"ts": t1})
 	acc.add(bson.M{"ts": t2})
 	schema := acc.build(2)

--- a/internal/servers/groups_test.go
+++ b/internal/servers/groups_test.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"vervet/internal/models"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateGroup(t *testing.T) {

--- a/internal/servers/store_test.go
+++ b/internal/servers/store_test.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"vervet/internal/models"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type MockConfigurationStore struct {


### PR DESCRIPTION
## Summary

Migrates the entire Go backend from `go.mongodb.org/mongo-driver` v1.17.9 to `.../v2` v2.5.0 and removes v1. Pure mechanical port except where v2 forced changes.

## Changes

- Import paths `→ /v2/`, `bson/primitive` merged into `bson`, `event → /v2/event` across 43 files.
- `mongo.Connect` drops its `ctx` param (6 sites).
- Dropped v1 from `go.mod`/`go.sum` (`go mod tidy` also removed orphaned `snappy`, `montanaflynn/stats`).

### Forced v2 deviations (behavior-preserving)

1. **Index drops** — v2 `Indexes().DropOne`/`DropAll` return only `error`, dropping the `{nIndexesWas, ok}` response the shell displays. Replaced with `RunCommand({dropIndexes, index})` to preserve it.
2. **`maxTimeMS`** — v2 removed `FindOptions.SetMaxTime`; now mapped to a `context.WithTimeout` deadline in `dispatchFind`. Classified as `QueryTimeout` on trip, so user-facing behavior is unchanged.
3. **New `js_normalize.go`** — v2 added `String()`/`MarshalJSON()` to `bson.M`/`bson.D`; goja only reflects a *method-less* map as a JS object, so the JS-shell result path regressed (property access returned `undefined`). `normalizeForJS` strips `bson.M`/`bson.D`/`map[string]any`→plain map, `bson.A`/slices→`[]any`, leaves scalar BSON types untouched. Applied via `toJSValue` at result-bearing goja sites only.

## Verification

- `go build`/`go vet`/`go test ./...` — green.
- **Integration (queryengine + schema + jsmodules) — all green.** New `TestIntegration_RunCommand_PropertyAccess` proves the normalizer end-to-end (`db.runCommand({ping:1}).ok` reachable).
- New OIDC characterization tests (written on v1, still pass on v2) guard the auth callback wiring.

## Drive-by test fix

Fixed 22 pre-existing integration failures unrelated to the driver bump: they asserted on `result.RawOutput` for queries returning objects/arrays (`getUsers`, `getRoles`, `runCommand`, `explain`, …), but structured results land in `result.Documents` by design. Added a `resultText` helper (RawOutput if set, else JSON of Documents) and assert through it. These failed identically on the v1 base.