### PR TITLE
chore(deps): bump mongo-driver v2.7 behind new integration coverage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/mongodb v0.43.0
 	github.com/wailsapp/wails/v2 v2.12.0
-	go.mongodb.org/mongo-driver/v2 v2.5.0
+	go.mongodb.org/mongo-driver/v2 v2.7.0
 	golang.org/x/image v0.44.0
 	golang.org/x/oauth2 v0.36.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
-go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
-go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
+go.mongodb.org/mongo-driver/v2 v2.7.0 h1:RO+zqavD2/GCL3cxOMyZhx6R9Irzr8/6gsoqx5tcY/c=
+go.mongodb.org/mongo-driver/v2 v2.7.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 h1:sbiXRNDSWJOTobXh5HyQKjq6wUC5tNybqjIqDpAY4CU=

--- a/internal/clientregistry/registry_integration_test.go
+++ b/internal/clientregistry/registry_integration_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+package clientregistry
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/mongodb"
+
+	"vervet/internal/models"
+)
+
+var testURI string
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+
+	container, err := mongodb.Run(ctx, "mongo:7")
+	if err != nil {
+		log.Fatalf("start container: %v", err)
+	}
+	defer func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			log.Printf("terminate: %v", err)
+		}
+	}()
+
+	testURI, err = container.ConnectionString(ctx)
+	if err != nil {
+		log.Fatalf("conn string: %v", err)
+	}
+
+	os.Exit(m.Run())
+}
+
+func newRegistry(t *testing.T) *ClientRegistry {
+	t.Helper()
+	// nil TokenManager is safe: no test exercises the AuthOIDC branch.
+	r := NewClientRegistry(slog.Default(), nil)
+	r.Init(context.Background())
+	t.Cleanup(func() { r.DisconnectAll() })
+	return r
+}
+
+func TestIntegration_Connect_RegistersAndPings(t *testing.T) {
+	r := newRegistry(t)
+
+	client, err := r.Connect("srv-1", "Primary", testURI)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	assert.True(t, r.IsConnected("srv-1"))
+
+	got, err := r.GetClient("srv-1")
+	require.NoError(t, err)
+	assert.Same(t, client, got, "GetClient must return the registered client")
+}
+
+func TestIntegration_Connect_DuplicateRejected(t *testing.T) {
+	r := newRegistry(t)
+
+	_, err := r.Connect("srv-dup", "A", testURI)
+	require.NoError(t, err)
+
+	_, err = r.Connect("srv-dup", "A again", testURI)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already connected")
+}
+
+func TestIntegration_Connect_BadURIFailsPing(t *testing.T) {
+	r := newRegistry(t)
+
+	// Port 1 has nothing listening; serverSelectionTimeoutMS keeps it quick.
+	_, err := r.Connect("srv-bad", "Bad", "mongodb://127.0.0.1:1/?serverSelectionTimeoutMS=500")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ping failed")
+
+	assert.False(t, r.IsConnected("srv-bad"), "a failed connect must not register a client")
+}
+
+func TestIntegration_ConnectWithConfig_NonOIDC(t *testing.T) {
+	r := newRegistry(t)
+
+	client, err := r.ConnectWithConfig("srv-cfg", "Cfg", models.ConnectionConfig{
+		URI:        testURI,
+		AuthMethod: models.AuthNone,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.True(t, r.IsConnected("srv-cfg"))
+}
+
+func TestIntegration_GetClient_UnknownServerErrors(t *testing.T) {
+	r := newRegistry(t)
+
+	_, err := r.GetClient("nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active connection")
+}
+
+func TestIntegration_GetAll_ReturnsEveryRegisteredClient(t *testing.T) {
+	r := newRegistry(t)
+
+	require.NoError(t, mustConnect(t, r, "a", "Alpha"))
+	require.NoError(t, mustConnect(t, r, "b", "Beta"))
+
+	all := r.GetAll()
+	require.Len(t, all, 2)
+
+	byID := map[string]string{}
+	for _, c := range all {
+		byID[c.ServerID] = c.Name
+	}
+	assert.Equal(t, "Alpha", byID["a"])
+	assert.Equal(t, "Beta", byID["b"])
+}
+
+func TestIntegration_Disconnect_RemovesClient(t *testing.T) {
+	r := newRegistry(t)
+	require.NoError(t, mustConnect(t, r, "srv-dc", "X"))
+
+	require.NoError(t, r.Disconnect("srv-dc"))
+	assert.False(t, r.IsConnected("srv-dc"))
+
+	_, err := r.GetClient("srv-dc")
+	assert.Error(t, err)
+}
+
+func TestIntegration_Disconnect_UnknownIsIdempotent(t *testing.T) {
+	r := newRegistry(t)
+	// Documented behaviour: disconnecting an absent server is success, so the
+	// frontend can retry against stale state without a warning.
+	assert.NoError(t, r.Disconnect("never-connected"))
+}
+
+func TestIntegration_DisconnectAll_ClearsRegistry(t *testing.T) {
+	r := newRegistry(t)
+	require.NoError(t, mustConnect(t, r, "x", "X"))
+	require.NoError(t, mustConnect(t, r, "y", "Y"))
+
+	require.NoError(t, r.DisconnectAll())
+
+	assert.Empty(t, r.GetAll())
+	assert.False(t, r.IsConnected("x"))
+	assert.False(t, r.IsConnected("y"))
+}
+
+func mustConnect(t *testing.T, r *ClientRegistry, id, name string) error {
+	t.Helper()
+	_, err := r.Connect(id, name, testURI)
+	return err
+}

--- a/internal/collections/service_integration_test.go
+++ b/internal/collections/service_integration_test.go
@@ -1,0 +1,220 @@
+//go:build integration
+
+package collections
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/mongodb"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+var testClient *mongo.Client
+
+type stubProvider struct {
+	client *mongo.Client
+	err    error
+}
+
+func (s stubProvider) GetClient(string) (*mongo.Client, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.client, nil
+}
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+
+	container, err := mongodb.Run(ctx, "mongo:7")
+	if err != nil {
+		log.Fatalf("start container: %v", err)
+	}
+	defer func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			log.Printf("terminate: %v", err)
+		}
+	}()
+
+	uri, err := container.ConnectionString(ctx)
+	if err != nil {
+		log.Fatalf("conn string: %v", err)
+	}
+
+	testClient, err = mongo.Connect(options.Client().ApplyURI(uri))
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer testClient.Disconnect(ctx)
+
+	os.Exit(m.Run())
+}
+
+func newService(t *testing.T) *CollectionsService {
+	t.Helper()
+	svc := NewCollectionsService(slog.Default(), stubProvider{client: testClient})
+	svc.Init(context.Background())
+	return svc
+}
+
+func seedColl(t *testing.T, dbName, collName string) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := testClient.Database(dbName).Collection(collName).InsertOne(ctx, bson.M{"x": 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { testClient.Database(dbName).Drop(ctx) })
+}
+
+func TestIntegration_GetCollections_ListsAndSorts(t *testing.T) {
+	db := "coll_list"
+	seedColl(t, db, "zebra")
+	seedColl(t, db, "alpha")
+
+	names, err := newService(t).GetCollections("srv", db)
+	require.NoError(t, err)
+
+	assert.Contains(t, names, "alpha")
+	assert.Contains(t, names, "zebra")
+	assert.True(t, slices.IsSorted(names), "want sorted, got %v", names)
+}
+
+func TestIntegration_GetViews_ReturnsOnlyViews(t *testing.T) {
+	ctx := context.Background()
+	db := "coll_views"
+	seedColl(t, db, "base")
+
+	err := testClient.Database(db).RunCommand(ctx, bson.D{
+		{Key: "create", Value: "myview"},
+		{Key: "viewOn", Value: "base"},
+		{Key: "pipeline", Value: bson.A{}},
+	}).Err()
+	require.NoError(t, err)
+
+	views, err := newService(t).GetViews("srv", db)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"myview"}, views)
+	assert.NotContains(t, views, "base")
+}
+
+func TestIntegration_CreateCollection_ThenListed(t *testing.T) {
+	ctx := context.Background()
+	db := "coll_create"
+	t.Cleanup(func() { testClient.Database(db).Drop(ctx) })
+
+	svc := newService(t)
+	require.NoError(t, svc.CreateCollection("srv", db, "fresh"))
+
+	names, err := svc.GetCollections("srv", db)
+	require.NoError(t, err)
+	assert.Contains(t, names, "fresh")
+}
+
+// MongoDB's create command is idempotent when the existing collection's options
+// match, so re-creating is success rather than a NamespaceExists error.
+func TestIntegration_CreateCollection_DuplicateIsNoOp(t *testing.T) {
+	db := "coll_dup"
+	seedColl(t, db, "dup")
+
+	assert.NoError(t, newService(t).CreateCollection("srv", db, "dup"))
+}
+
+func TestIntegration_CreateCollection_InvalidNameErrors(t *testing.T) {
+	db := "coll_invalid"
+
+	err := newService(t).CreateCollection("srv", db, "bad$name")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create collection")
+}
+
+func TestIntegration_RenameCollection_MovesDocuments(t *testing.T) {
+	ctx := context.Background()
+	db := "coll_rename"
+	seedColl(t, db, "oldname")
+
+	svc := newService(t)
+	require.NoError(t, svc.RenameCollection("srv", db, "oldname", "newname"))
+
+	names, err := svc.GetCollections("srv", db)
+	require.NoError(t, err)
+	assert.Contains(t, names, "newname")
+	assert.NotContains(t, names, "oldname")
+
+	count, err := testClient.Database(db).Collection("newname").CountDocuments(ctx, bson.D{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "documents must survive the rename")
+}
+
+func TestIntegration_RenameCollection_RejectsEmptyName(t *testing.T) {
+	err := newService(t).RenameCollection("srv", "any", "old", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be empty")
+}
+
+func TestIntegration_RenameCollection_RejectsIdenticalName(t *testing.T) {
+	err := newService(t).RenameCollection("srv", "any", "same", "same")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must differ")
+}
+
+func TestIntegration_DropCollection_RemovesIt(t *testing.T) {
+	db := "coll_drop"
+	seedColl(t, db, "goner")
+
+	svc := newService(t)
+	require.NoError(t, svc.DropCollection("srv", db, "goner"))
+
+	names, err := svc.GetCollections("srv", db)
+	require.NoError(t, err)
+	assert.NotContains(t, names, "goner")
+}
+
+func TestIntegration_GetStatistics_ReturnsCollStats(t *testing.T) {
+	db := "coll_stats"
+	seedColl(t, db, "c")
+
+	stats, err := newService(t).GetStatistics("srv", db, "c")
+	require.NoError(t, err)
+
+	assert.Contains(t, stats, "count")
+	assert.Contains(t, stats, "size")
+}
+
+func TestIntegration_GetServerStatistics_ReturnsServerStatus(t *testing.T) {
+	stats, err := newService(t).GetServerStatistics("srv")
+	require.NoError(t, err)
+
+	assert.Contains(t, stats, "host")
+	assert.Contains(t, stats, "version")
+}
+
+func TestIntegration_SampleSchema_InfersFields(t *testing.T) {
+	db := "coll_sample"
+	seedColl(t, db, "c")
+
+	// SampleSchema takes its own ctx rather than using s.ctx.
+	schema, err := newService(t).SampleSchema(context.Background(), "srv", db, "c", 100)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), schema.TotalCount)
+	assert.NotZero(t, schema.SampledCount)
+}
+
+func TestIntegration_GetCollections_PropagatesProviderError(t *testing.T) {
+	svc := NewCollectionsService(slog.Default(), stubProvider{err: assert.AnError})
+	svc.Init(context.Background())
+
+	_, err := svc.GetCollections("srv", "any")
+	assert.ErrorIs(t, err, assert.AnError)
+}

--- a/internal/connections/manager.go
+++ b/internal/connections/manager.go
@@ -30,6 +30,10 @@ type ConnectionManager struct {
 	store          connectionStrings.Store
 	serverProvider ServerProvider
 	log            *slog.Logger
+
+	// emit is a seam over runtime.EventsEmit. Wails resolves its emitter from
+	// the context and log.Fatalf's when absent, so tests must replace this.
+	emit func(ctx context.Context, eventName string, optionalData ...interface{})
 }
 
 type ServerProvider interface {
@@ -43,6 +47,7 @@ func NewManager(log *slog.Logger, registry *clientregistry.ClientRegistry, store
 		registry:       registry,
 		store:          store,
 		serverProvider: provider,
+		emit:           runtime.EventsEmit,
 	}
 }
 
@@ -80,7 +85,7 @@ func (cm *ConnectionManager) Connect(serverID string) (models.Connection, error)
 	}
 
 	cm.log.Debug("Successfully connected to MongoDB", slog.String("serverID", serverID))
-	runtime.EventsEmit(cm.ctx, ConnectedEvent, serverID)
+	cm.emit(cm.ctx, ConnectedEvent, serverID)
 
 	return models.Connection{
 		ServerID: serverID,
@@ -143,7 +148,7 @@ func (cm *ConnectionManager) Disconnect(serverID string) error {
 	// Always emit the event: the registry removes the client from its map
 	// even when the underlying driver disconnect fails, so the frontend
 	// must know the connection is gone.
-	runtime.EventsEmit(cm.ctx, DisconnectedEvent, serverID)
+	cm.emit(cm.ctx, DisconnectedEvent, serverID)
 
 	if err != nil {
 		return err
@@ -160,7 +165,7 @@ func (cm *ConnectionManager) DisconnectAll() error {
 	err := cm.registry.DisconnectAll()
 
 	for _, c := range all {
-		runtime.EventsEmit(cm.ctx, DisconnectedEvent, c.ServerID)
+		cm.emit(cm.ctx, DisconnectedEvent, c.ServerID)
 	}
 
 	if err != nil {

--- a/internal/connections/manager_integration_test.go
+++ b/internal/connections/manager_integration_test.go
@@ -1,0 +1,264 @@
+//go:build integration
+
+package connections
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/mongodb"
+
+	"vervet/internal/clientregistry"
+	"vervet/internal/models"
+)
+
+var testURI string
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+
+	container, err := mongodb.Run(ctx, "mongo:7")
+	if err != nil {
+		log.Fatalf("start container: %v", err)
+	}
+	defer func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			log.Printf("terminate: %v", err)
+		}
+	}()
+
+	testURI, err = container.ConnectionString(ctx)
+	if err != nil {
+		log.Fatalf("conn string: %v", err)
+	}
+
+	os.Exit(m.Run())
+}
+
+// fakeServerProvider satisfies ServerProvider.
+type fakeServerProvider struct {
+	servers map[string]*models.RegisteredServer
+}
+
+func (f fakeServerProvider) GetServer(id string) (*models.RegisteredServer, error) {
+	s, ok := f.servers[id]
+	if !ok {
+		return nil, fmt.Errorf("no server %s", id)
+	}
+	return s, nil
+}
+
+// fakeStore satisfies connectionStrings.Store. Only GetConnectionConfig is
+// exercised; the rest are present to satisfy the interface.
+type fakeStore struct {
+	configs map[string]models.ConnectionConfig
+}
+
+func (f fakeStore) StoreRegisteredServerURI(string, string) error               { return nil }
+func (f fakeStore) GetRegisteredServerURI(string) (string, error)               { return "", nil }
+func (f fakeStore) DeleteRegisteredServerURI(string) error                      { return nil }
+func (f fakeStore) StoreConnectionConfig(string, models.ConnectionConfig) error { return nil }
+func (f fakeStore) UpdateRefreshToken(string, string) error                     { return nil }
+
+func (f fakeStore) GetConnectionConfig(id string) (models.ConnectionConfig, error) {
+	cfg, ok := f.configs[id]
+	if !ok {
+		return models.ConnectionConfig{}, fmt.Errorf("no config for %s", id)
+	}
+	return cfg, nil
+}
+
+// recorder captures emitted Wails events in place of runtime.EventsEmit.
+type recorder struct {
+	mu     sync.Mutex
+	events []event
+}
+
+type event struct {
+	name string
+	data []interface{}
+}
+
+func (r *recorder) emit(_ context.Context, name string, data ...interface{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event{name: name, data: data})
+}
+
+func (r *recorder) names() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, 0, len(r.events))
+	for _, e := range r.events {
+		out = append(out, e.name)
+	}
+	return out
+}
+
+// newManager wires a real ClientRegistry to the container, a fake store and a
+// fake server provider, and replaces the Wails emitter with a recorder.
+func newManager(t *testing.T, serverID, name string, cfg models.ConnectionConfig) (*ConnectionManager, *recorder) {
+	t.Helper()
+
+	registry := clientregistry.NewClientRegistry(slog.Default(), nil)
+	registry.Init(context.Background())
+	t.Cleanup(func() { registry.DisconnectAll() })
+
+	provider := fakeServerProvider{servers: map[string]*models.RegisteredServer{
+		serverID: {ID: serverID, Name: name},
+	}}
+	store := fakeStore{configs: map[string]models.ConnectionConfig{serverID: cfg}}
+
+	cm := NewManager(slog.Default(), registry, store, provider)
+	require.NoError(t, cm.Init(context.Background()))
+
+	rec := &recorder{}
+	cm.emit = rec.emit
+	return cm, rec
+}
+
+func TestIntegration_Connect_EmitsConnectedEvent(t *testing.T) {
+	cm, rec := newManager(t, "srv-1", "Primary", models.ConnectionConfig{
+		URI: testURI, AuthMethod: models.AuthNone,
+	})
+
+	conn, err := cm.Connect("srv-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, "srv-1", conn.ServerID)
+	assert.Equal(t, "Primary", conn.Name)
+	assert.Equal(t, []string{ConnectedEvent}, rec.names())
+}
+
+func TestIntegration_Connect_DuplicateRejectedAndEmitsNothing(t *testing.T) {
+	cm, rec := newManager(t, "srv-dup", "Dup", models.ConnectionConfig{
+		URI: testURI, AuthMethod: models.AuthNone,
+	})
+
+	_, err := cm.Connect("srv-dup")
+	require.NoError(t, err)
+
+	_, err = cm.Connect("srv-dup")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already connected")
+
+	assert.Equal(t, []string{ConnectedEvent}, rec.names(), "the rejected connect must not emit")
+}
+
+func TestIntegration_Connect_UnknownServerErrors(t *testing.T) {
+	cm, rec := newManager(t, "srv-known", "K", models.ConnectionConfig{
+		URI: testURI, AuthMethod: models.AuthNone,
+	})
+
+	_, err := cm.Connect("srv-unknown")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error retrieving server")
+	assert.Empty(t, rec.names())
+}
+
+func TestIntegration_GetConnections_ReflectsRegistry(t *testing.T) {
+	cm, _ := newManager(t, "srv-list", "Listed", models.ConnectionConfig{
+		URI: testURI, AuthMethod: models.AuthNone,
+	})
+
+	assert.Empty(t, cm.GetConnections())
+
+	_, err := cm.Connect("srv-list")
+	require.NoError(t, err)
+
+	conns := cm.GetConnections()
+	require.Len(t, conns, 1)
+	assert.Equal(t, "srv-list", conns[0].ServerID)
+	assert.Equal(t, "Listed", conns[0].Name)
+}
+
+func TestIntegration_Disconnect_EmitsDisconnectedEvent(t *testing.T) {
+	cm, rec := newManager(t, "srv-dc", "D", models.ConnectionConfig{
+		URI: testURI, AuthMethod: models.AuthNone,
+	})
+
+	_, err := cm.Connect("srv-dc")
+	require.NoError(t, err)
+	require.NoError(t, cm.Disconnect("srv-dc"))
+
+	assert.Equal(t, []string{ConnectedEvent, DisconnectedEvent}, rec.names())
+	assert.Empty(t, cm.GetConnections())
+}
+
+// Disconnecting an unknown server still emits, because the registry treats it
+// as success and the frontend must converge on "disconnected".
+func TestIntegration_Disconnect_UnknownStillEmits(t *testing.T) {
+	cm, rec := newManager(t, "srv-any", "A", models.ConnectionConfig{
+		URI: testURI, AuthMethod: models.AuthNone,
+	})
+
+	require.NoError(t, cm.Disconnect("never-connected"))
+	assert.Equal(t, []string{DisconnectedEvent}, rec.names())
+}
+
+func TestIntegration_DisconnectAll_EmitsPerServer(t *testing.T) {
+	cm, rec := newManager(t, "srv-1", "One", models.ConnectionConfig{
+		URI: testURI, AuthMethod: models.AuthNone,
+	})
+
+	_, err := cm.Connect("srv-1")
+	require.NoError(t, err)
+	require.NoError(t, cm.DisconnectAll())
+
+	assert.Equal(t, []string{ConnectedEvent, DisconnectedEvent}, rec.names())
+	assert.Empty(t, cm.GetConnections())
+}
+
+func TestIntegration_TestConnection_Succeeds(t *testing.T) {
+	cm, _ := newManager(t, "srv-t", "T", models.ConnectionConfig{
+		URI: testURI, AuthMethod: models.AuthNone,
+	})
+
+	ok, err := cm.TestConnection(testURI)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestIntegration_TestConnection_BadURIFails(t *testing.T) {
+	cm, _ := newManager(t, "srv-t", "T", models.ConnectionConfig{
+		URI: testURI, AuthMethod: models.AuthNone,
+	})
+
+	ok, err := cm.TestConnection("mongodb://127.0.0.1:1/?serverSelectionTimeoutMS=500")
+	require.Error(t, err)
+	assert.False(t, ok)
+}
+
+func TestIntegration_TestConnectionWithConfig_Succeeds(t *testing.T) {
+	cm, _ := newManager(t, "srv-t", "T", models.ConnectionConfig{
+		URI: testURI, AuthMethod: models.AuthNone,
+	})
+
+	ok, err := cm.TestConnectionWithConfig(context.Background(), models.ConnectionConfig{
+		URI: testURI, AuthMethod: models.AuthNone,
+	})
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestIntegration_TestConnectionWithConfig_RejectsOIDC(t *testing.T) {
+	cm, _ := newManager(t, "srv-t", "T", models.ConnectionConfig{
+		URI: testURI, AuthMethod: models.AuthNone,
+	})
+
+	ok, err := cm.TestConnectionWithConfig(context.Background(), models.ConnectionConfig{
+		URI: testURI, AuthMethod: models.AuthOIDC,
+	})
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Contains(t, err.Error(), "not supported for OIDC")
+}

--- a/internal/connections/manager_test.go
+++ b/internal/connections/manager_test.go
@@ -1,0 +1,34 @@
+package connections
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewManager_DefaultsEmitToWailsRuntime(t *testing.T) {
+	cm := NewManager(slog.Default(), nil, nil, nil)
+	require.NotNil(t, cm.emit, "emit must be defaulted so production keeps emitting events")
+}
+
+func TestNewManager_EmitIsOverridable(t *testing.T) {
+	cm := NewManager(slog.Default(), nil, nil, nil)
+
+	type captured struct {
+		name string
+		data []interface{}
+	}
+	var got []captured
+	cm.emit = func(_ context.Context, name string, data ...interface{}) {
+		got = append(got, captured{name: name, data: data})
+	}
+
+	cm.emit(context.Background(), ConnectedEvent, "server-1")
+
+	require.Len(t, got, 1)
+	assert.Equal(t, ConnectedEvent, got[0].name)
+	assert.Equal(t, []interface{}{"server-1"}, got[0].data)
+}

--- a/internal/databases/service_integration_test.go
+++ b/internal/databases/service_integration_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package databases
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/mongodb"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+var testClient *mongo.Client
+
+// stubProvider satisfies ClientProvider, handing every caller the container client.
+type stubProvider struct {
+	client *mongo.Client
+	err    error
+}
+
+func (s stubProvider) GetClient(string) (*mongo.Client, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.client, nil
+}
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+
+	container, err := mongodb.Run(ctx, "mongo:7")
+	if err != nil {
+		log.Fatalf("start container: %v", err)
+	}
+	defer func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			log.Printf("terminate: %v", err)
+		}
+	}()
+
+	uri, err := container.ConnectionString(ctx)
+	if err != nil {
+		log.Fatalf("conn string: %v", err)
+	}
+
+	testClient, err = mongo.Connect(options.Client().ApplyURI(uri))
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer testClient.Disconnect(ctx)
+
+	os.Exit(m.Run())
+}
+
+func newService(t *testing.T) *DatabasesService {
+	t.Helper()
+	svc := NewDatabasesService(slog.Default(), stubProvider{client: testClient})
+	svc.Init(context.Background())
+	return svc
+}
+
+func seed(t *testing.T, dbName string) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := testClient.Database(dbName).Collection("seed").InsertOne(ctx, bson.M{"x": 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { testClient.Database(dbName).Drop(ctx) })
+}
+
+func TestIntegration_GetDatabases_ListsAndSorts(t *testing.T) {
+	seed(t, "zz_db_list")
+	seed(t, "aa_db_list")
+
+	names, err := newService(t).GetDatabases("srv")
+	require.NoError(t, err)
+
+	assert.Contains(t, names, "aa_db_list")
+	assert.Contains(t, names, "zz_db_list")
+	assert.True(t, slices.IsSorted(names), "GetDatabases must return sorted names, got %v", names)
+}
+
+func TestIntegration_GetDatabases_PropagatesProviderError(t *testing.T) {
+	svc := NewDatabasesService(slog.Default(), stubProvider{err: assert.AnError})
+	svc.Init(context.Background())
+
+	_, err := svc.GetDatabases("srv")
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func TestIntegration_GetDatabaseStatistics_ReturnsDbStats(t *testing.T) {
+	seed(t, "db_stats_test")
+
+	stats, err := newService(t).GetDatabaseStatistics("srv", "db_stats_test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "db_stats_test", stats["db"])
+	assert.Contains(t, stats, "collections")
+	assert.Contains(t, stats, "dataSize")
+}
+
+func TestIntegration_DropDatabase_RemovesIt(t *testing.T) {
+	ctx := context.Background()
+	seed(t, "db_to_drop")
+
+	svc := newService(t)
+	require.NoError(t, svc.DropDatabase("srv", "db_to_drop"))
+
+	names, err := testClient.ListDatabaseNames(ctx, bson.D{})
+	require.NoError(t, err)
+	assert.NotContains(t, names, "db_to_drop")
+}
+
+func TestIntegration_DropDatabase_NonExistentIsNoError(t *testing.T) {
+	// MongoDB treats dropping an absent database as success.
+	assert.NoError(t, newService(t).DropDatabase("srv", "never_existed_xyz"))
+}

--- a/internal/indexes/service.go
+++ b/internal/indexes/service.go
@@ -91,17 +91,8 @@ func (s *IndexService) GetIndexes(serverID, dbName, collectionName string) ([]mo
 		{Key: "collStats", Value: collectionName},
 	}).Decode(&collStatsResult)
 	if err == nil {
-		if indexSizes, ok := collStatsResult["indexSizes"].(bson.M); ok {
-			for name, size := range indexSizes {
-				switch v := size.(type) {
-				case int32:
-					sizeMap[name] = int64(v)
-				case int64:
-					sizeMap[name] = v
-				case float64:
-					sizeMap[name] = int64(v)
-				}
-			}
+		for name, size := range indexSizesFrom(collStatsResult["indexSizes"]) {
+			sizeMap[name] = size
 		}
 	}
 
@@ -235,6 +226,37 @@ func (s *IndexService) buildIndexModel(keys []models.IndexKeyField, name string,
 		Keys:    bsonKeys,
 		Options: indexOpts,
 	}
+}
+
+// indexSizesFrom normalises the collStats "indexSizes" sub-document. The driver
+// decodes nested documents as bson.D even when the parent decodes into bson.M,
+// so accept both rather than silently reporting every index as zero bytes.
+func indexSizesFrom(raw any) map[string]int64 {
+	sizes := make(map[string]int64)
+
+	add := func(name string, value any) {
+		switch v := value.(type) {
+		case int32:
+			sizes[name] = int64(v)
+		case int64:
+			sizes[name] = v
+		case float64:
+			sizes[name] = int64(v)
+		}
+	}
+
+	switch doc := raw.(type) {
+	case bson.D:
+		for _, elem := range doc {
+			add(elem.Key, elem.Value)
+		}
+	case bson.M:
+		for name, value := range doc {
+			add(name, value)
+		}
+	}
+
+	return sizes
 }
 
 func (s *IndexService) captureIndex(collection *mongo.Collection, indexName string) (*mongo.IndexModel, error) {

--- a/internal/indexes/service_integration_test.go
+++ b/internal/indexes/service_integration_test.go
@@ -1,0 +1,283 @@
+//go:build integration
+
+package indexes
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/mongodb"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"vervet/internal/models"
+)
+
+var testClient *mongo.Client
+
+type stubProvider struct {
+	client *mongo.Client
+	err    error
+}
+
+func (s stubProvider) GetClient(string) (*mongo.Client, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.client, nil
+}
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+
+	container, err := mongodb.Run(ctx, "mongo:7")
+	if err != nil {
+		log.Fatalf("start container: %v", err)
+	}
+	defer func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			log.Printf("terminate: %v", err)
+		}
+	}()
+
+	uri, err := container.ConnectionString(ctx)
+	if err != nil {
+		log.Fatalf("conn string: %v", err)
+	}
+
+	testClient, err = mongo.Connect(options.Client().ApplyURI(uri))
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer testClient.Disconnect(ctx)
+
+	os.Exit(m.Run())
+}
+
+func newService(t *testing.T) *IndexService {
+	t.Helper()
+	svc := NewIndexService(slog.Default(), stubProvider{client: testClient})
+	svc.Init(context.Background())
+	return svc
+}
+
+// seedIdx creates a database with one collection holding one document, and
+// registers cleanup. Returns the db name.
+func seedIdx(t *testing.T, dbName string) string {
+	t.Helper()
+	ctx := context.Background()
+	_, err := testClient.Database(dbName).Collection("c").InsertOne(ctx, bson.M{"email": "a@b.c", "age": 1})
+	require.NoError(t, err)
+	t.Cleanup(func() { testClient.Database(dbName).Drop(ctx) })
+	return dbName
+}
+
+func findIndex(t *testing.T, list []models.Index, name string) models.Index {
+	t.Helper()
+	for _, idx := range list {
+		if idx.Name == name {
+			return idx
+		}
+	}
+	t.Fatalf("index %q not found in %+v", name, list)
+	return models.Index{}
+}
+
+func TestIntegration_GetIndexes_IncludesDefaultIdIndex(t *testing.T) {
+	db := seedIdx(t, "idx_default")
+
+	list, err := newService(t).GetIndexes("srv", db, "c")
+	require.NoError(t, err)
+
+	idIdx := findIndex(t, list, "_id_")
+	require.Len(t, idIdx.Keys, 1)
+	assert.Equal(t, "_id", idIdx.Keys[0].Field)
+}
+
+func TestIntegration_CreateIndex_UniqueSparseAndKeys(t *testing.T) {
+	db := seedIdx(t, "idx_create")
+	svc := newService(t)
+
+	err := svc.CreateIndex("srv", db, "c", models.CreateIndexRequest{
+		Name:   "email_unique",
+		Keys:   []models.IndexKeyField{{Field: "email", Direction: 1}},
+		Unique: true,
+		Sparse: true,
+	})
+	require.NoError(t, err)
+
+	list, err := svc.GetIndexes("srv", db, "c")
+	require.NoError(t, err)
+
+	idx := findIndex(t, list, "email_unique")
+	assert.True(t, idx.Unique)
+	assert.True(t, idx.Sparse)
+	require.Len(t, idx.Keys, 1)
+	assert.Equal(t, "email", idx.Keys[0].Field)
+}
+
+// buildIndexModel coerces float64 directions to int, because JSON decodes all
+// numbers as float64. Guard that conversion.
+func TestIntegration_CreateIndex_CoercesFloat64Direction(t *testing.T) {
+	db := seedIdx(t, "idx_float_dir")
+	svc := newService(t)
+
+	err := svc.CreateIndex("srv", db, "c", models.CreateIndexRequest{
+		Name: "age_desc",
+		Keys: []models.IndexKeyField{{Field: "age", Direction: float64(-1)}},
+	})
+	require.NoError(t, err, "float64(-1) direction must be coerced to int(-1)")
+
+	list, err := svc.GetIndexes("srv", db, "c")
+	require.NoError(t, err)
+	findIndex(t, list, "age_desc")
+}
+
+func TestIntegration_CreateIndex_TTL(t *testing.T) {
+	db := seedIdx(t, "idx_ttl")
+	svc := newService(t)
+
+	ttl := int32(3600)
+	err := svc.CreateIndex("srv", db, "c", models.CreateIndexRequest{
+		Name: "ttl_idx",
+		Keys: []models.IndexKeyField{{Field: "createdAt", Direction: 1}},
+		TTL:  &ttl,
+	})
+	require.NoError(t, err)
+
+	list, err := svc.GetIndexes("srv", db, "c")
+	require.NoError(t, err)
+
+	idx := findIndex(t, list, "ttl_idx")
+	require.NotNil(t, idx.TTL, "TTL must round-trip from expireAfterSeconds")
+	assert.Equal(t, int32(3600), *idx.TTL)
+}
+
+// This is the bug test. It fails against current main: collStats decodes
+// indexSizes as bson.D, not bson.M, so the type assertion in GetIndexes never
+// fires and every Size stays 0.
+func TestIntegration_GetIndexes_ReportsSize(t *testing.T) {
+	db := seedIdx(t, "idx_size")
+
+	list, err := newService(t).GetIndexes("srv", db, "c")
+	require.NoError(t, err)
+
+	idIdx := findIndex(t, list, "_id_")
+	assert.Greater(t, idIdx.Size, int64(0),
+		"index Size must be populated from collStats.indexSizes; got 0, meaning the type assertion failed")
+}
+
+func TestIntegration_EditIndex_SameNameRecreates(t *testing.T) {
+	db := seedIdx(t, "idx_edit_same")
+	svc := newService(t)
+
+	require.NoError(t, svc.CreateIndex("srv", db, "c", models.CreateIndexRequest{
+		Name: "e", Keys: []models.IndexKeyField{{Field: "email", Direction: 1}},
+	}))
+
+	err := svc.EditIndex("srv", db, "c", models.EditIndexRequest{
+		OldName: "e",
+		Name:    "e",
+		Keys:    []models.IndexKeyField{{Field: "email", Direction: 1}},
+		Unique:  true,
+	})
+	require.NoError(t, err)
+
+	list, err := svc.GetIndexes("srv", db, "c")
+	require.NoError(t, err)
+	assert.True(t, findIndex(t, list, "e").Unique, "edit must apply the new unique flag")
+}
+
+func TestIntegration_EditIndex_RenameCreatesThenDrops(t *testing.T) {
+	db := seedIdx(t, "idx_edit_rename")
+	svc := newService(t)
+
+	require.NoError(t, svc.CreateIndex("srv", db, "c", models.CreateIndexRequest{
+		Name: "old_idx", Keys: []models.IndexKeyField{{Field: "email", Direction: 1}},
+	}))
+
+	err := svc.EditIndex("srv", db, "c", models.EditIndexRequest{
+		OldName: "old_idx",
+		Name:    "new_idx",
+		Keys:    []models.IndexKeyField{{Field: "age", Direction: 1}},
+	})
+	require.NoError(t, err)
+
+	list, err := svc.GetIndexes("srv", db, "c")
+	require.NoError(t, err)
+
+	findIndex(t, list, "new_idx")
+	for _, idx := range list {
+		assert.NotEqual(t, "old_idx", idx.Name, "old index must be dropped after rename")
+	}
+}
+
+// When same-name recreation fails, EditIndex restores the original index.
+// A unique index over duplicate values cannot be built, forcing that path.
+func TestIntegration_EditIndex_RestoresOriginalOnFailure(t *testing.T) {
+	ctx := context.Background()
+	db := seedIdx(t, "idx_edit_rollback")
+	svc := newService(t)
+
+	// Two docs sharing an email make a unique index impossible.
+	_, err := testClient.Database(db).Collection("c").InsertOne(ctx, bson.M{"email": "a@b.c", "age": 2})
+	require.NoError(t, err)
+
+	require.NoError(t, svc.CreateIndex("srv", db, "c", models.CreateIndexRequest{
+		Name: "email_idx", Keys: []models.IndexKeyField{{Field: "email", Direction: 1}},
+	}))
+
+	err = svc.EditIndex("srv", db, "c", models.EditIndexRequest{
+		OldName: "email_idx",
+		Name:    "email_idx",
+		Keys:    []models.IndexKeyField{{Field: "email", Direction: 1}},
+		Unique:  true,
+	})
+	require.Error(t, err, "unique index over duplicate emails must fail")
+	assert.Contains(t, err.Error(), "failed to create replacement index")
+
+	list, err := svc.GetIndexes("srv", db, "c")
+	require.NoError(t, err)
+	restored := findIndex(t, list, "email_idx")
+	assert.False(t, restored.Unique, "original non-unique index must be restored")
+}
+
+func TestIntegration_DropIndex_RemovesIt(t *testing.T) {
+	db := seedIdx(t, "idx_drop")
+	svc := newService(t)
+
+	require.NoError(t, svc.CreateIndex("srv", db, "c", models.CreateIndexRequest{
+		Name: "doomed", Keys: []models.IndexKeyField{{Field: "email", Direction: 1}},
+	}))
+	require.NoError(t, svc.DropIndex("srv", db, "c", "doomed"))
+
+	list, err := svc.GetIndexes("srv", db, "c")
+	require.NoError(t, err)
+	for _, idx := range list {
+		assert.NotEqual(t, "doomed", idx.Name)
+	}
+}
+
+func TestIntegration_DropIndex_UnknownErrors(t *testing.T) {
+	db := seedIdx(t, "idx_drop_unknown")
+
+	err := newService(t).DropIndex("srv", db, "c", "no_such_index")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to drop index")
+}
+
+func TestIntegration_GetIndexes_PropagatesProviderError(t *testing.T) {
+	svc := NewIndexService(slog.Default(), stubProvider{err: assert.AnError})
+	svc.Init(context.Background())
+
+	_, err := svc.GetIndexes("srv", "any", "c")
+	assert.ErrorIs(t, err, assert.AnError)
+}


### PR DESCRIPTION
Bumps `mongo-driver/v2` from v2.5.0 to v2.7.0, landed behind new integration coverage for every driver-facing package — so the bump has real regression protection rather than a green build.

## Coverage

Five packages went from near-zero to covered, each with a `//go:build integration` suite backed by a real `mongo:7` testcontainer:

| Package | Before | After |
|---|---|---|
| `internal/databases` | 0.0% | 83.9% |
| `internal/collections` | 0.0% | 84.0% |
| `internal/indexes` | 0.0% | 84.4% |
| `internal/clientregistry` | 20.8% | 75.5% |
| `internal/connections` | 10.7% | 85.3% |

## Bug found and fixed: every index reported a size of 0 bytes

`internal/indexes/service.go` type-asserted the `collStats` `indexSizes` sub-document to `bson.M`. The driver decodes nested documents as `bson.D` even when the parent decodes into `bson.M`, so the assertion never fired, `sizeMap` stayed empty, and every `models.Index.Size` was `0` in the UI.

This regressed during the v1 → v2 driver migration and no test caught it, because the package had no tests. The failing test is committed first (`test(indexes): ... expose always-zero index Size`), then fixed in the following commit. `indexSizesFrom` now accepts both `bson.D` and `bson.M`.

## The `emit` seam in `connections`

`ConnectionManager` called `runtime.EventsEmit` directly. Wails resolves its emitter from the context and `log.Fatalf`s (i.e. `os.Exit(1)`) when it is absent, so any test touching `Connect`/`Disconnect`/`DisconnectAll` killed the test binary with no failure output.

A fake cannot be injected via the context: Wails type-asserts to `frontend.Events`, which lives in an internal package Vervet cannot import, and its `Notify(sender Frontend, ...)` method names another internal type. No external type can satisfy it.

So `ConnectionManager` gained a single unexported field, `emit`, defaulted to `runtime.EventsEmit` in `NewManager`. Production behaviour is unchanged; tests overwrite the field and assert on emitted events.

## Deviation from the plan

The planned `TestIntegration_CreateCollection_DuplicateErrors` did not hold. MongoDB's `create` command is idempotent when the existing collection's options match — verified with a raw `runCommand`, which also returns no error. The code was right and the plan's assumption was wrong. Replaced with a no-op assertion documenting the real behaviour, plus an invalid-name test that does exercise the `failed to create collection` error wrapping.

## Verification

- `go build ./...` — silent
- `go vet ./...` — silent
- `go test -count=1 ./...` — all pass
- `TESTCONTAINERS_RYUK_DISABLED=true go test -count=1 -tags integration ./internal/...` — all pass
- `govulncheck ./...` — 0 reachable vulnerabilities (1 unreachable module-level advisory in `x/crypto`, known)
- `cd frontend && bun run lint` — silent

## Out of scope

Wails v2.13, the goja snapshot bump, frontend majors, and OIDC connect paths (need a live identity provider) are each deliberately left for their own PR.
